### PR TITLE
feat(openai): externalise prompt templates into OpenAiOptions (#89)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,12 @@ Configuration is bound from the `OpenAI` section using double-underscore notatio
 | `OpenAI__ImageModel` | string | No | `gpt-image-1.5` | Model used for image generation. |
 | `OpenAI__ImageSize` | string | No | `1024x1024` | Output image size. |
 | `OpenAI__ImageCount` | int | No | `1` | Number of images to generate per request. |
+| `OpenAI__SummarySystemPromptTemplate` | string | No | *(see default)* | System prompt for summarisation. Supports `{MaxChars}` placeholder. |
+| `OpenAI__SummaryUserPromptTemplate` | string | No | *(see default)* | User prompt for summarisation. Supports `{Text}` placeholder. |
+| `OpenAI__ImagePromptSystemTemplate` | string | No | *(see default)* | System prompt for image prompt generation. No placeholders. |
+| `OpenAI__ImagePromptUserTemplate` | string | No | *(see default)* | User prompt for image prompt generation. Supports `{Summary}` placeholder. |
+| `OpenAI__ImagePromptMaxTokens` | int | No | `60` | Max tokens for image prompt generation requests. |
+| `OpenAI__ImagePromptTemperature` | double | No | `0.7` | Temperature for image prompt generation requests. |
 
 ## Azure Functions Runtime
 

--- a/src/Models/OpenAiOptions.cs
+++ b/src/Models/OpenAiOptions.cs
@@ -45,4 +45,43 @@ public sealed class OpenAiOptions
 
     /// <summary>Gets or sets the number of images to generate per request.</summary>
     public int ImageCount { get; set; } = 1;
+
+    // ── Prompt Templates ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Gets or sets the system prompt template for text summarisation.
+    /// Supports placeholder <c>{MaxChars}</c>, replaced at runtime with the effective character limit.
+    /// </summary>
+    public string SummarySystemPromptTemplate { get; set; } =
+        "You are an assistant that summarizes text concisely. " +
+        "It's very important that you keep summaries under {MaxChars} characters.";
+
+    /// <summary>
+    /// Gets or sets the user prompt template for text summarisation.
+    /// Supports placeholder <c>{Text}</c>, replaced at runtime with the input text.
+    /// </summary>
+    public string SummaryUserPromptTemplate { get; set; } =
+        "Summarize this text in a few sentences. text: {Text}";
+
+    /// <summary>
+    /// Gets or sets the system prompt template for image prompt generation.
+    /// No runtime placeholders — the full instruction is used as-is.
+    /// </summary>
+    public string ImagePromptSystemTemplate { get; set; } =
+        "You are an assistant that generates image prompts for an AI image generation model based on text summaries. " +
+        "Create a concise, vivid prompt in English that reflects the summary's content, includes a Bitcoin-related element (e.g., a coin), " +
+        "and avoids text, signs, or words in the image. Respect content policy for generating images.";
+
+    /// <summary>
+    /// Gets or sets the user prompt template for image prompt generation.
+    /// Supports placeholder <c>{Summary}</c>, replaced at runtime with the input summary.
+    /// </summary>
+    public string ImagePromptUserTemplate { get; set; } =
+        "Generate an image prompt based on this summary: {Summary}";
+
+    /// <summary>Gets or sets the max tokens for image prompt generation requests.</summary>
+    public int ImagePromptMaxTokens { get; set; } = 60;
+
+    /// <summary>Gets or sets the temperature for image prompt generation requests.</summary>
+    public double ImagePromptTemperature { get; set; } = 0.7;
 }

