### PR TITLE
chore: add NuGet.Config to pin restore to nuget.org only

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Summary

Adds a repo-level `NuGet.Config` that clears all inherited package sources and
declares only `nuget.org` as the authoritative feed.

## Problem

The global NuGet configuration on the development machine includes other 
feed from an unrelated project. Every `dotnet restore` in this repo contacted
that endpoint — generating `NU1900` warnings and slowing down restores on
machines without access to that Azure DevOps organisation.

## Change

`NuGet.Config` at repo root:
```xml
<packageSources>
  <clear />
  <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
</packageSources>