### PR TITLE
Develop

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,7 +48,7 @@ XPoster is a **serverless, event-driven pipeline** that runs on a timer, selects
     ├────────────────┤
     │ • AI Service   │ ◄─── OpenAI Integration
     │ • Feed Service │ ◄─── RSS Parser
-    │ • Crypto Svc   │ ◄─── Security Utils
+    │ • Crypto Svc   │ ◄─── CryptoPrices HTTP client
     └────────┬───────┘
              │
              ▼
@@ -83,7 +83,7 @@ XPoster is a **serverless, event-driven pipeline** that runs on a timer, selects
 Each generator implements `IGenerator` and encapsulates a specific **content production algorithm**:
 
 - **FeedGenerator**: fetches RSS entries via `FeedService`, calls `AiService` to produce a gpt-4.1-nano summary, and requests a gpt-image-1.5 image. It is stateless and side-effect-free until it hands off the `Post`.
-- **PowerLawGenerator**: constructs posts based on statistical/mathematical content (Bitcoin Power Law model). It consumes `CryptoService` for price data and `AiService` for narrative framing.
+- **PowerLawGenerator**: constructs posts based on the Bitcoin Power Law model (`value = 10⁻¹⁷ × days^5.83`, where `days` is elapsed since the Bitcoin genesis block on 2009-01-03). It consumes `CryptoService` to fetch the live BTC price and compares it against the model's fair-value estimate. It has no dependency on `AiService`.
 - **NoGenerator**: a null-object implementation that returns `null` immediately, allowing the factory to represent "no posting" without null-checks in the orchestrator.
 
 ### Services Layer — Shared Infrastructure
@@ -92,7 +92,7 @@ Services are registered as singletons or transients in the DI container and are 
 
 - **AiService**: thin wrapper over the OpenAI API; isolates all prompt engineering and model-specific parameters behind a stable interface (`IAiService`).
 - **FeedService**: RSS parser with in-memory caching and deduplication; exposes a clean `IEnumerable<FeedItem>` contract.
-- **CryptoService**: utility layer for cryptocurrency data retrieval and token handling; used for security-sensitive operations and market data queries.
+- **CryptoService**: thin HTTP client that polls `cryptoprices.cc` to retrieve the current market price for a given cryptocurrency symbol. Returns `0` on failure to allow graceful degradation in generators.
 
 ### Sender Plugins — Platform Abstraction
 
@@ -201,7 +201,7 @@ Each sender implements `ISender`, which exposes `Task<bool> SendAsync(Post post)
 
 ---
 
-### ADR-004 — OpenAI Integration via Direct API
+### ADR-004 — OpenAI Integration via Azure OpenAI SDK
 
 | Field | Detail |
 |---|---|
@@ -210,11 +210,7 @@ Each sender implements `ISender`, which exposes `Task<bool> SendAsync(Post post)
 
 **Context**: Content generation requires a large language model for summarisation and an image model for visuals.
 
-<<<<<<< develop
 **Decision**: Use **Azure OpenAI Service** (gpt-4.1-nano for text, gpt-image-1.5 for images) accessed through the official Azure SDK, abstracted behind `IAiService`.
-=======
-**Decision**: Use **OpenAI direct API** (`api.openai.com`) accessed via `HttpClient` + `OPENAI_API_KEY`, abstracted behind `IAiService`.
->>>>>>> master
 
 **Rationale**:
 - **Models**: `gpt-4.1-nano` for summarisation/prompting, `gpt-image-1.5` for image generation.
