### PR TITLE
fix(ci): install .NET 10 SDK for graphify-dotnet tool

### DIFF
--- a/.github/workflows/regenerate-agent-graph.yml
+++ b/.github/workflows/regenerate-agent-graph.yml
@@ -40,6 +40,8 @@ jobs:
       # =========================
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'  # graphify-dotnet targets net10.0 and requires the .NET 10 SDK
 
       - name: Install graphify-dotnet
         run: dotnet tool install --global graphify-dotnet


### PR DESCRIPTION
## Problem

After merging #144 (which removed the version pin entirely), the workflow still fails. The log reveals the root cause:

```
--runtime dotnet --channel LTS   ← only the runtime is installed, not the SDK
Installed version is 10.0.9

--version 8.0.421                ← runner falls back to the pre-installed SDK 8
.NET Core SDK with version '8.0.421' is already installed.
```

Without an explicit `dotnet-version`, `setup-dotnet` installs only the **LTS runtime** and then uses the **SDK 8 already present on the runner**. `dotnet tool install` then runs under SDK 8, which cannot handle a tool targeting `net10.0`.

## Root Cause

`graphify-dotnet` targets `net10.0` and requires the **.NET 10 SDK** — not just the runtime. Omitting `dotnet-version` does not guarantee the SDK 10 is active.

## Fix

Explicitly pin `dotnet-version: '10.0.x'` to force installation of the .NET 10 SDK:

```yaml
- name: Setup .NET
  uses: actions/setup-dotnet@v4
  with:
    dotnet-version: '10.0.x'  # graphify-dotnet targets net10.0
```

> **Note:** This does not affect `ci.yml`, which correctly remains on .NET 8 for building the XPoster project itself.