### PR TITLE
fix: guard against empty choices array in AI provider responses

### DIFF
--- a/src/Services/AzureFoundryService.cs
+++ b/src/Services/AzureFoundryService.cs
@@ -55,7 +55,13 @@ public sealed class AzureFoundryService : IAiService
             }
 
             var result = await response.Content.ReadFromJsonAsync<OpenAIResponse>(cancellationToken);
-            text = result?.choices[0].message.content.Trim() ?? string.Empty;
+            if (result is null || result.choices is null || result.choices.Length == 0)
+            {
+                _logger.LogWarning("Azure Foundry returned a response with no choices during summary generation.");
+                return string.Empty;
+            }
+
+            text = result.choices[0].message.content.Trim();
         }
 
         return text;
@@ -78,7 +84,13 @@ public sealed class AzureFoundryService : IAiService
         }
 
         var result = await response.Content.ReadFromJsonAsync<OpenAIResponse>(cancellationToken);
-        return result?.choices[0].message.content.Trim() ?? string.Empty;
+        if (result is null || result.choices is null || result.choices.Length == 0)
+        {
+            _logger.LogWarning("Azure Foundry returned a response with no choices during image prompt generation.");
+            return string.Empty;
+        }
+
+        return result.choices[0].message.content.Trim();
     }
 
     /// <inheritdoc/>

--- a/src/Services/DeepSeekService.cs
+++ b/src/Services/DeepSeekService.cs
@@ -60,7 +60,13 @@ public class DeepSeekService : IAiService
             }
 
             var result = await response.Content.ReadFromJsonAsync<OpenAIResponse>(cancellationToken);
-            text = result?.choices[0].message.content.Trim() ?? string.Empty;
+            if (result is null || result.choices is null || result.choices.Length == 0)
+            {
+                _logger.LogWarning("DeepSeek returned a response with no choices during summary generation.");
+                return string.Empty;
+            }
+
+            text = result.choices[0].message.content.Trim();
         }
 
         return text;
@@ -83,7 +89,13 @@ public class DeepSeekService : IAiService
         }
 
         var result = await response.Content.ReadFromJsonAsync<OpenAIResponse>(cancellationToken);
-        return result?.choices[0].message.content.Trim() ?? string.Empty;
+        if (result is null || result.choices is null || result.choices.Length == 0)
+        {
+            _logger.LogWarning("DeepSeek returned a response with no choices during image prompt generation.");
+            return string.Empty;
+        }
+
+        return result.choices[0].message.content.Trim();
     }
 
     /// <inheritdoc/>

--- a/src/Services/OpenAiService.cs
+++ b/src/Services/OpenAiService.cs
@@ -54,7 +54,13 @@ public class OpenAiService : IAiService
             }
 
             var result = await response.Content.ReadFromJsonAsync<OpenAIResponse>(cancellationToken);
-            text = result?.choices[0].message.content.Trim() ?? string.Empty;
+            if (result is null || result.choices is null || result.choices.Length == 0)
+            {
+                _logger.LogWarning("OpenAI returned a response with no choices during summary generation.");
+                return string.Empty;
+            }
+
+            text = result.choices[0].message.content.Trim();
         }
         // CS8603: text cannot be null here — while loop guard ensures non-null or early return
         return text ?? string.Empty;
@@ -77,7 +83,13 @@ public class OpenAiService : IAiService
         }
 
         var result = await response.Content.ReadFromJsonAsync<OpenAIResponse>(cancellationToken);
-        return result?.choices[0].message.content.Trim() ?? string.Empty;
+        if (result is null || result.choices is null || result.choices.Length == 0)
+        {
+            _logger.LogWarning("OpenAI returned a response with no choices during image prompt generation.");
+            return string.Empty;
+        }
+
+        return result.choices[0].message.content.Trim();
     }
 
     /// <inheritdoc/>

--- a/tests/Services/AzureFoundryServiceTests.cs
+++ b/tests/Services/AzureFoundryServiceTests.cs
@@ -84,6 +84,26 @@ public class AzureFoundryServiceTests
     }
 
     [Fact]
+    public async Task GetSummaryAsync_WhenChoicesArrayIsEmpty_ReturnsEmptyString()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{\"choices\":[]}").Object, out _);
+
+        var result = await svc.GetSummaryAsync(new string('a', 300), 100);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WhenChoicesIsNull_ReturnsEmptyString()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{\"choices\":null}").Object, out _);
+
+        var result = await svc.GetSummaryAsync(new string('a', 300), 100);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
     public async Task GetImagePromptAsync_WhenApiReturnsValidResponse_ReturnsPrompt()
     {
         var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, ChatCompletionJson("prompt result")).Object, out _);
@@ -91,6 +111,26 @@ public class AzureFoundryServiceTests
         var result = await svc.GetImagePromptAsync("summary");
 
         Assert.Equal("prompt result", result);
+    }
+
+    [Fact]
+    public async Task GetImagePromptAsync_WhenChoicesArrayIsEmpty_ReturnsEmptyString()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{\"choices\":[]}").Object, out _);
+
+        var result = await svc.GetImagePromptAsync("summary");
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public async Task GetImagePromptAsync_WhenChoicesIsNull_ReturnsEmptyString()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{\"choices\":null}").Object, out _);
+
+        var result = await svc.GetImagePromptAsync("summary");
+
+        Assert.Equal(string.Empty, result);
     }
 
     [Fact]

