### PR TITLE
fix(ci): remove dotnet version pin in regenerate-agent-graph workflow

### DIFF
--- a/.github/workflows/regenerate-agent-graph.yml
+++ b/.github/workflows/regenerate-agent-graph.yml
@@ -40,8 +40,6 @@ jobs:
       # =========================
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.x'   # Aligned with ci.yml DOTNET_VERSION
 
       - name: Install graphify-dotnet
         run: dotnet tool install --global graphify-dotnet


### PR DESCRIPTION
## Problem

The `Regenerate Agent Graph` workflow was failing on PRs #142 and #143 with:

```
Tool 'graphify-dotnet' failed to install.
Settings file 'DotnetToolSettings.xml' was not found in the package.
```

## Root Cause

`graphify-dotnet` is a **.NET 10 tool** ([ref](https://github.com/elbruno/graphify-dotnet)). The workflow was pinning `dotnet-version: '8.0.x'`, which is two major versions behind. When `dotnet tool install` attempts to install a tool targeting `net10.0` on an SDK that only knows up to `net8.0`, the package appears malformed — hence the misleading `DotnetToolSettings.xml` error.

## Fix

Removed the `with: dotnet-version` block from the `Setup .NET` step entirely, allowing the runner to pick up the latest available SDK (currently .NET 10 on `ubuntu-latest`).

```yaml
# Before
- name: Setup .NET
  uses: actions/setup-dotnet@v4
  with:
    dotnet-version: '8.0.x'

# After
- name: Setup .NET
  uses: actions/setup-dotnet@v4
```

> **Note:** This change is isolated to `regenerate-agent-graph.yml` and does not affect `ci.yml`, which correctly remains on .NET 8 for building the XPoster project itself.