### PR TITLE
fix(ci): run graphify-dotnet install outside repo to bypass global.json

### DIFF
--- a/.github/workflows/regenerate-agent-graph.yml
+++ b/.github/workflows/regenerate-agent-graph.yml
@@ -44,7 +44,12 @@ jobs:
           dotnet-version: '10.0.x'  # graphify-dotnet targets net10.0 and requires the .NET 10 SDK
 
       - name: Install graphify-dotnet
-        run: dotnet tool install --global graphify-dotnet
+        # Run install from /tmp to avoid global.json in the repo root, which pins
+        # the SDK to 8.0.x and prevents dotnet from using the .NET 10 SDK installed above.
+        run: |
+          mkdir -p /tmp/dotnet-tool-install
+          cd /tmp/dotnet-tool-install
+          dotnet tool install --global graphify-dotnet
 
       - name: Regenerate agent graph (code + docs + infra)
         run: |


### PR DESCRIPTION
## Problem

Despite the .NET 10 SDK being correctly installed by `setup-dotnet`, `dotnet tool install` was still failing with:

```
Settings file 'DotnetToolSettings.xml' was not found in the package.
```

## Root Cause

The repository has a `global.json` in the root that pins the SDK to `8.0.x`:

```json
{
  "sdk": {
    "version": "8.0.421",
    "rollForward": "latestPatch"
  }
}
```

`rollForward: latestPatch` only allows patch-level rollforward within the same major version — it **cannot** cross to .NET 10. Any `dotnet` command run inside the repository directory (including `tool install`) is subject to `global.json` and is forced onto SDK 8, regardless of what `setup-dotnet` installed. This is confirmed by the runner log showing SDK `8.0.421` being used at the install step.

The misleading `DotnetToolSettings.xml` error is a symptom of SDK/tool target framework mismatch, not a broken NuGet package.

## Fix

Run `dotnet tool install` from `/tmp`, outside the repository directory, so `global.json` is not in scope and the .NET 10 SDK is used freely:

```yaml
- name: Install graphify-dotnet
  run: |
    mkdir -p /tmp/dotnet-tool-install
    cd /tmp/dotnet-tool-install
    dotnet tool install --global graphify-dotnet
```

The tool is installed globally (`~/.dotnet/tools/`) so it remains available for all subsequent steps that run inside the repo.

> **Note:** `global.json` is intentionally kept as-is — it correctly governs the XPoster project build on .NET 8. Only the graphify-dotnet install is moved outside its scope.