### PR TITLE
[CI] Upgrade azure/login to v3 and Azure/functions-action to v1.5.6 (Node.js 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,10 +228,7 @@ jobs:
           popd
       
       - name: Login to Azure
-        # NOTE: azure/login is pinned to v2 (latest: v2.3.0).
-        # A Node.js 24-compatible version has not been released yet.
-        # Track: https://github.com/Azure/login/releases
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_04545C92864042ED99D5EBF6456192FB }}
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_F13F54A171EE481AAE09734F721803BB }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,10 +235,7 @@ jobs:
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_87ED0225F8DF4E9DA6B45A7951B44B42 }}
       
       - name: Deploy Azure Functions
-        # NOTE: Azure/functions-action is pinned to v1 (latest: v1.5.3).
-        # A Node.js 24-compatible version has not been released yet.
-        # Track: https://github.com/Azure/functions-action/releases
-        uses: Azure/functions-action@v1
+        uses: Azure/functions-action@v1.5.6
         id: fa
         with:
           app-name: 'XPosterFunction'


### PR DESCRIPTION
## Summary

Completes the Node.js 24 migration for the two Azure-related actions that were left pending in PR #136, resolving the tracking issue #137.

Closes #137

---

## Changes

| Action | Before | After | Node.js 24 since | Released |
|---|---|---|---|---|
| `azure/login` | `v2` | `v3` | `v3.0.0` | 2026-03-17 ([release notes](https://github.com/Azure/login/releases/tag/v3.0.0)) |
| `Azure/functions-action` | `v1` | `v1.5.6` | `v1.5.4` | 2026-02-19 ([release notes](https://github.com/Azure/functions-action/releases/tag/v1.5.4)) |

All `# NOTE:` tracking comments removed from `ci.yml`.

---

## Testing

- [ ] CI: Build job passes
- [ ] CI: Test job passes
- [ ] CI: Quality job passes
- [ ] No Node.js 20 deprecation warnings in Actions logs
- [ ] Deploy job is not triggered on this PR (will be validated on next push to master)