--- a/src/Models/OpenAiOptionsValidator.cs
+++ b/src/Models/OpenAiOptionsValidator.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Options;
+
+namespace XPoster.Models;
+
+/// <summary>
+/// Validates that <see cref="OpenAiOptions"/> prompt templates contain their required runtime placeholders.
+/// Registered as <see cref="IValidateOptions{TOptions}"/> so the Azure Functions host fails fast at startup
+/// rather than silently producing degraded output at runtime.
+/// </summary>
+public sealed class OpenAiOptionsValidator : IValidateOptions<OpenAiOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, OpenAiOptions options)
+    {
+        var failures = new List<string>();
+
+        if (!options.SummarySystemPromptTemplate.Contains("{MaxChars}", StringComparison.Ordinal))
+        {
+            failures.Add(
+                $"{nameof(OpenAiOptions.SummarySystemPromptTemplate)} must contain the {{MaxChars}} placeholder.");
+        }
+
+        if (!options.SummaryUserPromptTemplate.Contains("{Text}", StringComparison.Ordinal))
+        {
+            failures.Add(
+                $"{nameof(OpenAiOptions.SummaryUserPromptTemplate)} must contain the {{Text}} placeholder.");
+        }
+
+        if (!options.ImagePromptUserTemplate.Contains("{Summary}", StringComparison.Ordinal))
+        {
+            failures.Add(
+                $"{nameof(OpenAiOptions.ImagePromptUserTemplate)} must contain the {{Summary}} placeholder.");
+        }
+
+        return failures.Count > 0
+            ? ValidateOptionsResult.Fail(failures)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -38,6 +38,7 @@ builder.Services.AddTransient<IGeneratorFactory, GeneratorFactory>();
 builder.Services.AddTransient<ICryptoService, CryptoService>();
 builder.Services.AddTransient<IFeedService, FeedService>();
 builder.Services.Configure<OpenAiOptions>(builder.Configuration.GetSection("OpenAI"));
+builder.Services.AddSingleton<IValidateOptions<OpenAiOptions>, OpenAiOptionsValidator>();
 builder.Services.AddTransient<IAiService, OpenAiService>();
 
 builder.Build().Run();

--- a/src/Services/OpenAiService.cs
+++ b/src/Services/OpenAiService.cs
@@ -118,13 +118,19 @@ public class OpenAiService : IAiService
     {
         var maxTokens = messageMaxLenght / _options.SummaryMaxTokensPerChar;
         var underCharacters = messageMaxLenght - _options.SummarySafetyMarginChars;
+
+        var systemContent = _options.SummarySystemPromptTemplate
+            .Replace("{MaxChars}", underCharacters.ToString(), StringComparison.Ordinal);
+        var userContent = _options.SummaryUserPromptTemplate
+            .Replace("{Text}", text, StringComparison.Ordinal);
+
         return new
         {
             model = _options.ChatModel,
             messages = new[]
             {
-                new { role = "system", content = $"You are an assistant that summarizes text concisely. It's very important that you keep summaries under {underCharacters} characters." },
-                new { role = "user", content = $"Summarize this text in a few sentences. text: {text}" }
+                new { role = "system", content = systemContent },
+                new { role = "user", content = userContent }
             },
             max_tokens = maxTokens,
             temperature = _options.SummaryTemperature
@@ -139,16 +145,19 @@ public class OpenAiService : IAiService
     /// <returns>An anonymous object serialisable as a valid OpenAI Chat Completions request body.</returns>
     private object GetPromptForImage(string summary)
     {
+        var userContent = _options.ImagePromptUserTemplate
+            .Replace("{Summary}", summary, StringComparison.Ordinal);
+
         return new
         {
             model = _options.ChatModel,
             messages = new[]
             {
-                new { role = "system", content = "You are an assistant that generates image prompts for an AI image generation model based on text summaries. Create a concise, vivid prompt in English that reflects the summary's content, includes a Bitcoin-related element (e.g., a coin), and avoids text, signs, or words in the image. Respect content policy for generating images." },
-                new { role = "user", content = $"Generate an image prompt based on this summary: {summary}" }
+                new { role = "system", content = _options.ImagePromptSystemTemplate },
+                new { role = "user", content = userContent }
             },
-            max_tokens = 60,
-            temperature = 0.7
+            max_tokens = _options.ImagePromptMaxTokens,
+            temperature = _options.ImagePromptTemperature
         };
     }
 }

--- a/src/local.settings.json.example
+++ b/src/local.settings.json.example
@@ -23,10 +23,16 @@
     "OpenAI__SummaryTemperature": "0.5",
     "OpenAI__SummaryMaxTokensPerChar": "5",
     "OpenAI__SummarySafetyMarginChars": "50",
+    "OpenAI__SummarySystemPromptTemplate": "You are an assistant that summarizes text concisely. It's very important that you keep summaries under {MaxChars} characters.",
+    "OpenAI__SummaryUserPromptTemplate": "Summarize this text in a few sentences. text: {Text}",
     "OpenAI__ImageEndpoint": "https://api.openai.com/v1/images/generations",
     "OpenAI__ImageModel": "gpt-image-1.5",
     "OpenAI__ImageSize": "1024x1024",
     "OpenAI__ImageCount": "1",
+    "OpenAI__ImagePromptSystemTemplate": "You are an assistant that generates image prompts for an AI image generation model based on text summaries. Create a concise, vivid prompt in English that reflects the summary's content, includes a Bitcoin-related element (e.g., a coin), and avoids text, signs, or words in the image. Respect content policy for generating images.",
+    "OpenAI__ImagePromptUserTemplate": "Generate an image prompt based on this summary: {Summary}",
+    "OpenAI__ImagePromptMaxTokens": "60",
+    "OpenAI__ImagePromptTemperature": "0.7",
 
     "APPLICATIONINSIGHTS_CONNECTION_STRING": ""
   }

--- a/tests/Models/OpenAiOptionsValidatorTests.cs
+++ b/tests/Models/OpenAiOptionsValidatorTests.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.Options;
+using XPoster.Models;
+
+namespace XPoster.Tests.Models;
+
+/// <summary>
+/// Unit tests for <see cref="OpenAiOptionsValidator"/>.
+/// Verifies that the validator accepts well-formed options and rejects each
+/// missing placeholder individually as well as all together.
+/// </summary>
+public class OpenAiOptionsValidatorTests
+{
+    private static OpenAiOptions ValidOptions() => new OpenAiOptions();
+
+    private readonly OpenAiOptionsValidator _sut = new();
+
+    // ── Success path ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_DefaultOptions_Succeeds()
+    {
+        var result = _sut.Validate(null, ValidOptions());
+
+        Assert.True(result.Succeeded);
+    }
+
+    // ── SummarySystemPromptTemplate ───────────────────────────────────────────
+
+    [Fact]
+    public void Validate_MissingMaxCharsPlaceholder_Fails()
+    {
+        var options = ValidOptions();
+        options.SummarySystemPromptTemplate = "You are a summariser."; // no {MaxChars}
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains("{MaxChars}"));
+    }
+
+    [Fact]
+    public void Validate_MissingMaxCharsPlaceholder_ErrorNamesProperty()
+    {
+        var options = ValidOptions();
+        options.SummarySystemPromptTemplate = "No placeholder here.";
+
+        var result = _sut.Validate(null, options);
+
+        Assert.Contains(result.Failures!,
+            f => f.Contains(nameof(OpenAiOptions.SummarySystemPromptTemplate)));
+    }
+
+    // ── SummaryUserPromptTemplate ─────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_MissingTextPlaceholder_Fails()
+    {
+        var options = ValidOptions();
+        options.SummaryUserPromptTemplate = "Summarize this."; // no {Text}
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains("{Text}"));
+    }
+
+    [Fact]
+    public void Validate_MissingTextPlaceholder_ErrorNamesProperty()
+    {
+        var options = ValidOptions();
+        options.SummaryUserPromptTemplate = "No placeholder here.";
+
+        var result = _sut.Validate(null, options);
+
+        Assert.Contains(result.Failures!,
+            f => f.Contains(nameof(OpenAiOptions.SummaryUserPromptTemplate)));
+    }
+
+    // ── ImagePromptUserTemplate ───────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_MissingSummaryPlaceholder_Fails()
+    {
+        var options = ValidOptions();
+        options.ImagePromptUserTemplate = "Generate an image prompt."; // no {Summary}
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains("{Summary}"));
+    }
+
+    [Fact]
+    public void Validate_MissingSummaryPlaceholder_ErrorNamesProperty()
+    {
+        var options = ValidOptions();
+        options.ImagePromptUserTemplate = "No placeholder here.";
+
+        var result = _sut.Validate(null, options);
+
+        Assert.Contains(result.Failures!,
+            f => f.Contains(nameof(OpenAiOptions.ImagePromptUserTemplate)));
+    }
+
+    // ── Multiple failures ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_AllPlaceholdersMissing_ReportsThreeFailures()
+    {
+        var options = ValidOptions();
+        options.SummarySystemPromptTemplate = "No placeholder.";
+        options.SummaryUserPromptTemplate = "No placeholder.";
+        options.ImagePromptUserTemplate = "No placeholder.";
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Equal(3, result.Failures!.Count());
+    }
+}


