### PR TITLE
docs: align README.md and tests/README.md to actual test project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,16 +514,14 @@ public class QuoteGenerator : BaseGenerator
 
 ```
 tests/
-├── XPoster.Tests/
-│   ├── Generators/
-│   │   ├── FeedGeneratorTests.cs
-│   │   └── PowerLawGeneratorTests.cs
-│   ├── Services/
-│   │   ├── AiServiceTests.cs
-│   │   └── FeedServiceTests.cs
-│   └── SenderPlugins/
-│       ├── XSenderTests.cs
-│       └── InSenderTests.cs
+├── Abstraction/             # tests for src/Abstraction/
+├── Implementation/          # tests for src/Implementation/ (FeedGenerator, PowerLawGenerator, GeneratorFactory…)
+├── Models/                  # tests for src/Models/
+├── SenderPlugins/           # tests for src/SenderPlugins/ (XSender, InSender, IgSender…)
+├── Services/                # tests for src/Services/ (AiService, FeedService, CryptoService…)
+├── XFunctionMissingBranchTests.cs
+├── XFunctionTests.cs        # integration-level tests for XFunction
+└── XPoster.Tests.csproj
 ```
 
 ### Running Tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,17 +38,17 @@ XPoster uses a **unit-first** approach:
 One test file per production class, mirroring the `src/` directory structure:
 
 ```
-tests/XPoster.Tests/
-├── Generators/
-│   ├── FeedGeneratorTests.cs       # tests for src/Implementation/FeedGenerator.cs
-│   └── PowerLawGeneratorTests.cs
-├── Services/
-│   ├── AiServiceTests.cs
-│   └── FeedServiceTests.cs
-└── SenderPlugins/
-    ├── XSenderTests.cs
-    └── InSenderTests.cs
+tests/
+├── Abstraction/             # tests for src/Abstraction/
+├── Implementation/          # tests for src/Implementation/ (FeedGenerator, PowerLawGenerator, GeneratorFactory…)
+├── Models/                  # tests for src/Models/
+├── SenderPlugins/           # tests for src/SenderPlugins/ (XSender, InSender, IgSender…)
+├── Services/                # tests for src/Services/ (AiService, FeedService, CryptoService…)
+├── XFunctionMissingBranchTests.cs
+├── XFunctionTests.cs        # integration-level tests for XFunction
+└── XPoster.Tests.csproj
 ```
+The `tests/` directory is itself the test project root (not a `tests/XPoster.Tests/` subdirectory). Mirror the folder name from `src/` — e.g., new tests for `src/Implementation/FeedGenerator.cs` go in `tests/Implementation/FeedGeneratorTests.cs`.
 
 ### Test method names
 


### PR DESCRIPTION
## What
Updated the directory tree diagrams in `README.md` and `tests/README.md` 
to reflect the actual test project structure on disk.

## Why
The previous diagrams described a nested `tests/XPoster.Tests/` layout 
that does not exist, which could cause confusion for new contributors 
placing test files in incorrect paths.

## Changes
- `README.md` — replaced outdated tree in the Testing section with the 
  actual structure
- `tests/README.md` — replaced outdated tree in Section 3 and added a 
  clarifying note explaining that `tests/` is the project root

## Related issue
Closes #74

## Notes
Documentation-only change. No test files were moved or renamed.