### PR TITLE
feat(ai): add Azure Foundry IAiService provider (#119)

### DIFF
--- a/docs/azure-foundry-setup.md
+++ b/docs/azure-foundry-setup.md
@@ -1,0 +1,98 @@
+# Azure Foundry Setup
+
+This guide explains how to provision Azure AI Foundry and configure XPoster to use `AzureFoundryService` as `IAiService` provider.
+
+## 1. Create Azure AI Foundry Resource
+
+1. Open the Azure Portal.
+2. Create a new `Azure AI Foundry` (or Azure OpenAI-compatible) resource.
+3. Choose subscription, resource group, region, and pricing tier.
+4. After deployment, open the resource and note:
+- Endpoint URL
+- Keys (Key 1 / Key 2)
+
+## 2. Create Project And Deploy Models
+
+1. Open Azure AI Foundry Studio for your resource.
+2. Create a project (or use an existing one).
+3. Deploy a chat model (for summaries and prompt generation).
+4. Deploy an image-capable model (for image generation).
+5. Save both deployment names.
+
+Recommended mapping:
+- `DeploymentName`: chat deployment
+- `ImageDeploymentName`: image deployment
+
+## 3. Retrieve Required Parameters
+
+Collect these values from Portal/Foundry:
+
+- `Endpoint`: resource endpoint, for example `https://<resource>.openai.azure.com`
+- `ApiKey`: resource key
+- `DeploymentName`: chat deployment name
+- `ImageDeploymentName`: image deployment name
+- `ApiVersion`: API version accepted by your deployed models (default in XPoster: `2024-02-01`)
+
+## 4. Configure XPoster
+
+Set these values in local settings (`src/local.settings.json`) or Azure App Settings:
+
+```json
+{
+  "Values": {
+    "AiProvider": "AzureFoundry",
+    "AzureFoundry__Endpoint": "https://<resource>.openai.azure.com",
+    "AzureFoundry__ApiKey": "<secret>",
+    "AzureFoundry__DeploymentName": "<chat-deployment>",
+    "AzureFoundry__ImageDeploymentName": "<image-deployment>",
+    "AzureFoundry__ApiVersion": "2024-02-01"
+  }
+}
+```
+
+## 5. Store Secrets Safely
+
+For production:
+
+- Use Azure Function App Settings for non-secret config.
+- Store secrets (`ApiKey`) in Azure Key Vault.
+- Reference Key Vault values from Function App Settings.
+- Never commit secrets into source control.
+
+## 6. Switch Provider Using `AiProvider`
+
+XPoster supports provider selection via `AiProvider` for AI-enabled generator slots.
+
+- `AiProvider=OpenAi` uses `OpenAiService`.
+- `AiProvider=AzureFoundry` uses `AzureFoundryService`.
+
+If `AiProvider` is missing or invalid, XPoster falls back to the schedule default provider configured in `GeneratorFactory`.
+
+## 7. Troubleshooting
+
+### 401 / 403 Unauthorized
+
+- Verify `AzureFoundry__ApiKey` value.
+- Ensure key belongs to the same resource as `Endpoint`.
+
+### 404 Deployment Not Found
+
+- Confirm `DeploymentName` and `ImageDeploymentName` match deployed model names exactly.
+- Check region/project alignment.
+
+### 400 Bad Request (API version)
+
+- Set `AzureFoundry__ApiVersion` to a version supported by your deployment.
+- Validate endpoint path format and trailing slash handling.
+
+### 429 Too Many Requests
+
+- Reduce call frequency or increase capacity/quota.
+- Check model quota usage and regional limits.
+
+### Empty Summary Or Image Output
+
+- Verify prompt templates include required placeholders:
+- `SummarySystemPromptTemplate` must include `{MaxChars}`
+- `SummaryUserPromptTemplate` must include `{Text}`
+- `ImagePromptUserTemplate` must include `{Summary}`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,12 @@ All configuration is passed via environment variables (locally in `src/local.set
 
 ## AI (OpenAI)
 
+Use `AiProvider` to select which provider `GeneratorFactory` should resolve for AI-enabled slots.
+
+| Setting | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `AiProvider` | string | No | `OpenAi` | Overrides schedule default for AI-enabled slots. Supported values: `OpenAi`, `AzureFoundry`. |
+
 Configuration is bound from the `OpenAI` section using double-underscore notation in Azure App Settings / `local.settings.json` (e.g. `OpenAI__ApiKey`).
 
 | Setting | Type | Required | Default | Description |
@@ -58,6 +64,27 @@ Configuration is bound from the `OpenAI` section using double-underscore notatio
 | `OpenAI__ImagePromptUserTemplate` | string | No | *(see default)* | User prompt for image prompt generation. Supports `{Summary}` placeholder. |
 | `OpenAI__ImagePromptMaxTokens` | int | No | `60` | Max tokens for image prompt generation requests. |
 | `OpenAI__ImagePromptTemperature` | double | No | `0.7` | Temperature for image prompt generation requests. |
+
+## AI (Azure Foundry)
+
+Configuration is bound from the `AzureFoundry` section using double-underscore notation in Azure App Settings / `local.settings.json` (e.g. `AzureFoundry__Endpoint`).
+
+| Setting | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `AzureFoundry__Endpoint` | string | ✅ Yes | — | Base endpoint for your Foundry/OpenAI-compatible resource. |
+| `AzureFoundry__ApiKey` | string | ✅ Yes | — | API key used as `api-key` header. |
+| `AzureFoundry__DeploymentName` | string | ✅ Yes | — | Chat deployment used for summary and image-prompt generation. |
+| `AzureFoundry__ImageDeploymentName` | string | No | — | Image deployment used by `GenerateImageAsync`. |
+| `AzureFoundry__ApiVersion` | string | No | `2024-02-01` | API version appended to requests. |
+| `AzureFoundry__SummaryTemperature` | double | No | `0.5` | Temperature for summary generation. |
+| `AzureFoundry__SummaryMaxTokensPerChar` | int | No | `5` | Divisor to convert character budget to `max_tokens`. |
+| `AzureFoundry__SummarySafetyMarginChars` | int | No | `50` | Character margin subtracted from budget. |
+| `AzureFoundry__SummarySystemPromptTemplate` | string | No | *(see default)* | System prompt for summarisation. Supports `{MaxChars}`. |
+| `AzureFoundry__SummaryUserPromptTemplate` | string | No | *(see default)* | User prompt for summarisation. Supports `{Text}`. |
+| `AzureFoundry__ImagePromptSystemTemplate` | string | No | *(see default)* | System prompt for image-prompt generation. |
+| `AzureFoundry__ImagePromptUserTemplate` | string | No | *(see default)* | User prompt for image-prompt generation. Supports `{Summary}`. |
+| `AzureFoundry__ImagePromptMaxTokens` | int | No | `60` | Max tokens for image-prompt generation. |
+| `AzureFoundry__ImagePromptTemperature` | double | No | `0.7` | Temperature for image-prompt generation. |
 
 ## Azure Functions Runtime
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Welcome to the XPoster documentation hub. Use the links below to navigate to eac
 |---|---|
 | [Getting Started](getting-started.md) | Setup, prerequisites, first run |
 | [Configuration Reference](configuration.md) | All environment variables with type, default, and description |
+| [Azure Foundry Setup](azure-foundry-setup.md) | Provisioning and configuration for Azure AI Foundry integration |
 | [Deployment Guide](deployment.md) | Step-by-step Azure deployment |
 | [Extending XPoster](extending-xposter.md) | Adding new senders and generators |
 | [Monitoring & Alerting](monitoring.md) | Application Insights setup and KQL queries |

--- a/src/Abstraction/AiProvider.cs
+++ b/src/Abstraction/AiProvider.cs
@@ -12,6 +12,8 @@ public enum AiProvider
     OpenAi = 1,
 
     /// <summary>Perplexity provider.</summary>
-    Perplexity = 2
-    // Extend here for future providers (e.g., Foundry)
+    Perplexity = 2,
+
+    /// <summary>Azure AI Foundry provider.</summary>
+    AzureFoundry = 3
 }

--- a/src/Implementation/AiServiceFactory.cs
+++ b/src/Implementation/AiServiceFactory.cs
@@ -14,6 +14,7 @@ public class AiServiceFactory : IAiServiceFactory
     private static readonly HashSet<AiProvider> _supportedProviders =
     [
         AiProvider.OpenAi,
+        AiProvider.AzureFoundry,
         // AiProvider.Perplexity, // Uncomment when implemented
     ];
 

--- a/src/Implementation/GeneratorFactory.cs
+++ b/src/Implementation/GeneratorFactory.cs
@@ -25,6 +25,7 @@ public class GeneratorFactory : IGeneratorFactory
     /// <param name="log">Factory logger.</param>
     /// <param name="timeProvider">Time provider used to determine current hour slot.</param>
     /// <param name="aiServiceFactory">Factory used to resolve the AI service by provider.</param>
+    /// <param name="configuration">Optional configuration used to override the AI provider via <c>AiProvider</c> setting.</param>
     public GeneratorFactory(
         IServiceProvider serviceProvider,
         ILogger<GeneratorFactory> log,

--- a/src/Implementation/GeneratorFactory.cs
+++ b/src/Implementation/GeneratorFactory.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using XPoster.Abstraction;
@@ -15,6 +16,7 @@ public class GeneratorFactory : IGeneratorFactory
     private readonly ILogger<GeneratorFactory> _log;
     private readonly ITimeProvider _timeProvider;
     private readonly IAiServiceFactory _aiServiceFactory;
+    private readonly IConfiguration? _configuration;
 
     /// <summary>
     /// Initialises a new instance of <see cref="GeneratorFactory"/>.
@@ -27,12 +29,14 @@ public class GeneratorFactory : IGeneratorFactory
         IServiceProvider serviceProvider,
         ILogger<GeneratorFactory> log,
         ITimeProvider timeProvider,
-        IAiServiceFactory aiServiceFactory)
+        IAiServiceFactory aiServiceFactory,
+        IConfiguration? configuration = null)
     {
         _serviceProvider = serviceProvider;
         _log = log;
         _timeProvider = timeProvider;
         _aiServiceFactory = aiServiceFactory;
+        _configuration = configuration;
     }
 
     /// <summary>
@@ -68,7 +72,8 @@ public class GeneratorFactory : IGeneratorFactory
         IAiService? aiService = null;
         if (profile.AiProvider.HasValue)
         {
-            aiService = _aiServiceFactory.GetByProvider(profile.AiProvider.Value);
+            var effectiveProvider = ResolveAiProvider(profile.AiProvider.Value);
+            aiService = _aiServiceFactory.GetByProvider(effectiveProvider);
         }
 
         // Dynamically instantiate the generator with sender and aiService if required
@@ -102,6 +107,26 @@ public class GeneratorFactory : IGeneratorFactory
             }
         }
         return (BaseGenerator)Activator.CreateInstance(generatorType, args.ToArray())!;
+    }
+
+    private AiProvider ResolveAiProvider(AiProvider defaultProvider)
+    {
+        var configuredProvider = _configuration?["AiProvider"];
+        if (string.IsNullOrWhiteSpace(configuredProvider))
+        {
+            return defaultProvider;
+        }
+
+        if (Enum.TryParse<AiProvider>(configuredProvider, ignoreCase: true, out var parsedProvider))
+        {
+            return parsedProvider;
+        }
+
+        _log.LogWarning("Invalid AiProvider value '{AiProvider}' in configuration. Falling back to {DefaultProvider}.",
+            configuredProvider,
+            defaultProvider);
+
+        return defaultProvider;
     }
 
     /// <summary>

--- a/src/Models/AzureFoundryOptions.cs
+++ b/src/Models/AzureFoundryOptions.cs
@@ -1,0 +1,73 @@
+namespace XPoster.Models;
+
+/// <summary>
+/// Strongly-typed configuration for the Azure AI Foundry provider, bound from the <c>AzureFoundry</c> section.
+/// </summary>
+public sealed class AzureFoundryOptions
+{
+    /// <summary>Gets or sets the Foundry endpoint base URL (for example, <c>https://resource-name.openai.azure.com</c>).</summary>
+    public string Endpoint { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the API key used for Foundry authentication.</summary>
+    public string ApiKey { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the chat/completions deployment name.</summary>
+    public string DeploymentName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the image generation deployment name.</summary>
+    public string ImageDeploymentName { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the REST API version.</summary>
+    public string ApiVersion { get; set; } = "2024-02-01";
+
+    /// <summary>Gets or sets the temperature used for summary generation.</summary>
+    public double SummaryTemperature { get; set; } = 0.5;
+
+    /// <summary>
+    /// Gets or sets the divisor used to convert a character budget into a <c>max_tokens</c> value.
+    /// Formula: <c>max_tokens = messageMaxLength / SummaryMaxTokensPerChar</c>.
+    /// </summary>
+    public int SummaryMaxTokensPerChar { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets the safety margin (in characters) subtracted from the character budget
+    /// when building the "keep under N characters" prompt.
+    /// </summary>
+    public int SummarySafetyMarginChars { get; set; } = 50;
+
+    /// <summary>
+    /// Gets or sets the system prompt template for summarisation.
+    /// Supports placeholder <c>{MaxChars}</c>.
+    /// </summary>
+    public string SummarySystemPromptTemplate { get; set; } =
+        "You are an assistant that summarizes text concisely. " +
+        "It's very important that you keep summaries under {MaxChars} characters.";
+
+    /// <summary>
+    /// Gets or sets the user prompt template for summarisation.
+    /// Supports placeholder <c>{Text}</c>.
+    /// </summary>
+    public string SummaryUserPromptTemplate { get; set; } =
+        "Summarize this text in a few sentences. text: {Text}";
+
+    /// <summary>
+    /// Gets or sets the system prompt template for image prompt generation.
+    /// </summary>
+    public string ImagePromptSystemTemplate { get; set; } =
+        "You are an assistant that generates image prompts for an AI image generation model based on text summaries. " +
+        "Create a concise, vivid prompt in English that reflects the summary's content, includes a Bitcoin-related element (e.g., a coin), " +
+        "and avoids text, signs, or words in the image. Respect content policy for generating images.";
+
+    /// <summary>
+    /// Gets or sets the user prompt template for image prompt generation.
+    /// Supports placeholder <c>{Summary}</c>.
+    /// </summary>
+    public string ImagePromptUserTemplate { get; set; } =
+        "Generate an image prompt based on this summary: {Summary}";
+
+    /// <summary>Gets or sets max tokens for image prompt generation requests.</summary>
+    public int ImagePromptMaxTokens { get; set; } = 60;
+
+    /// <summary>Gets or sets the temperature for image prompt generation requests.</summary>
+    public double ImagePromptTemperature { get; set; } = 0.7;
+}

--- a/src/Models/AzureFoundryOptionsValidator.cs
+++ b/src/Models/AzureFoundryOptionsValidator.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Options;
+
+namespace XPoster.Models;
+
+/// <summary>
+/// Validates <see cref="AzureFoundryOptions"/> when the Azure Foundry provider is resolved.
+/// </summary>
+public sealed class AzureFoundryOptionsValidator : IValidateOptions<AzureFoundryOptions>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, AzureFoundryOptions options)
+    {
+        var failures = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.Endpoint))
+        {
+            failures.Add($"{nameof(AzureFoundryOptions.Endpoint)} is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.ApiKey))
+        {
+            failures.Add($"{nameof(AzureFoundryOptions.ApiKey)} is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.DeploymentName))
+        {
+            failures.Add($"{nameof(AzureFoundryOptions.DeploymentName)} is required.");
+        }
+
+        if (!options.SummarySystemPromptTemplate.Contains("{MaxChars}", StringComparison.Ordinal))
+        {
+            failures.Add(
+                $"{nameof(AzureFoundryOptions.SummarySystemPromptTemplate)} must contain the {{MaxChars}} placeholder.");
+        }
+
+        if (!options.SummaryUserPromptTemplate.Contains("{Text}", StringComparison.Ordinal))
+        {
+            failures.Add(
+                $"{nameof(AzureFoundryOptions.SummaryUserPromptTemplate)} must contain the {{Text}} placeholder.");
+        }
+
+        if (!options.ImagePromptUserTemplate.Contains("{Summary}", StringComparison.Ordinal))
+        {
+            failures.Add(
+                $"{nameof(AzureFoundryOptions.ImagePromptUserTemplate)} must contain the {{Summary}} placeholder.");
+        }
+
+        return failures.Count > 0
+            ? ValidateOptionsResult.Fail(failures)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -40,6 +40,7 @@ builder.Services.AddSingleton<ITimeProvider, XPoster.Services.TimeProvider>();
 // Register IAiServiceFactory and all IAiService implementations
 builder.Services.AddSingleton<IAiServiceFactory, AiServiceFactory>();
 builder.Services.AddKeyedTransient<IAiService, OpenAiService>(AiProvider.OpenAi);
+builder.Services.AddKeyedTransient<IAiService, AzureFoundryService>(AiProvider.AzureFoundry);
 // builder.Services.AddKeyedTransient<IAiService, PerplexityService>(AiProvider.Perplexity); // Uncomment when implemented
 
 builder.Services.AddTransient<IGeneratorFactory, GeneratorFactory>();
@@ -48,5 +49,7 @@ builder.Services.AddTransient<ICryptoService, CryptoService>();
 builder.Services.AddTransient<IFeedService, FeedService>();
 builder.Services.Configure<OpenAiOptions>(builder.Configuration.GetSection("OpenAI"));
 builder.Services.AddSingleton<IValidateOptions<OpenAiOptions>, OpenAiOptionsValidator>();
+builder.Services.Configure<AzureFoundryOptions>(builder.Configuration.GetSection("AzureFoundry"));
+builder.Services.AddSingleton<IValidateOptions<AzureFoundryOptions>, AzureFoundryOptionsValidator>();
 
 builder.Build().Run();

--- a/src/Services/AzureFoundryService.cs
+++ b/src/Services/AzureFoundryService.cs
@@ -1,0 +1,176 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using XPoster.Abstraction;
+using XPoster.Models;
+
+namespace XPoster.Services;
+
+/// <summary>
+/// Implements <see cref="IAiService"/> by calling Azure AI Foundry OpenAI-compatible endpoints.
+/// </summary>
+public sealed class AzureFoundryService : IAiService
+{
+    private readonly HttpClient _client;
+    private readonly ILogger<AzureFoundryService> _logger;
+    private readonly AzureFoundryOptions _options;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="AzureFoundryService"/>.
+    /// </summary>
+    public AzureFoundryService(
+        IHttpClientFactory httpClientFactory,
+        IOptions<AzureFoundryOptions> options,
+        ILogger<AzureFoundryService> logger)
+    {
+        _logger = logger;
+        _options = options.Value;
+        _client = httpClientFactory.CreateClient();
+        _client.DefaultRequestHeaders.Add("api-key", _options.ApiKey);
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> GetSummaryAsync(string text, int messageMaxLength)
+    {
+        int tries = 0;
+
+        while (text.Length > messageMaxLength && tries <= 2)
+        {
+            tries++;
+            var response = await _client.PostAsJsonAsync(GetChatCompletionsEndpoint(), BuildSummaryPayload(text, messageMaxLength));
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                _logger.LogInformation("Azure Foundry returned 429 during summary generation.");
+                return string.Empty;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogInformation("Azure Foundry summary request failed with status code {StatusCode}", response.StatusCode);
+                return string.Empty;
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<OpenAIResponse>();
+            text = result?.choices[0].message.content.Trim() ?? string.Empty;
+        }
+
+        return text;
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> GetImagePromptAsync(string text)
+    {
+        var response = await _client.PostAsJsonAsync(GetChatCompletionsEndpoint(), BuildImagePromptPayload(text));
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            _logger.LogInformation("Azure Foundry returned 429 during image prompt generation.");
+            return string.Empty;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogInformation("Azure Foundry image prompt request failed with status code {StatusCode}", response.StatusCode);
+            return string.Empty;
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<OpenAIResponse>();
+        return result?.choices[0].message.content.Trim() ?? string.Empty;
+    }
+
+    /// <inheritdoc/>
+    public async Task<byte[]> GenerateImageAsync(string prompt)
+    {
+        var requestBody = new
+        {
+            prompt,
+            n = 1,
+            size = "1024x1024",
+            response_format = "b64_json"
+        };
+
+        var response = await _client.PostAsJsonAsync(GetImageGenerationEndpoint(), requestBody);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Azure Foundry image generation failed with status code {StatusCode}", response.StatusCode);
+            return Array.Empty<byte>();
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<JsonElement>();
+        if (!result.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
+        {
+            _logger.LogError("Azure Foundry image generation response does not contain data entries.");
+            return Array.Empty<byte>();
+        }
+
+        var first = data[0];
+
+        if (first.TryGetProperty("b64_json", out var b64Property))
+        {
+            var base64 = b64Property.GetString();
+            return string.IsNullOrWhiteSpace(base64)
+                ? Array.Empty<byte>()
+                : Convert.FromBase64String(base64);
+        }
+
+        if (first.TryGetProperty("url", out var urlProperty))
+        {
+            var imageUrl = urlProperty.GetString();
+            if (string.IsNullOrWhiteSpace(imageUrl))
+            {
+                return Array.Empty<byte>();
+            }
+
+            return await _client.GetByteArrayAsync(imageUrl);
+        }
+
+        return Array.Empty<byte>();
+    }
+
+    private string GetChatCompletionsEndpoint() =>
+        $"{_options.Endpoint.TrimEnd('/')}/openai/deployments/{Uri.EscapeDataString(_options.DeploymentName)}/chat/completions?api-version={Uri.EscapeDataString(_options.ApiVersion)}";
+
+    private string GetImageGenerationEndpoint() =>
+        $"{_options.Endpoint.TrimEnd('/')}/openai/deployments/{Uri.EscapeDataString(_options.ImageDeploymentName)}/images/generations?api-version={Uri.EscapeDataString(_options.ApiVersion)}";
+
+    private object BuildSummaryPayload(string text, int messageMaxLength)
+    {
+        var tokenDivisor = Math.Max(1, _options.SummaryMaxTokensPerChar);
+        var maxTokens = Math.Max(1, messageMaxLength / tokenDivisor);
+        var underCharacters = Math.Max(1, messageMaxLength - _options.SummarySafetyMarginChars);
+
+        var systemContent = _options.SummarySystemPromptTemplate
+            .Replace("{MaxChars}", underCharacters.ToString(), StringComparison.Ordinal);
+        var userContent = _options.SummaryUserPromptTemplate
+            .Replace("{Text}", text, StringComparison.Ordinal);
+
+        return new
+        {
+            messages = new[]
+            {
+                new { role = "system", content = systemContent },
+                new { role = "user", content = userContent }
+            },
+            max_tokens = maxTokens,
+            temperature = _options.SummaryTemperature
+        };
+    }
+
+    private object BuildImagePromptPayload(string summary)
+    {
+        var userContent = _options.ImagePromptUserTemplate
+            .Replace("{Summary}", summary, StringComparison.Ordinal);
+
+        return new
+        {
+            messages = new[]
+            {
+                new { role = "system", content = _options.ImagePromptSystemTemplate },
+                new { role = "user", content = userContent }
+            },
+            max_tokens = _options.ImagePromptMaxTokens,
+            temperature = _options.ImagePromptTemperature
+        };
+    }
+}

--- a/src/local.settings.json.example
+++ b/src/local.settings.json.example
@@ -4,6 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "CronSchedule": "0 0 6,8,14,16 * * *",
+    "AiProvider": "OpenAi",
 
     "X_API_KEY": "",
     "X_API_SECRET": "",
@@ -33,6 +34,21 @@
     "OpenAI__ImagePromptUserTemplate": "Generate an image prompt based on this summary: {Summary}",
     "OpenAI__ImagePromptMaxTokens": "60",
     "OpenAI__ImagePromptTemperature": "0.7",
+
+    "AzureFoundry__Endpoint": "",
+    "AzureFoundry__ApiKey": "",
+    "AzureFoundry__DeploymentName": "",
+    "AzureFoundry__ImageDeploymentName": "",
+    "AzureFoundry__ApiVersion": "2024-02-01",
+    "AzureFoundry__SummaryTemperature": "0.5",
+    "AzureFoundry__SummaryMaxTokensPerChar": "5",
+    "AzureFoundry__SummarySafetyMarginChars": "50",
+    "AzureFoundry__SummarySystemPromptTemplate": "You are an assistant that summarizes text concisely. It's very important that you keep summaries under {MaxChars} characters.",
+    "AzureFoundry__SummaryUserPromptTemplate": "Summarize this text in a few sentences. text: {Text}",
+    "AzureFoundry__ImagePromptSystemTemplate": "You are an assistant that generates image prompts for an AI image generation model based on text summaries. Create a concise, vivid prompt in English that reflects the summary's content, includes a Bitcoin-related element (e.g., a coin), and avoids text, signs, or words in the image. Respect content policy for generating images.",
+    "AzureFoundry__ImagePromptUserTemplate": "Generate an image prompt based on this summary: {Summary}",
+    "AzureFoundry__ImagePromptMaxTokens": "60",
+    "AzureFoundry__ImagePromptTemperature": "0.7",
 
     "APPLICATIONINSIGHTS_CONNECTION_STRING": ""
   }

--- a/tests/Implementation/AiServiceFactoryTests.cs
+++ b/tests/Implementation/AiServiceFactoryTests.cs
@@ -35,6 +35,24 @@ public class AiServiceFactoryTests
     }
 
     [Fact]
+    public void GetByProvider_Should_ReturnAzureFoundryService_When_ProviderIsMappedAndResolvable()
+    {
+        // ARRANGE
+        var aiService = new Mock<IAiService>();
+        _keyedServiceProvider
+            .Setup(sp => sp.GetKeyedService(typeof(IAiService), AiProvider.AzureFoundry))
+            .Returns(aiService.Object);
+
+        var factory = new AiServiceFactory(_serviceProvider.Object);
+
+        // ACT
+        var result = factory.GetByProvider(AiProvider.AzureFoundry);
+
+        // ASSERT
+        Assert.Same(aiService.Object, result);
+    }
+
+    [Fact]
     public void GetByProvider_Should_ThrowArgumentException_When_ProviderIsNotMapped()
     {
         // ARRANGE

--- a/tests/Models/AzureFoundryOptionsValidatorTests.cs
+++ b/tests/Models/AzureFoundryOptionsValidatorTests.cs
@@ -1,0 +1,56 @@
+using XPoster.Models;
+
+namespace XPoster.Tests.Models;
+
+public class AzureFoundryOptionsValidatorTests
+{
+    private readonly AzureFoundryOptionsValidator _sut = new();
+
+    private static AzureFoundryOptions ValidOptions() => new()
+    {
+        Endpoint = "https://myfoundry.openai.azure.com",
+        ApiKey = "key",
+        DeploymentName = "gpt-4.1-nano",
+        ImageDeploymentName = "gpt-image-1"
+    };
+
+    [Fact]
+    public void Validate_ValidOptions_Succeeds()
+    {
+        var result = _sut.Validate(null, ValidOptions());
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_MissingRequiredProperties_Fails()
+    {
+        var options = ValidOptions();
+        options.Endpoint = string.Empty;
+        options.ApiKey = string.Empty;
+        options.DeploymentName = string.Empty;
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains(nameof(AzureFoundryOptions.Endpoint)));
+        Assert.Contains(result.Failures!, f => f.Contains(nameof(AzureFoundryOptions.ApiKey)));
+        Assert.Contains(result.Failures!, f => f.Contains(nameof(AzureFoundryOptions.DeploymentName)));
+    }
+
+    [Fact]
+    public void Validate_MissingPlaceholders_Fails()
+    {
+        var options = ValidOptions();
+        options.SummarySystemPromptTemplate = "no max chars";
+        options.SummaryUserPromptTemplate = "no text";
+        options.ImagePromptUserTemplate = "no summary";
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains("{MaxChars}"));
+        Assert.Contains(result.Failures!, f => f.Contains("{Text}"));
+        Assert.Contains(result.Failures!, f => f.Contains("{Summary}"));
+    }
+}

--- a/tests/Services/AzureFoundryServiceTests.cs
+++ b/tests/Services/AzureFoundryServiceTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using XPoster.Models;
+using XPoster.Services;
+
+namespace XPoster.Tests.Services;
+
+public class AzureFoundryServiceTests
+{
+    private static AzureFoundryService BuildService(HttpMessageHandler handler, out Mock<ILogger<AzureFoundryService>> loggerMock, AzureFoundryOptions? opts = null)
+    {
+        loggerMock = new Mock<ILogger<AzureFoundryService>>();
+        var factory = new Mock<IHttpClientFactory>();
+        var client = new HttpClient(handler);
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        var options = Options.Create(opts ?? new AzureFoundryOptions
+        {
+            Endpoint = "https://myfoundry.openai.azure.com",
+            ApiKey = "fake-key",
+            DeploymentName = "gpt-4.1-nano",
+            ImageDeploymentName = "gpt-image-1"
+        });
+
+        return new AzureFoundryService(factory.Object, options, loggerMock.Object);
+    }
+
+    private static Mock<HttpMessageHandler> MakeHandlerMock(HttpStatusCode code, string json)
+    {
+        var mock = new Mock<HttpMessageHandler>();
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(code)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            });
+
+        return mock;
+    }
+
+    private static string ChatCompletionJson(string content) =>
+        "{\"choices\":[{\"message\":{\"content\":\"" + content + "\"}}]}";
+
+    [Fact]
+    public async Task GetSummaryAsync_WhenTextExceedsLimit_CallsApiAndReturnsTrimmedContent()
+    {
+        var handler = MakeHandlerMock(HttpStatusCode.OK, ChatCompletionJson("summary result"));
+        var svc = BuildService(handler.Object, out _);
+
+        var result = await svc.GetSummaryAsync(new string('a', 300), 100);
+
+        Assert.Equal("summary result", result);
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Post && r.RequestUri!.AbsolutePath.Contains("/chat/completions", StringComparison.Ordinal)),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WhenApiReturns429_ReturnsEmptyString()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.TooManyRequests, "{}").Object, out _);
+
+        var result = await svc.GetSummaryAsync(new string('a', 300), 100);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WhenApiReturnsNonSuccess_ReturnsEmptyString()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.BadGateway, "{}").Object, out _);
+
+        var result = await svc.GetSummaryAsync(new string('a', 300), 100);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public async Task GetImagePromptAsync_WhenApiReturnsValidResponse_ReturnsPrompt()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, ChatCompletionJson("prompt result")).Object, out _);
+
+        var result = await svc.GetImagePromptAsync("summary");
+
+        Assert.Equal("prompt result", result);
+    }
+
+    [Fact]
+    public async Task GenerateImageAsync_WhenApiReturnsValidResponse_ReturnsByteArray()
+    {
+        var imageBytes = new byte[] { 1, 2, 3, 4 };
+        var base64 = Convert.ToBase64String(imageBytes);
+        var json = "{\"data\":[{\"b64_json\":\"" + base64 + "\"}]}";
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, json).Object, out _);
+
+        var result = await svc.GenerateImageAsync("image prompt");
+
+        Assert.Equal(imageBytes, result);
+    }
+
+    [Fact]
+    public async Task GenerateImageAsync_WhenApiReturnsNonSuccess_ReturnsEmptyByteArray()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.BadRequest, "{}").Object, out _);
+
+        var result = await svc.GenerateImageAsync("image prompt");
+
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
## Summary

Implemented `AzureFoundryService` as a concrete `IAiService` provider, integrated with the existing `AiServiceFactory` + keyed DI architecture (`AiProvider`).

This PR adds:
- new provider `AiProvider.AzureFoundry`
- new service `AzureFoundryService` using Azure Foundry OpenAI-compatible REST endpoints
- strongly typed configuration via `AzureFoundryOptions` + validation
- DI wiring in `Program.cs`
- provider resolution support in `AiServiceFactory`
- Azure Foundry keys in `local.settings.json.example`
- complete setup guide in `docs/azure-foundry-setup.md`
- dedicated unit tests

## Changes

### Code
- Added `AiProvider.AzureFoundry`
- Added `AzureFoundryOptions`
- Added `AzureFoundryOptionsValidator`
- Added `AzureFoundryService : IAiService`
- Registered:
  - `AddKeyedTransient<IAiService, AzureFoundryService>(AiProvider.AzureFoundry)`
  - `Configure<AzureFoundryOptions>(...)`
  - `IValidateOptions<AzureFoundryOptions>`
- Extended `AiServiceFactory` supported providers with `AzureFoundry`
- Added optional `AiProvider` configuration override in `GeneratorFactory` (with fallback to schedule default)

### Config & Docs
- Updated `src/local.settings.json.example` with:
  - `AiProvider`
  - `AzureFoundry__Endpoint`
  - `AzureFoundry__ApiKey`
  - `AzureFoundry__DeploymentName`
  - `AzureFoundry__ImageDeploymentName`
  - additional tuning keys (API version, temperature, prompt templates, etc.)
- Added `docs/azure-foundry-setup.md`
- Updated docs index and configuration reference

### Tests
- Added `AzureFoundryServiceTests`:
  - `GetSummaryAsync_WhenTextExceedsLimit_CallsApiAndReturnsTrimmedContent`
  - `GetSummaryAsync_WhenApiReturns429_ReturnsEmptyString`
  - `GetSummaryAsync_WhenApiReturnsNonSuccess_ReturnsEmptyString`
  - `GetImagePromptAsync_WhenApiReturnsValidResponse_ReturnsPrompt`
  - `GenerateImageAsync_WhenApiReturnsValidResponse_ReturnsByteArray`
  - `GenerateImageAsync_WhenApiReturnsNonSuccess_ReturnsEmptyByteArray`
- Added `AzureFoundryOptionsValidatorTests`
- Extended `AiServiceFactoryTests` for `AiProvider.AzureFoundry`

## Acceptance Criteria Check

- [x] `AzureFoundryService` implements `IAiService` and compiles
- [x] `AzureFoundryOptions` bound from `AzureFoundry` section; no service-level hardcoded config values
- [x] `AiServiceFactory` resolves `AzureFoundryService` with `AiProvider.AzureFoundry`
- [x] Existing `OpenAi` behavior unchanged
- [x] `GetSummaryAsync`, `GetImagePromptAsync`, `GenerateImageAsync` implemented
- [x] `docs/azure-foundry-setup.md` added and complete
- [x] Configuration keys documented in `local.settings.json.example`
- [x] Unit tests passing

## Validation

- `dotnet build src/XPoster.csproj` ✅
- `dotnet test tests/XPoster.Tests.csproj` ✅ (141 passed)

## Notes

- Scope kept intentionally small and architecture-consistent with current XPoster patterns.
- No secrets committed.