--- a/tests/Services/DeepSeekServiceTests.cs
+++ b/tests/Services/DeepSeekServiceTests.cs
@@ -108,6 +108,26 @@ public class DeepSeekServiceTests
         Assert.Equal(string.Empty, result);
     }
 
+    [Fact]
+    public async Task GetSummaryAsync_WhenChoicesArrayIsEmpty_ReturnsEmptyString()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{\"choices\":[]}").Object, out _);
+
+        var result = await svc.GetSummaryAsync(new string('a', 300), 100);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WhenChoicesIsNull_ReturnsEmptyString()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{\"choices\":null}").Object, out _);
+
+        var result = await svc.GetSummaryAsync(new string('a', 300), 100);
+
+        Assert.Equal(string.Empty, result);
+    }
+
     // ── GetImagePromptAsync ──────────────────────────────────────────────────
 
     [Fact]
@@ -136,6 +156,26 @@ public class DeepSeekServiceTests
         var svc = BuildService(MakeHandlerMock(HttpStatusCode.BadGateway, "{}").Object, out _);
 
         var result = await svc.GetImagePromptAsync("summary");
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public async Task GetImagePromptAsync_WhenChoicesArrayIsEmpty_ReturnsEmptyString()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{\"choices\":[]}").Object, out _);
+
+        var result = await svc.GetImagePromptAsync("summary text");
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public async Task GetImagePromptAsync_WhenChoicesIsNull_ReturnsEmptyString()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{\"choices\":null}").Object, out _);
+
+        var result = await svc.GetImagePromptAsync("summary text");
 
         Assert.Equal(string.Empty, result);
     }

--- a/tests/Services/OpenAiServiceTests.cs
+++ b/tests/Services/OpenAiServiceTests.cs
@@ -77,6 +77,22 @@ public class OpenAiServiceTests
         Assert.Equal(string.Empty, result);
     }
 
+    [Fact]
+    public async Task GetSummaryAsync_WhenChoicesArrayIsEmpty_ReturnsEmpty()
+    {
+        var svc = BuildService(MakeHandler(HttpStatusCode.OK, "{\"choices\":[]}"), out _);
+        var result = await svc.GetSummaryAsync(new string('a', 300), 100);
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WhenChoicesIsNull_ReturnsEmpty()
+    {
+        var svc = BuildService(MakeHandler(HttpStatusCode.OK, "{\"choices\":null}"), out _);
+        var result = await svc.GetSummaryAsync(new string('a', 300), 100);
+        Assert.Equal(string.Empty, result);
+    }
+
     // ── GetImagePromptAsync ──────────────────────────────────────────────────
 
     [Fact]
@@ -99,6 +115,22 @@ public class OpenAiServiceTests
     public async Task GetImagePromptAsync_WhenApiReturnsError_ReturnsEmpty()
     {
         var svc = BuildService(MakeHandler(HttpStatusCode.BadRequest, "{}"), out _);
+        var result = await svc.GetImagePromptAsync("some summary");
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public async Task GetImagePromptAsync_WhenChoicesArrayIsEmpty_ReturnsEmpty()
+    {
+        var svc = BuildService(MakeHandler(HttpStatusCode.OK, "{\"choices\":[]}"), out _);
+        var result = await svc.GetImagePromptAsync("some summary");
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public async Task GetImagePromptAsync_WhenChoicesIsNull_ReturnsEmpty()
+    {
+        var svc = BuildService(MakeHandler(HttpStatusCode.OK, "{\"choices\":null}"), out _);
         var result = await svc.GetImagePromptAsync("some summary");
         Assert.Equal(string.Empty, result);
     }


### PR DESCRIPTION
## Summary

Fixes #124.

All three chat-based services accessed `choices[0]` directly after deserialising the API response without checking that the array was non-null and non-empty. A response with `"choices": []` — which can occur on content-policy refusals or partial API errors — threw an unhandled `IndexOutOfRangeException`.

## Changes

### Production code

Added a guard clause in `GetSummaryAsync` and `GetImagePromptAsync` for all three affected services:

```csharp
var result = await response.Content.ReadFromJsonAsync<OpenAIResponse>(cancellationToken);
if (result is null || result.choices is null || result.choices.Length == 0)
{
    _logger.LogWarning("[Provider] returned a response with no choices during [operation].");
    return string.Empty;
}
text = result.choices[0].message.content.Trim();
```

`FalAiImageService` is **not** modified — it already uses `TryGetProperty` and checks array length before access.

### Tests

Added 4 new `[Fact]` tests per service (12 total), covering:
- `GetSummaryAsync` when `choices` is an empty array → returns `string.Empty`
- `GetSummaryAsync` when `choices` is `null` → returns `string.Empty`
- `GetImagePromptAsync` when `choices` is an empty array → returns `string.Empty`
- `GetImagePromptAsync` when `choices` is `null` → returns `string.Empty`

All tests follow the existing `BuildService` / `MakeHandlerMock` pattern already established in the test suite.

## Acceptance criteria

- [x] `DeepSeekService.GetSummaryAsync` guards against empty `choices`
- [x] `DeepSeekService.GetImagePromptAsync` guards against empty `choices`
- [x] `OpenAiService.GetSummaryAsync` guards against empty `choices`
- [x] `OpenAiService.GetImagePromptAsync` guards against empty `choices`
- [x] `AzureFoundryService.GetSummaryAsync` guards against empty `choices`
- [x] `AzureFoundryService.GetImagePromptAsync` guards against empty `choices`
- [x] Unit tests cover the empty-choices scenario for all three services