@@ -223,7 +219,7 @@ Each sender implements `ISender`, which exposes `Task<bool> SendAsync(Post post)
 - Azure OpenAI migration is a future option.
 
 **Alternatives considered**:
-- **Azure OpenAI Service**: Rejected in v1.2.0 — `response_format` parameter incompatibility with DALL-E 3.
+- **OpenAI direct API**: Used in v1.2.0 transition period; superseded by Azure OpenAI SDK on develop branch.
 - **Hugging Face / open-source models**: Rejected — self-hosting adds infrastructure burden; quality gap for summarisation tasks at current scale.
 
 **Consequences**: OpenAI API quotas and rate limits must be managed. Token usage should be monitored via Application Insights (see KQL queries in README).
@@ -322,6 +318,7 @@ sequenceDiagram
     participant Gen as IGenerator<br/>(Feed / PowerLaw)
     participant AI as AiService<br/>(OpenAI)
     participant Feed as FeedService<br/>(RSS)
+    participant Crypto as CryptoService<br/>(cryptoprices.cc)
     participant Sender as ISender<br/>(X / LinkedIn / Instagram)
     participant Platform as Social Platform API
 
@@ -337,10 +334,11 @@ sequenceDiagram
         Gen->>AI: GetSummaryAsync(content, maxLength)
         AI-->>Gen: summary text
         Gen->>AI: GenerateImageAsync(title)
-        AI-->>Gen: image URL
+        AI-->>Gen: image bytes
     else PowerLawGenerator
-        Gen->>AI: GetPowerLawNarrativeAsync(priceData)
-        AI-->>Gen: narrative text
+        Gen->>Crypto: GetPriceAsync(symbol)
+        Crypto-->>Gen: current BTC price (decimal)
+        Gen->>Gen: Compute fair value (10⁻¹⁷ × days^5.83)
     end
 
     Gen-->>Fn: Post { Content, ImageUrl }

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@
     ├────────────────┤
     │ • AI Service   │ ◄─── OpenAI Integration
     │ • Feed Service │ ◄─── RSS Parser
-    │ • Crypto Svc   │ ◄─── Security Utils
+    │ • Crypto Svc   │ ◄─── CryptoPrices HTTP client
     └────────┬───────┘
              │
              ▼
@@ -118,22 +118,24 @@ Timer-triggered Azure Function that orchestrates the entire publishing workflow.
 #### 2. **GeneratorFactory** (Factory + Strategy Pattern)
 Dynamically selects the appropriate generator based on current time.
 
-| Time | Platform | Strategy |
-|------|----------|----------|
-| 06:00 | LinkedIn | Feed Summary |
-| 08:00 | Twitter/X | Feed Summary |
-| 14:00 | LinkedIn | Power Law |
-| 16:00 | Twitter/X | Power Law |
+| Time | Platform | Strategy | Status |
+|------|----------|----------|--------|
+| 06:00 | LinkedIn | Feed Summary | ✅ Active |
+| 08:00 | Twitter/X | Feed Summary | ✅ Active |
+| 10:00 | Instagram | Feed Summary | ⚠️ Disabled — pending Instagram production readiness |
+| 14:00 | LinkedIn | Power Law | ✅ Active |
+| 16:00 | Twitter/X | Power Law | ✅ Active |
+| 18:00 | Instagram | Power Law | ⚠️ Disabled — pending Instagram production readiness |
 
 #### 3. **Generators** (Content Strategy)
 - **FeedGenerator**: Analyzes crypto RSS feeds, generates AI summaries, creates images
-- **PowerLawGenerator**: Generates content based on statistical distribution
+- **PowerLawGenerator**: Generates posts based on the Bitcoin Power Law model (`value = 10⁻¹⁷ × days^5.83`), comparing the fair-value estimate with the live BTC price
 - **NoGenerator**: Placeholder for time slots without publishing
 
 #### 4. **Services Layer**
 - **AiService**: Interface with OpenAI (gpt-4.1-nano, gpt-image-1.5)
 - **FeedService**: RSS parser with caching and intelligent filtering
-- **CryptoService**: Crypto-currencies utilities
+- **CryptoService**: Thin HTTP client that polls `cryptoprices.cc` to retrieve the current market price for a given cryptocurrency symbol
 
 #### 5. **Sender Plugins** (Platform Abstraction)
 - **XSender**: Twitter/X via LinqToTwitter
@@ -419,14 +421,14 @@ az functionapp config appsettings set
 Modify `GeneratorFactory.cs` to customize which generator to use at each hour:
 
 ```csharp
