### PR TITLE
fix(ci): open auto-PR instead of direct push to respect branch protection

### DIFF
--- a/.github/workflows/regenerate-agent-graph.yml
+++ b/.github/workflows/regenerate-agent-graph.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write  # Required by peter-evans/create-pull-request to open the auto-PR
 
 # Cancel any in-progress run for the same ref to avoid redundant graph rebuilds.
 concurrency:
@@ -108,19 +109,22 @@ jobs:
           NOTICE_EOF
 
       # =========================
-      # COMMIT (only if graph changed)
-      # [skip ci] prevents ci.yml from triggering on this commit.
+      # AUTO-PR (respects branch protection on develop)
+      # peter-evans/create-pull-request commits any workspace changes onto a
+      # dedicated branch and opens a PR targeting develop.
+      # If no files changed, the action is a no-op and no PR is created.
+      # [skip ci] in the commit message prevents ci.yml from running on the
+      # auto-PR branch itself (docs-only change, no code to validate).
       # =========================
-      - name: Commit updated graph
-        run: |
-          git add docs/agent-graph
-          if git diff --cached --quiet -- docs/agent-graph; then
-            echo "No graph changes detected. Skipping commit."
-            exit 0
-          fi
+      - name: Open auto-PR for updated graph
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/regenerate-agent-graph
+          commit-message: "docs(graph): regenerate agent graph [skip ci]"
+          title: "docs(graph): regenerate agent graph"
+          body: |
+            Automated update of `docs/agent-graph` triggered by the `Regenerate Agent Graph` workflow.
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git commit -m "docs(graph): regenerate agent graph [skip ci]"
-          git push
+            > This PR was opened automatically by the CI bot. Merge once the status checks pass.
+          labels: automated
+          delete-branch: true


### PR DESCRIPTION
## Problem

After merging #146, the workflow still fails at the commit step:

```
remote: error: GH006: Protected branch update failed for refs/heads/develop.
remote: - Changes must be made through a pull request.
remote: - 3 of 3 required status checks are expected.
error: failed to push some refs to 'https://github.com/artcava/XPoster'
```

## Root Cause

`develop` has branch protection rules that require all changes to go through a PR with passing status checks. The previous implementation used a direct `git push` to `develop`, which is always rejected by these rules — regardless of who the pusher is.

Enabling a bot bypass would work technically, but opens a security gap: any contributor who can trigger this workflow could potentially push arbitrary content to `develop` without CI validation.

## Fix

Replaced the `git commit + git push` block with `peter-evans/create-pull-request@v7`, which:

1. Detects any changes in `docs/agent-graph` after the graphify run
2. Commits them onto a dedicated branch (`chore/regenerate-agent-graph`)
3. Opens a PR targeting `develop` — going through the normal CI gate
4. Is a **no-op** if nothing changed (no PR is created)
5. Cleans up the branch after merge (`delete-branch: true`)

Also added `pull-requests: write` to the job permissions, required by the action to open the PR.

```yaml
- name: Open auto-PR for updated graph
  uses: peter-evans/create-pull-request@v7
  with:
    branch: chore/regenerate-agent-graph
    commit-message: "docs(graph): regenerate agent graph [skip ci]"
    title: "docs(graph): regenerate agent graph"
    body: |
      Automated update of `docs/agent-graph` ...
    labels: automated
    delete-branch: true
```