### PR DESCRIPTION
## Summary

Moves all hard-coded prompt strings and the two remaining magic numbers (`max_tokens = 60`, `temperature = 0.7`) from `OpenAiService` into `OpenAiOptions`, completing the externalisation of OpenAI configuration started in #88.

## Changes

### `src/Models/OpenAiOptions.cs`
Added six new properties with production-ready defaults:
- `SummarySystemPromptTemplate` — system prompt for summarisation; supports `{MaxChars}` placeholder
- `SummaryUserPromptTemplate` — user prompt for summarisation; supports `{Text}` placeholder
- `ImagePromptSystemTemplate` — system prompt for image prompt generation
- `ImagePromptUserTemplate` — user prompt for image prompt generation; supports `{Summary}` placeholder
- `ImagePromptMaxTokens` (default `60`) — max tokens for image prompt requests
- `ImagePromptTemperature` (default `0.7`) — temperature for image prompt requests

### `src/Services/OpenAiService.cs`
- `GetSummary`: replaced inline `$"..."` strings with `SummarySystemPromptTemplate.Replace("{MaxChars}", ...)` and `SummaryUserPromptTemplate.Replace("{Text}", ...)`
- `GetPromptForImage`: replaced inline strings and magic numbers with the new `ImagePrompt*` options

### `src/local.settings.json.example`
Added six `OpenAI__*` keys documenting the new settings with their defaults.

### `docs/configuration.md`
Added six rows to the AI/OpenAI configuration table.

## Runtime Impact

No behaviour change — the default values in `OpenAiOptions` reproduce the previously hard-coded strings exactly. Operators can now override prompts and parameters via Azure App Settings without redeployment.

## Tests

All 117 existing tests pass. No new tests required (the template substitution is exercised through the existing HTTP-level service tests).

Closes #89