### PR TITLE
docs: align tests/README.md and README.md to actual test project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,16 +514,14 @@ public class QuoteGenerator : BaseGenerator
 
 ```
 tests/
-├── XPoster.Tests/
-│   ├── Generators/
-│   │   ├── FeedGeneratorTests.cs
-│   │   └── PowerLawGeneratorTests.cs
-│   ├── Services/
-│   │   ├── AiServiceTests.cs
-│   │   └── FeedServiceTests.cs
-│   └── SenderPlugins/
-│       ├── XSenderTests.cs
-│       └── InSenderTests.cs
+├── Abstraction/             # tests for src/Abstraction/
+├── Implementation/          # tests for src/Implementation/ (FeedGenerator, PowerLawGenerator, GeneratorFactory…)
+├── Models/                  # tests for src/Models/
+├── Services/                # tests for src/Services/ (AiService, FeedService, CryptoService…)
+├── SenderPlugins/           # tests for src/SenderPlugins/ (XSender, InSender, IgSender…)
+├── XFunctionTests.cs        # integration-level tests for XFunction
+├── XFunctionMissingBranchTests.cs
+└── XPoster.Tests.csproj
 ```
 
 ### Running Tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,17 +38,18 @@ XPoster uses a **unit-first** approach:
 One test file per production class, mirroring the `src/` directory structure:
 
 ```
-tests/XPoster.Tests/
-├── Generators/
-│   ├── FeedGeneratorTests.cs       # tests for src/Implementation/FeedGenerator.cs
-│   └── PowerLawGeneratorTests.cs
-├── Services/
-│   ├── AiServiceTests.cs
-│   └── FeedServiceTests.cs
-└── SenderPlugins/
-    ├── XSenderTests.cs
-    └── InSenderTests.cs
+tests/
+├── Abstraction/             # tests for src/Abstraction/
+├── Implementation/          # tests for src/Implementation/ (FeedGenerator, PowerLawGenerator, GeneratorFactory…)
+├── Models/                  # tests for src/Models/
+├── Services/                # tests for src/Services/ (AiService, FeedService, CryptoService…)
+├── SenderPlugins/           # tests for src/SenderPlugins/ (XSender, InSender, IgSender…)
+├── XFunctionTests.cs        # integration-level tests for XFunction
+├── XFunctionMissingBranchTests.cs
+└── XPoster.Tests.csproj
 ```
+
+> The `tests/` directory is itself the test project root (not a `tests/XPoster.Tests/` subdirectory). Mirror the folder name from `src/` — e.g., new tests for `src/Implementation/FeedGenerator.cs` go in `tests/Implementation/FeedGeneratorTests.cs`.
 
 ### Test method names
 


### PR DESCRIPTION
Closes #74.

Both `README.md` (Testing section) and `tests/README.md` (Section 3) described a `tests/XPoster.Tests/` nested layout with `Generators/` that does not exist on disk — following the docs would lead contributors to place test files in paths that are not part of the project.

This updates both trees to the actual layout: `Abstraction/`, `Implementation/`, `Models/`, `Services/`, `SenderPlugins/`, plus the root-level `XFunctionTests.cs` / `XFunctionMissingBranchTests.cs` and the `.csproj`. Also added a clarifying note in `tests/README.md` that `tests/` is itself the test project root (not a nested subdirectory).

Documentation-only — no test files moved or renamed.