### PR TITLE
Develop

### DIFF
--- a/src/Implementation/AiServiceFactory.cs
+++ b/src/Implementation/AiServiceFactory.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using XPoster.Abstraction;
-using XPoster.Models;
-using XPoster.Services;
 
 namespace XPoster.Implementation;
 
@@ -13,11 +11,11 @@ namespace XPoster.Implementation;
 public class AiServiceFactory : IAiServiceFactory
 {
     private readonly IServiceProvider _serviceProvider;
-    private readonly Dictionary<AiProvider, Type> _providerMap = new()
-    {
-        { AiProvider.OpenAi, typeof(OpenAiService) },
-        // { AiProvider.Perplexity, typeof(PerplexityService) }, // Uncomment when implemented
-    };
+    private static readonly HashSet<AiProvider> _supportedProviders =
+    [
+        AiProvider.OpenAi,
+        // AiProvider.Perplexity, // Uncomment when implemented
+    ];
 
     /// <summary>
     /// Initialises a new instance of <see cref="AiServiceFactory"/>.
@@ -37,11 +35,13 @@ public class AiServiceFactory : IAiServiceFactory
     /// <exception cref="InvalidOperationException">Thrown when mapped service cannot be resolved from DI.</exception>
     public IAiService GetByProvider(AiProvider provider)
     {
-        if (!_providerMap.TryGetValue(provider, out var serviceType))
+        if (!_supportedProviders.Contains(provider))
             throw new ArgumentException($"No IAiService registered for provider: {provider}");
-        var service = _serviceProvider.GetService(serviceType) as IAiService;
-        if (service == null)
+
+        var service = _serviceProvider.GetKeyedService<IAiService>(provider);
+        if (service is null)
             throw new InvalidOperationException($"Could not resolve IAiService for provider: {provider}");
+
         return service;
     }
 }

--- a/src/Implementation/GeneratorFactory.cs
+++ b/src/Implementation/GeneratorFactory.cs
@@ -112,8 +112,8 @@ public class GeneratorFactory : IGeneratorFactory
         new ScheduledGenerationProfile(6, MessageSender.InSummaryFeed, typeof(FeedGenerator), AiProvider.OpenAi),
         new ScheduledGenerationProfile(8, MessageSender.XSummaryFeed, typeof(FeedGenerator), AiProvider.OpenAi),
         //new ScheduledGenerationProfile(10, MessageSender.IgSummaryFeed, typeof(FeedGenerator), AiProvider.OpenAi),
-        new ScheduledGenerationProfile(14, MessageSender.InPowerLaw, typeof(PowerLawGenerator), AiProvider.OpenAi),
-        new ScheduledGenerationProfile(16, MessageSender.XPowerLaw, typeof(PowerLawGenerator), AiProvider.OpenAi),
-        //new ScheduledGenerationProfile(18, MessageSender.IgPowerLow, typeof(PowerLawGenerator), AiProvider.OpenAi),
+        new ScheduledGenerationProfile(14, MessageSender.InPowerLaw, typeof(PowerLawGenerator)),
+        new ScheduledGenerationProfile(16, MessageSender.XPowerLaw, typeof(PowerLawGenerator)),
+        //new ScheduledGenerationProfile(18, MessageSender.IgPowerLow, typeof(PowerLawGenerator)),
     };
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -39,7 +39,7 @@ builder.Services.AddSingleton<ITimeProvider, XPoster.Services.TimeProvider>();
 
 // Register IAiServiceFactory and all IAiService implementations
 builder.Services.AddSingleton<IAiServiceFactory, AiServiceFactory>();
-builder.Services.AddTransient<IAiService, OpenAiService>();
+builder.Services.AddKeyedTransient<IAiService, OpenAiService>(AiProvider.OpenAi);
 // builder.Services.AddTransient<IAiService, PerplexityService>(); // Uncomment when implemented
 
 builder.Services.AddTransient<IGeneratorFactory, GeneratorFactory>();

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -40,7 +40,7 @@ builder.Services.AddSingleton<ITimeProvider, XPoster.Services.TimeProvider>();
 // Register IAiServiceFactory and all IAiService implementations
 builder.Services.AddSingleton<IAiServiceFactory, AiServiceFactory>();
 builder.Services.AddKeyedTransient<IAiService, OpenAiService>(AiProvider.OpenAi);
