### PR TITLE
refactor: rename AiService to OpenAiService (#87)

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,8 @@
+## Summary
+Align XPoster custom agents/skills with Azure Functions isolated workflow and clean up local C# Dev Kit cache tracking.
+
+## Included
+- Added/updated project agents and skills under `.github/agents` and `.github/skills`
+- Updated `.github/copilot-instructions.md`
+- Added `*.lscache` to `.gitignore`
+- Untracked generated `.lscache` files

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -35,6 +35,6 @@ builder.Services.AddTransient<IGeneratorFactory, GeneratorFactory>();
 
 builder.Services.AddTransient<ICryptoService, CryptoService>();
 builder.Services.AddTransient<IFeedService, FeedService>();
-builder.Services.AddTransient<IAiService, AiService>();
+builder.Services.AddTransient<IAiService, OpenAiService>();
 
 builder.Build().Run();

--- a/src/Services/OpenAiService.cs
+++ b/src/Services/OpenAiService.cs
@@ -10,18 +10,18 @@ namespace XPoster.Services;
 /// Implements <see cref="IAiService"/> by calling the OpenAI Chat Completions and Image Generations APIs.
 /// Uses <c>gpt-4.1-nano</c> for text tasks and <c>gpt-image-1.5</c> for image generation.
 /// </summary>
-public class AiService : IAiService
+public class OpenAiService : IAiService
 {
     private readonly HttpClient _client;
-    private readonly ILogger<AiService> _logger;
+    private readonly ILogger<OpenAiService> _logger;
 
     /// <summary>
-    /// Initialises a new instance of <see cref="AiService"/>, configuring the HTTP client
+    /// Initialises a new instance of <see cref="OpenAiService"/>, configuring the HTTP client
     /// with the OpenAI Bearer token read from the <c>OPENAI_API_KEY</c> environment variable.
     /// </summary>
     /// <param name="httpClientFactory">The factory used to create the underlying <see cref="HttpClient"/>.</param>
     /// <param name="logger">The logger for diagnostic output.</param>
-    public AiService(IHttpClientFactory httpClientFactory, ILogger<AiService> logger)
+    public OpenAiService(IHttpClientFactory httpClientFactory, ILogger<OpenAiService> logger)
     {
         _logger = logger;
         _client = httpClientFactory.CreateClient();

--- a/tests/Services/OpenAiServiceTests.cs
+++ b/tests/Services/OpenAiServiceTests.cs
@@ -7,19 +7,19 @@ using XPoster.Services;
 namespace XPoster.Tests.Services;
 
 /// <summary>
-/// Unit tests for <see cref="AiService"/> using a mocked <see cref="HttpMessageHandler"/>.
+/// Unit tests for <see cref="OpenAiService"/> using a mocked <see cref="HttpMessageHandler"/>.
 /// No real HTTP calls are made.
 /// </summary>
-public class AiServiceTests
+public class OpenAiServiceTests
 {
-    private static AiService BuildService(HttpMessageHandler handler, out Mock<ILogger<AiService>> loggerMock)
+    private static OpenAiService BuildService(HttpMessageHandler handler, out Mock<ILogger<OpenAiService>> loggerMock)
     {
-        loggerMock = new Mock<ILogger<AiService>>();
+        loggerMock = new Mock<ILogger<OpenAiService>>();
         var factory = new Mock<IHttpClientFactory>();
         var client = new HttpClient(handler);
         factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
         Environment.SetEnvironmentVariable("OPENAI_API_KEY", "fake-key");
-        return new AiService(factory.Object, loggerMock.Object);
+        return new OpenAiService(factory.Object, loggerMock.Object);
     }
 
     private static HttpMessageHandler MakeHandler(HttpStatusCode code, string json)


### PR DESCRIPTION
## Summary

Closes #87

Renames the `AiService` concrete implementation to `OpenAiService` to make its
provider-specific role explicit and prepare the codebase for additional AI provider
implementations (e.g. `PerplexityAiService`).

## Changes

- `src/Services/AiService.cs` → `OpenAiService.cs` (git mv, history preserved)
  - Class, constructor e ILogger<T> rinominati
  - XML docs aggiornati
- `src/Program.cs` — DI registration aggiornata
- `tests/Services/AiServiceTests.cs` → `OpenAiServiceTests.cs` (git mv, history preserved)
  - Tutti i riferimenti al tipo concreto aggiornati

## Acceptance Criteria

- [x] Build passa senza errori
- [x] Nessun riferimento residuo a `AiService` nel codebase
- [x] `IAiService` si risolve correttamente da DI
- [x] 114/114 test passati — zero regressioni