-private static readonly Dictionary<int, MessageSender> sendParameters = new()
+private static readonly List<ScheduledGenerationProfile> slotProfiles = new()
 {
-{ 6, MessageSender.InSummaryFeed }, // LinkedIn Feed
-{ 8, MessageSender.XSummaryFeed }, // Twitter Feed
-{ 10, MessageSender.IgSummaryFeed }, // Instagram Feed (enable when ready)
-{ 14, MessageSender.InPowerLaw }, // LinkedIn Power Law
-{ 16, MessageSender.XPowerLaw }, // Twitter Power Law
-{ 18, MessageSender.IgPowerLow }, // Instagram Power Law
+    new ScheduledGenerationProfile(6,  MessageSender.InSummaryFeed,  typeof(FeedGenerator),     AiProvider.OpenAi),
+    new ScheduledGenerationProfile(8,  MessageSender.XSummaryFeed,   typeof(FeedGenerator),     AiProvider.OpenAi),
+    //new ScheduledGenerationProfile(10, MessageSender.IgSummaryFeed, typeof(FeedGenerator),     AiProvider.OpenAi), // Disabled — see #72
+    new ScheduledGenerationProfile(14, MessageSender.InPowerLaw,     typeof(PowerLawGenerator)),
+    new ScheduledGenerationProfile(16, MessageSender.XPowerLaw,      typeof(PowerLawGenerator)),
+    //new ScheduledGenerationProfile(18, MessageSender.IgPowerLaw,   typeof(PowerLawGenerator)),                    // Disabled — see #72
 };
 ```
 ---

--- a/src/Abstraction/Enums.cs
+++ b/src/Abstraction/Enums.cs
@@ -12,7 +12,7 @@ public enum MessageSender
     /// <summary>Posts a Bitcoin Power Law update to LinkedIn.</summary>
     InPowerLaw,
     /// <summary>Posts a Bitcoin Power Law update to Instagram.</summary>
-    IgPowerLow,
+    IgPowerLaw,
     /// <summary>Posts a news feed summary to X (Twitter).</summary>
     XSummaryFeed,
     /// <summary>Posts a news feed summary to LinkedIn.</summary>

--- a/src/Implementation/GeneratorFactory.cs
+++ b/src/Implementation/GeneratorFactory.cs
@@ -61,7 +61,7 @@ public class GeneratorFactory : IGeneratorFactory
             MessageSender.InSummaryFeed => _serviceProvider.GetService(typeof(InSender)) as ISender,
             MessageSender.InPowerLaw => _serviceProvider.GetService(typeof(InSender)) as ISender,
             MessageSender.IgSummaryFeed => _serviceProvider.GetService(typeof(IgSender)) as ISender,
-            MessageSender.IgPowerLow => _serviceProvider.GetService(typeof(IgSender)) as ISender,
+            MessageSender.IgPowerLaw => _serviceProvider.GetService(typeof(IgSender)) as ISender,
             _ => null
         };
 
@@ -114,6 +114,6 @@ public class GeneratorFactory : IGeneratorFactory
         //new ScheduledGenerationProfile(10, MessageSender.IgSummaryFeed, typeof(FeedGenerator), AiProvider.OpenAi),
         new ScheduledGenerationProfile(14, MessageSender.InPowerLaw, typeof(PowerLawGenerator)),
         new ScheduledGenerationProfile(16, MessageSender.XPowerLaw, typeof(PowerLawGenerator)),
-        //new ScheduledGenerationProfile(18, MessageSender.IgPowerLow, typeof(PowerLawGenerator)),
+        //new ScheduledGenerationProfile(18, MessageSender.IgPowerLaw, typeof(PowerLawGenerator)),
     };
 }


### PR DESCRIPTION
## Summary

This PR merges a batch of documentation and code accuracy fixes tracked across five issues. All changes are confined to `README.md`, `ARCHITECTURE.md`, and `src/` source files — no behavioural or functional changes.

---

## Changes

### Fix incorrect `AiService` reference in `ARCHITECTURE.md` — `PowerLawGenerator`

`ARCHITECTURE.md` incorrectly stated that `PowerLawGenerator` consumes `AiService` for "narrative framing" and included a fabricated `GetPowerLawNarrativeAsync` call in the Mermaid data-flow diagram. `PowerLawGenerator` has no dependency on any AI service — it is fully deterministic.

Closes #106

---

### Fix `PowerLawGenerator` description in `README.md`

`README.md` described `PowerLawGenerator` as generating content based on "statistical distribution", which is inaccurate. The generator implements the Bitcoin Power Law model with the formula `value = 10⁻¹⁷ × days^5.83`.

Closes #107

---

### Fix typo: rename `IgPowerLow` → `IgPowerLaw`

The `MessageSender` enum contained a typo (`IgPowerLow`) that propagated to `GeneratorFactory.cs` and the scheduling snippet in `README.md`.

> ⚠️ Breaking rename of a public enum value — verify no external consumers reference `IgPowerLow` before merging.

Closes #108

---

### Add disabled Instagram slots to scheduling table in `README.md`

The scheduling table omitted the two Instagram slots that exist as commented-out entries in `GeneratorFactory.slotProfiles`. The table now includes them with a clear `⚠️ Disabled` marker, consistent with the note already present in `docs/configuration.md`.

Closes #109

---

### Fix `CryptoService` description in `ARCHITECTURE.md`

`ARCHITECTURE.md` described `CryptoService` as handling "security-sensitive operations" and "token handling". `CryptoService` performs a single HTTP GET to `cryptoprices.cc` and returns a decimal price — it handles no auth tokens and no secrets.

Closes #110

---

## Checklist

- [ ] No functional or behavioural changes introduced
- [ ] `IgPowerLow` → `IgPowerLaw` rename verified across all usages (`Enums.cs`, `GeneratorFactory.cs`, `README.md`)
- [ ] CI green on `develop` before merge