### PR TITLE
Fix isolated function deployment artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,24 @@ jobs:
           pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
           dotnet publish src/XPoster.csproj --configuration Release --output ./output --no-build
           popd
+
+      - name: Validate Functions package
+        shell: pwsh
+        run: |
+          pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
+          $requiredPaths = @(
+            './output/host.json',
+            './output/worker.config.json',
+            './output/.azurefunctions'
+          )
+
+          $missing = $requiredPaths | Where-Object { -not (Test-Path $_) }
+          if ($missing.Count -gt 0) {
+            Write-Error "Publish output is missing required Azure Functions isolated artifacts: $($missing -join ', ')"
+          }
+
+          Get-ChildItem ./output -Force | Select-Object Name
+          popd
       
       - name: Login to Azure
         uses: azure/login@v3

--- a/src/Implementation/GeneratorFactory.cs
+++ b/src/Implementation/GeneratorFactory.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using XPoster.Abstraction;
 using XPoster.SenderPlugins;
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,5 +1,8 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using XPoster.Abstraction;
 using XPoster.Implementation;

--- a/src/XPoster.csproj
+++ b/src/XPoster.csproj
@@ -1,11 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
 	<OutputType>Exe</OutputType>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
-	<FunctionsWorkerRuntime>dotnet-isolated</FunctionsWorkerRuntime>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Versioning baseline: overridden by /p:Version=X.Y.Z in CI release job -->
     <Version>0.1.0</Version>
@@ -16,6 +15,7 @@
 	<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	<PackageReference Include="Azure.Identity" Version="1.13.2" />
 	<PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.2.0" />
+  <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.6" OutputItemType="Analyzer" />
 	<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.8.0" />
 	<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
 	<PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />


### PR DESCRIPTION
## Summary

This PR fixes Azure Functions deployment packaging for the .NET isolated worker version of XPoster.

The production deployment was succeeding at the ZIP deploy level, but Azure was loading `0 functions` because the published package was missing the metadata artifacts required by a .NET isolated Function App, in particular the `.azurefunctions` folder and `worker.config.json`.

## Root Cause

The function project was not configured in the standard and reliable way for Azure Functions .NET isolated publishing.

Because of that, the publish output used by the CI deploy job could be generated without the isolated worker metadata required by Azure to index functions after deployment.

Observed runtime symptom in Azure:

- Host started successfully
- Storage lock was acquired
- `0 functions found`
- `0 functions loaded`
- Warning about missing `.azurefunctions` in deployed artifacts

## Changes

### Project configuration

Updated the function project to the standard .NET isolated layout:

- switched project SDK from `Microsoft.NET.Sdk.Worker` to `Microsoft.NET.Sdk`
- added explicit `Microsoft.Azure.Functions.Worker.Sdk` package reference as analyzer
- kept the existing Azure Functions worker/runtime package set
- removed the now-unnecessary project property that was not solving the deployment issue

### Source updates required by the project change

Added the explicit `Microsoft.Extensions.*` usings needed after moving to the standard SDK-based setup:

- `src/Program.cs`
- `src/Implementation/GeneratorFactory.cs`

### CI hardening

Added a validation step in the deploy workflow to fail early if the publish output is missing required isolated-worker artifacts.

The workflow now verifies the presence of:

- `host.json`
- `worker.config.json`
- `.azurefunctions`

This prevents future green deployments that would still result in Azure loading zero functions.

## Why this fix

After this change, the publish output generated for deployment correctly contains the isolated-worker metadata expected by Azure Functions, including:

- `.azurefunctions`
- `worker.config.json`
- `extensions.json`

This makes the deployed package indexable by Azure and restores normal function discovery and timer execution.

## Validation

Validated locally with the same deployment shape used by CI:

- `dotnet build src/XPoster.csproj --configuration Release`
- `dotnet publish src/XPoster.csproj --configuration Release --output ./output`
- `dotnet build` followed by `dotnet publish --no-build --output ./output`

Validated outcome:

- publish output now contains `.azurefunctions`
- publish output now contains `worker.config.json`
- Release build succeeds with `0` errors and `0` warnings

## Expected Impact

After deployment of this PR:

- Azure should detect and load `XPosterFunction` again
- the Function App should no longer report `0 functions loaded`
- timer-trigger execution should resume normally
- failed/incomplete deployment artifacts will be caught directly in CI before ZIP deploy

## Notes

This PR does not change XPoster runtime behavior or business logic.

It only fixes the deployment artifact generation path and adds a guardrail in CI to prevent the same failure mode from reaching Azure again.