-// builder.Services.AddTransient<IAiService, PerplexityService>(); // Uncomment when implemented
+// builder.Services.AddKeyedTransient<IAiService, PerplexityService>(AiProvider.Perplexity); // Uncomment when implemented
 
 builder.Services.AddTransient<IGeneratorFactory, GeneratorFactory>();
 

--- a/tests/Implementation/AiServiceFactoryTests.cs
+++ b/tests/Implementation/AiServiceFactoryTests.cs
@@ -8,10 +8,12 @@ namespace XPoster.Tests.Implementation;
 public class AiServiceFactoryTests
 {
     private readonly Mock<IServiceProvider> _serviceProvider;
+    private readonly Mock<IKeyedServiceProvider> _keyedServiceProvider;
 
     public AiServiceFactoryTests()
     {
         _serviceProvider = new Mock<IServiceProvider>();
+        _keyedServiceProvider = _serviceProvider.As<IKeyedServiceProvider>();
     }
 
     [Fact]
@@ -19,8 +21,8 @@ public class AiServiceFactoryTests
     {
         // ARRANGE
         var aiService = new Mock<IAiService>();
-        _serviceProvider
-            .Setup(sp => sp.GetService(typeof(XPoster.Services.OpenAiService)))
+        _keyedServiceProvider
+            .Setup(sp => sp.GetKeyedService(typeof(IAiService), AiProvider.OpenAi))
             .Returns(aiService.Object);
 
         var factory = new AiServiceFactory(_serviceProvider.Object);
@@ -50,8 +52,8 @@ public class AiServiceFactoryTests
     public void GetByProvider_Should_ThrowInvalidOperationException_When_MappedServiceCannotBeResolved()
     {
         // ARRANGE
-        _serviceProvider
-            .Setup(sp => sp.GetService(typeof(XPoster.Services.OpenAiService)))
+        _keyedServiceProvider
+            .Setup(sp => sp.GetKeyedService(typeof(IAiService), AiProvider.OpenAi))
             .Returns((object?)null);
 
         var factory = new AiServiceFactory(_serviceProvider.Object);


### PR DESCRIPTION
## Summary
This PR fixes AI service resolution in `GeneratorFactory` while keeping dependency registration interface-based (`IAiService`), and removes unnecessary AI dependency from `PowerLaw` slots.

## Problem
With the previous setup:
- `AiServiceFactory` resolved a concrete type (`OpenAiService`) from DI.
- `Program.cs` registered only the interface mapping (`IAiService -> OpenAiService`).
- This could trigger `InvalidOperationException` when `GetByProvider` was called, including in flows where AI was not needed.
- `PowerLaw` slots (14/16) also had `AiProvider` configured even though they do not use AI.

## What Changed
- Refactored `AiServiceFactory`:
  - from `AiProvider -> Type` mapping to a supported-provider set;
  - service resolution now uses `GetKeyedService<IAiService>(provider)`.
- Updated DI registration in `Program.cs`:
  - keyed interface registration:
    - `AddKeyedTransient<IAiService, OpenAiService>(AiProvider.OpenAi)`.
- Cleaned up schedule configuration in `GeneratorFactory`:
  - removed `AiProvider` from `PowerLaw` slots (hours 14 and 16).
- Updated unit tests:
  - `AiServiceFactoryTests` now mocks `IKeyedServiceProvider` for keyed resolution behavior.

## Files Changed
- `src/Implementation/AiServiceFactory.cs`
- `src/Implementation/GeneratorFactory.cs`
- `src/Program.cs`
- `tests/Implementation/AiServiceFactoryTests.cs`

## Impact
- No expected functional changes for `Feed` flows when AI provider is configured.
- Reduced runtime failure risk caused by DI registration/resolution mismatch.
- `PowerLaw` slots no longer attempt unnecessary AI resolution.

## Validation
- Targeted tests for AI factory and generator factory: **13 passed, 0 failed**.