### PR TITLE
feat(openai): externalise OpenAI endpoints, models and parameters into OpenAiOptions (#88)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,9 +38,20 @@ All configuration is passed via environment variables (locally in `src/local.set
 
 ## AI (OpenAI)
 
-| Variable | Type | Required | Description |
-|---|---|---|---|
-| `OPENAI_API_KEY` | string | ✅ Yes | OpenAI platform API key. Used by `AiService` for both text summarisation (`gpt-4.1-nano`) and image generation (`gpt-image-1.5`). |
+Configuration is bound from the `OpenAI` section using double-underscore notation in Azure App Settings / `local.settings.json` (e.g. `OpenAI__ApiKey`).
+
+| Setting | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `OpenAI__ApiKey` | string | ✅ Yes | — | OpenAI platform API key. Used by `OpenAiService` for all API calls. |
+| `OpenAI__ChatEndpoint` | string | No | `https://api.openai.com/v1/chat/completions` | Chat Completions API URL. |
+| `OpenAI__ChatModel` | string | No | `gpt-4.1-nano` | Model used for text summarisation and image prompt generation. |
+| `OpenAI__SummaryTemperature` | double | No | `0.5` | Temperature for summary generation. |
+| `OpenAI__SummaryMaxTokensPerChar` | int | No | `5` | Divisor to convert a character budget to `max_tokens`. |
+| `OpenAI__SummarySafetyMarginChars` | int | No | `50` | Character margin subtracted from the budget in the system prompt. |
+| `OpenAI__ImageEndpoint` | string | No | `https://api.openai.com/v1/images/generations` | Image Generations API URL. |
+| `OpenAI__ImageModel` | string | No | `gpt-image-1.5` | Model used for image generation. |
+| `OpenAI__ImageSize` | string | No | `1024x1024` | Output image size. |
+| `OpenAI__ImageCount` | int | No | `1` | Number of images to generate per request. |
 
 ## Azure Functions Runtime
 

--- a/src/Models/OpenAiOptions.cs
+++ b/src/Models/OpenAiOptions.cs
@@ -1,0 +1,48 @@
+namespace XPoster.Models;
+
+/// <summary>
+/// Strongly-typed configuration for the OpenAI provider, bound from the <c>OpenAI</c> configuration section.
+/// All properties have sensible defaults so the application works without explicit configuration.
+/// </summary>
+public sealed class OpenAiOptions
+{
+    /// <summary>Gets or sets the OpenAI API key used for authentication.</summary>
+    public string ApiKey { get; set; } = string.Empty;
+
+    // ── Chat / Completions ────────────────────────────────────────────────────
+
+    /// <summary>Gets or sets the Chat Completions API endpoint.</summary>
+    public string ChatEndpoint { get; set; } = "https://api.openai.com/v1/chat/completions";
+
+    /// <summary>Gets or sets the model used for chat/completion requests.</summary>
+    public string ChatModel { get; set; } = "gpt-4.1-nano";
+
+    /// <summary>Gets or sets the temperature used when generating summaries.</summary>
+    public double SummaryTemperature { get; set; } = 0.5;
+
+    /// <summary>
+    /// Gets or sets the divisor used to convert a character budget into a <c>max_tokens</c> value.
+    /// Formula: <c>max_tokens = messageMaxLength / SummaryMaxTokensPerChar</c>.
+    /// </summary>
+    public int SummaryMaxTokensPerChar { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets the safety margin (in characters) subtracted from the character budget
+    /// when building the "keep under N characters" system prompt.
+    /// </summary>
+    public int SummarySafetyMarginChars { get; set; } = 50;
+
+    // ── Image Generation ──────────────────────────────────────────────────────
+
+    /// <summary>Gets or sets the Image Generations API endpoint.</summary>
+    public string ImageEndpoint { get; set; } = "https://api.openai.com/v1/images/generations";
+
+    /// <summary>Gets or sets the model used for image generation requests.</summary>
+    public string ImageModel { get; set; } = "gpt-image-1.5";
+
+    /// <summary>Gets or sets the output image size (e.g. <c>1024x1024</c>).</summary>
+    public string ImageSize { get; set; } = "1024x1024";
+
+    /// <summary>Gets or sets the number of images to generate per request.</summary>
+    public int ImageCount { get; set; } = 1;
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,7 +1,9 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.Options;
 using XPoster.Abstraction;
 using XPoster.Implementation;
+using XPoster.Models;
 using XPoster.SenderPlugins;
 using XPoster.Services;
 
@@ -35,6 +37,7 @@ builder.Services.AddTransient<IGeneratorFactory, GeneratorFactory>();
 
 builder.Services.AddTransient<ICryptoService, CryptoService>();
 builder.Services.AddTransient<IFeedService, FeedService>();
+builder.Services.Configure<OpenAiOptions>(builder.Configuration.GetSection("OpenAI"));
 builder.Services.AddTransient<IAiService, OpenAiService>();
 
 builder.Build().Run();

--- a/src/Services/OpenAiService.cs
+++ b/src/Services/OpenAiService.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Microsoft.Extensions.Options;
 using XPoster.Abstraction;
 using XPoster.Models;
 
@@ -8,40 +9,38 @@ namespace XPoster.Services;
 
 /// <summary>
 /// Implements <see cref="IAiService"/> by calling the OpenAI Chat Completions and Image Generations APIs.
-/// Uses <c>gpt-4.1-nano</c> for text tasks and <c>gpt-image-1.5</c> for image generation.
+/// Endpoints, models, and behavioural parameters are supplied via <see cref="OpenAiOptions"/>.
 /// </summary>
 public class OpenAiService : IAiService
 {
     private readonly HttpClient _client;
     private readonly ILogger<OpenAiService> _logger;
+    private readonly OpenAiOptions _options;
 
     /// <summary>
     /// Initialises a new instance of <see cref="OpenAiService"/>, configuring the HTTP client
-    /// with the OpenAI Bearer token read from the <c>OPENAI_API_KEY</c> environment variable.
+    /// with the OpenAI Bearer token from <see cref="OpenAiOptions.ApiKey"/>.
     /// </summary>
     /// <param name="httpClientFactory">The factory used to create the underlying <see cref="HttpClient"/>.</param>
+    /// <param name="options">The OpenAI provider options.</param>
     /// <param name="logger">The logger for diagnostic output.</param>
-    public OpenAiService(IHttpClientFactory httpClientFactory, ILogger<OpenAiService> logger)
+    public OpenAiService(IHttpClientFactory httpClientFactory, IOptions<OpenAiOptions> options, ILogger<OpenAiService> logger)
     {
         _logger = logger;
+        _options = options.Value;
         _client = httpClientFactory.CreateClient();
-        _client.DefaultRequestHeaders.Add("Authorization", $"Bearer {Environment.GetEnvironmentVariable("OPENAI_API_KEY")}");
+        _client.DefaultRequestHeaders.Add("Authorization", $"Bearer {_options.ApiKey}");
     }
 
     /// <inheritdoc/>
     public async Task<string> GetSummaryAsync(string text, int messageMaxLength)
     {
-        if (!_client.DefaultRequestHeaders.Contains("Authorization"))
-        {
-            _client.DefaultRequestHeaders.Add("Authorization", $"Bearer {Environment.GetEnvironmentVariable("OPENAI_API_KEY")}");
-        }
-
         int tries = 0;
 
         while (text != null && text.Length > messageMaxLength && tries <= 2)
         {
             tries++;
-            var response = await _client.PostAsJsonAsync("https://api.openai.com/v1/chat/completions", GetSummary(text, messageMaxLength));
+            var response = await _client.PostAsJsonAsync(_options.ChatEndpoint, GetSummary(text, messageMaxLength));
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {
                 _logger.LogInformation("Too many requests. Please try again later.");
@@ -64,12 +63,7 @@ public class OpenAiService : IAiService
     /// <inheritdoc/>
     public async Task<string> GetImagePromptAsync(string text)
     {
-        if (!_client.DefaultRequestHeaders.Contains("Authorization"))
-        {
-            _client.DefaultRequestHeaders.Add("Authorization", $"Bearer {Environment.GetEnvironmentVariable("OPENAI_API_KEY")}");
-        }
-
-        var response = await _client.PostAsJsonAsync("https://api.openai.com/v1/chat/completions", GetPromptForImage(text));
+        var response = await _client.PostAsJsonAsync(_options.ChatEndpoint, GetPromptForImage(text));
         if (response.StatusCode == HttpStatusCode.TooManyRequests)
         {
             _logger.LogInformation("Too many requests. Please try again later.");
@@ -89,18 +83,17 @@ public class OpenAiService : IAiService
     /// <inheritdoc/>
     public async Task<byte[]> GenerateImageAsync(string prompt)
     {
-        _logger.LogInformation($"Generating image with gpt-image-1.5, prompt: {prompt}");
+        _logger.LogInformation($"Generating image with {_options.ImageModel}, prompt: {prompt}");
 
         var body = new
         {
-            model = "gpt-image-1.5",
+            model = _options.ImageModel,
             prompt,
-            n = 1,
-            size = "1024x1024"
+            n = _options.ImageCount,
+            size = _options.ImageSize
         };
 
-        var response = await _client.PostAsJsonAsync(
-            "https://api.openai.com/v1/images/generations", body);
+        var response = await _client.PostAsJsonAsync(_options.ImageEndpoint, body);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -121,20 +114,20 @@ public class OpenAiService : IAiService
     /// <param name="text">The text to summarise.</param>
     /// <param name="messageMaxLenght">The character limit that the summary must respect.</param>
     /// <returns>An anonymous object serialisable as a valid OpenAI Chat Completions request body.</returns>
-    private static object GetSummary(string text, int messageMaxLenght)
+    private object GetSummary(string text, int messageMaxLenght)
     {
-        var maxTokens = messageMaxLenght / 5;
-        var underCharacters = messageMaxLenght - 50;
+        var maxTokens = messageMaxLenght / _options.SummaryMaxTokensPerChar;
+        var underCharacters = messageMaxLenght - _options.SummarySafetyMarginChars;
         return new
         {
-            model = "gpt-4.1-nano",
+            model = _options.ChatModel,
             messages = new[]
             {
                 new { role = "system", content = $"You are an assistant that summarizes text concisely. It's very important that you keep summaries under {underCharacters} characters." },
                 new { role = "user", content = $"Summarize this text in a few sentences. text: {text}" }
             },
             max_tokens = maxTokens,
-            temperature = 0.5
+            temperature = _options.SummaryTemperature
         };
     }
 
@@ -144,11 +137,11 @@ public class OpenAiService : IAiService
     /// </summary>
     /// <param name="summary">The text summary to base the image prompt on.</param>
     /// <returns>An anonymous object serialisable as a valid OpenAI Chat Completions request body.</returns>
-    private static object GetPromptForImage(string summary)
+    private object GetPromptForImage(string summary)
     {
         return new
         {
-            model = "gpt-4.1-nano",
+            model = _options.ChatModel,
             messages = new[]
             {
                 new { role = "system", content = "You are an assistant that generates image prompts for an AI image generation model based on text summaries. Create a concise, vivid prompt in English that reflects the summary's content, includes a Bitcoin-related element (e.g., a coin), and avoids text, signs, or words in the image. Respect content policy for generating images." },

--- a/src/local.settings.json.example
+++ b/src/local.settings.json.example
@@ -17,7 +17,16 @@
     "IG_ACCESS_TOKEN": "",
     "IG_ACCOUNT_ID": "",
 
-    "OPENAI_API_KEY": "",
+    "OpenAI__ApiKey": "",
+    "OpenAI__ChatEndpoint": "https://api.openai.com/v1/chat/completions",
+    "OpenAI__ChatModel": "gpt-4.1-nano",
+    "OpenAI__SummaryTemperature": "0.5",
+    "OpenAI__SummaryMaxTokensPerChar": "5",
+    "OpenAI__SummarySafetyMarginChars": "50",
+    "OpenAI__ImageEndpoint": "https://api.openai.com/v1/images/generations",
+    "OpenAI__ImageModel": "gpt-image-1.5",
+    "OpenAI__ImageSize": "1024x1024",
+    "OpenAI__ImageCount": "1",
 
     "APPLICATIONINSIGHTS_CONNECTION_STRING": ""
   }

--- a/tests/Services/OpenAiServiceTests.cs
+++ b/tests/Services/OpenAiServiceTests.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
+using XPoster.Models;
 using XPoster.Services;
 
 namespace XPoster.Tests.Services;
@@ -12,14 +14,14 @@ namespace XPoster.Tests.Services;
 /// </summary>
 public class OpenAiServiceTests
 {
-    private static OpenAiService BuildService(HttpMessageHandler handler, out Mock<ILogger<OpenAiService>> loggerMock)
+    private static OpenAiService BuildService(HttpMessageHandler handler, out Mock<ILogger<OpenAiService>> loggerMock, OpenAiOptions? opts = null)
     {
         loggerMock = new Mock<ILogger<OpenAiService>>();
         var factory = new Mock<IHttpClientFactory>();
         var client = new HttpClient(handler);
         factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
-        Environment.SetEnvironmentVariable("OPENAI_API_KEY", "fake-key");
-        return new OpenAiService(factory.Object, loggerMock.Object);
+        var options = Options.Create(opts ?? new OpenAiOptions { ApiKey = "fake-key" });
+        return new OpenAiService(factory.Object, options, loggerMock.Object);
     }
 
     private static HttpMessageHandler MakeHandler(HttpStatusCode code, string json)


### PR DESCRIPTION
## Summary

Introduces `OpenAiOptions`, a strongly-typed configuration class for the OpenAI provider. All hard-coded literals are removed from `OpenAiService` and replaced with values injected via `IOptions<OpenAiOptions>`.

Closes #88

## Changes

### `src/Models/OpenAiOptions.cs` *(new)*
- Sealed class with properties and sensible defaults for:
  `ApiKey`, `ChatEndpoint`, `ChatModel`, `SummaryTemperature`, `SummaryMaxTokensPerChar`, `SummarySafetyMarginChars`, `ImageEndpoint`, `ImageModel`, `ImageSize`, `ImageCount`

### `src/Services/OpenAiService.cs`
- Constructor now accepts `IOptions<OpenAiOptions>` instead of reading `OPENAI_API_KEY` directly from env.
- All hard-coded literals replaced with options properties.
- Removed 2 redundant `Authorization` header guards in `GetSummaryAsync` and `GetImagePromptAsync`.
- `GetSummary` and `GetPromptForImage` converted from `static` to instance methods (access to `_options`).

### `src/Program.cs`
- Added `builder.Services.Configure<OpenAiOptions>(builder.Configuration.GetSection("OpenAI"))`.

### `src/local.settings.json.example`
- Replaced `OPENAI_API_KEY` with the full `OpenAI__*` key set.

### `docs/configuration.md`
- AI section rewritten with a complete parameter table for `OpenAiOptions`.

### `tests/Services/OpenAiServiceTests.cs`
- `BuildService` now instantiates `IOptions<OpenAiOptions>` via `Options.Create(...)` instead of setting env vars.

## Behaviour

No functional change. All default values in `OpenAiOptions` match the previous hard-coded literals, so existing deployments work without any configuration update.

## Deployment action required

Before deploying this version, update Azure App Settings:

| Action | Key |
|---|---|
| ➕ Add | `OpenAI__ApiKey` → your OpenAI key |
| 🗑️ Remove | `OPENAI_API_KEY` (no longer read) |

All other `OpenAI__*` keys are optional (defaults apply).

## Test results

117/117 passing ✅