### PR TITLE
feat(insender): add LinkedIn organization page support (#71)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,8 @@ All configuration is passed via environment variables (locally in `src/local.set
 | Variable | Type | Required | Description |
 |---|---|---|---|
 | `IN_ACCESS_TOKEN` | string | ✅ Yes | LinkedIn OAuth 2.0 access token. Obtain from LinkedIn Developer Portal → OAuth credentials. Expires every 60 days (manual rotation required). |
-| `IN_OWNER` | string | ✅ Yes | Numeric LinkedIn person ID of the account that will author posts (e.g. `123456789`). Find it via `GET https://api.linkedin.com/v2/userinfo`. Posts are published as `urn:li:person:{IN_OWNER}`. |
+| `IN_OWNER` | string | ⚠️ One of `IN_OWNER` / `IN_ORG_ID` | Numeric LinkedIn person ID of the account that will author posts (e.g. `123456789`). Find it via `GET https://api.linkedin.com/v2/userinfo`. Posts are published as `urn:li:person:{IN_OWNER}`. Ignored when `IN_ORG_ID` is set. |
+| `IN_ORG_ID` | string | ⚠️ One of `IN_OWNER` / `IN_ORG_ID` | Numeric LinkedIn organization ID for publishing on behalf of a company page (e.g. `98765432`). When set, takes precedence over `IN_OWNER`. Posts are published as `urn:li:organization:{IN_ORG_ID}`. |
 
 ## Instagram
 

--- a/src/SenderPlugins/InSender.cs
+++ b/src/SenderPlugins/InSender.cs
@@ -8,7 +8,9 @@ namespace XPoster.SenderPlugins;
 /// <summary>
 /// Publishes posts to LinkedIn using the LinkedIn UGC Posts API (v2).
 /// Supports both text-only posts and posts with an image attachment via the LinkedIn asset upload flow.
-/// Credentials are read from the <c>IN_ACCESS_TOKEN</c> and <c>IN_OWNER</c> environment variables.
+/// Credentials are read from the <c>IN_ACCESS_TOKEN</c> environment variable.
+/// The author URN is resolved from <c>IN_ORG_ID</c> (organization) when set,
+/// otherwise from <c>IN_OWNER</c> (person). At least one must be set.
 /// </summary>
 public class InSender : ISender
 {
@@ -52,10 +54,7 @@ public class InSender : ISender
 
         try
         {
-            // CS8600/CS8604: inOwner from env var is nullable — guard before use
-            var inOwner = Environment.GetEnvironmentVariable("IN_OWNER")
-                ?? throw new InvalidOperationException("IN_OWNER environment variable is not set.");
-
+            var author = ResolveAuthorUrn();
             var postText = post.Content + Post.Firm;
             dynamic postPayload;
 
@@ -66,7 +65,7 @@ public class InSender : ISender
                     registerUploadRequest = new
                     {
                         recipes = new[] { "urn:li:digitalmediaRecipe:feedshare-image" },
-                        owner = $"urn:li:person:{inOwner}",
+                        owner = author,
                         serviceRelationships = new[]
                         {
                             new { relationshipType = "OWNER", identifier = "urn:li:userGeneratedContent" }
@@ -109,11 +108,11 @@ public class InSender : ISender
                     }
                 }
 
-                postPayload = generatePayLoad(asset, inOwner, postText);
+                postPayload = generatePayLoad(asset, author, postText);
             }
             else
             {
-                postPayload = generatePayLoad(null, inOwner, postText);
+                postPayload = generatePayLoad(null, author, postText);
             }
 
             var json = JsonSerializer.Serialize(postPayload);
@@ -133,13 +132,29 @@ public class InSender : ISender
     }
 
     /// <summary>
+    /// Resolves the LinkedIn author URN for the post.
+    /// Returns an organization URN when <c>IN_ORG_ID</c> is set; otherwise returns a person URN from <c>IN_OWNER</c>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when neither <c>IN_ORG_ID</c> nor <c>IN_OWNER</c> is set.</exception>
+    private static string ResolveAuthorUrn()
+    {
+        var orgId = Environment.GetEnvironmentVariable("IN_ORG_ID");
+        if (!string.IsNullOrWhiteSpace(orgId))
+            return $"urn:li:organization:{orgId}";
+
+        var personId = Environment.GetEnvironmentVariable("IN_OWNER")
+            ?? throw new InvalidOperationException("Either IN_OWNER or IN_ORG_ID must be set.");
+        return $"urn:li:person:{personId}";
+    }
+
+    /// <summary>
     /// Builds the LinkedIn UGC post payload, optionally embedding an image asset.
     /// </summary>
     /// <param name="asset">The LinkedIn asset URN of the uploaded image, or <c>null</c> for text-only posts.</param>
-    /// <param name="owner">The LinkedIn person URN of the post author (from <c>IN_OWNER</c>).</param>
+    /// <param name="authorUrn">The fully-qualified LinkedIn author URN (person or organization).</param>
     /// <param name="summary">The text body of the post.</param>
     /// <returns>An anonymous object serialisable as a valid LinkedIn UGC post request body.</returns>
-    private dynamic generatePayLoad(string? asset, string owner, string summary)
+    private dynamic generatePayLoad(string? asset, string authorUrn, string summary)
     {
         Dictionary<string, object> specificContent;
         if (string.IsNullOrEmpty(asset))
@@ -186,7 +201,7 @@ public class InSender : ISender
 
         return new
         {
-            author = $"urn:li:person:{owner}",
+            author = authorUrn,
             lifecycleState = "PUBLISHED",
             specificContent,
             visibility

--- a/src/local.settings.json.example
+++ b/src/local.settings.json.example
@@ -12,6 +12,7 @@
 
     "IN_ACCESS_TOKEN": "",
     "IN_OWNER": "",
+    "IN_ORG_ID": "",
 
     "IG_ACCESS_TOKEN": "",
     "IG_ACCOUNT_ID": "",

--- a/tests/SenderPlugins/InSenderMissingBranchTests.cs
+++ b/tests/SenderPlugins/InSenderMissingBranchTests.cs
@@ -59,4 +59,59 @@ public class InSenderMissingBranchTests
         var result = await sender.SendAsync(new Post { Content = "  " });
         Assert.False(result);
     }
+
+    #region ResolveAuthorUrn tests (exercised via SendAsync)
+
+    [Fact]
+    public async Task SendAsync_WhenOrgIdIsSet_UsesOrganizationUrn()
+    {
+        // Arrange: set IN_ORG_ID — IN_OWNER is also present but should be ignored
+        Environment.SetEnvironmentVariable("IN_ACCESS_TOKEN", "fake_token");
+        Environment.SetEnvironmentVariable("IN_OWNER", "fake_owner");
+        Environment.SetEnvironmentVariable("IN_ORG_ID", "98765432");
+        var sender = new InSender(_logger.Object);
+
+        // Act: SendAsync will call ResolveAuthorUrn() → organization URN → HTTP call fails → false
+        var result = await sender.SendAsync(new Post { Content = "org post" });
+
+        // Assert: execution reached the HTTP call (not an env-var exception)
+        Assert.False(result);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("IN_ORG_ID", null);
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenOrgIdIsAbsentAndOwnerIsSet_UsesPersonUrn()
+    {
+        // Arrange: IN_ORG_ID is absent, IN_OWNER is present → person URN
+        Environment.SetEnvironmentVariable("IN_ACCESS_TOKEN", "fake_token");
+        Environment.SetEnvironmentVariable("IN_OWNER", "123456789");
+        Environment.SetEnvironmentVariable("IN_ORG_ID", null);
+        var sender = new InSender(_logger.Object);
+
+        // Act: reaches HTTP call → false (no real server)
+        var result = await sender.SendAsync(new Post { Content = "person post" });
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenBothOrgIdAndOwnerAreAbsent_ThrowsAndReturnsFalse()
+    {
+        // Arrange: neither IN_ORG_ID nor IN_OWNER is set → InvalidOperationException caught → false
+        Environment.SetEnvironmentVariable("IN_ACCESS_TOKEN", "fake_token");
+        Environment.SetEnvironmentVariable("IN_OWNER", null);
+        Environment.SetEnvironmentVariable("IN_ORG_ID", null);
+        var sender = new InSender(_logger.Object);
+
+        var result = await sender.SendAsync(new Post { Content = "no author" });
+
+        Assert.False(result);
+
+        // Restore
+        Environment.SetEnvironmentVariable("IN_OWNER", "fake_owner");
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

Adds support for publishing posts to a LinkedIn **organization page** in addition to personal profiles.

Closes #71

## Changes

### `src/SenderPlugins/InSender.cs`
- Added `ResolveAuthorUrn()` private static helper that returns `urn:li:organization:{IN_ORG_ID}` when `IN_ORG_ID` is set, falling back to `urn:li:person:{IN_OWNER}`.
- Refactored `SendAsync` to call `ResolveAuthorUrn()` instead of reading `IN_OWNER` directly.
- Updated `generatePayLoad` to accept a pre-built `authorUrn` string — the method no longer constructs the URN internally.

### `src/local.settings.json.example`
- Added `IN_ORG_ID` (empty string) alongside existing `IN_OWNER`.

### `docs/configuration.md`
- Updated LinkedIn settings table: `IN_OWNER` and `IN_ORG_ID` are now documented as mutually exclusive alternatives (at least one required).

### `tests/SenderPlugins/InSenderMissingBranchTests.cs`
- Added 3 new tests:
  - `SendAsync_WhenOrgIdIsSet_UsesOrganizationUrn`
  - `SendAsync_WhenOrgIdIsAbsentAndOwnerIsSet_UsesPersonUrn`
  - `SendAsync_WhenBothOrgIdAndOwnerAreAbsent_ThrowsAndReturnsFalse`

## Behaviour

| `IN_ORG_ID` | `IN_OWNER` | Author URN used |
|---|---|---|
| set | any | `urn:li:organization:{IN_ORG_ID}` |
| not set | set | `urn:li:person:{IN_OWNER}` |
| not set | not set | `InvalidOperationException` → `SendAsync` returns `false` |

Existing deployments using only `IN_OWNER` are **fully backwards-compatible** — no configuration change required.

## Test results

117/117 passing ✅