### PR TITLE
fix(#139): image generation response handling — fallback and safe access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`AzureFoundryService.GenerateImageAsync` hardened** to match `FalAiImageService` as the reference implementation ([#139](https://github.com/artcava/XPoster/issues/139)):
+  - Added 429 intercept before the success check, consistent with `GetSummaryAsync` and `GetImagePromptAsync` in the same class.
+  - Wrapped `ReadFromJsonAsync<JsonElement>` in `try/catch (JsonException)` to handle malformed API responses without throwing.
+  - Added `null`-check and `try/catch (FormatException)` around `Convert.FromBase64String` for the `b64_json` path.
+  - Added origin validation for the `url` fallback: emits `LogWarning` with the full URL when the download origin does not match `_options.Endpoint`, enabling audit in Application Insights; download proceeds as defence-in-depth.
+  - Wrapped `GetByteArrayAsync` in `try/catch (HttpRequestException)` on the `url` fallback path.
+  - Added explicit `LogError` when the response data entry contains neither `b64_json` nor `url`.
+- **`OpenAiService.GenerateImageAsync` hardened** ([#139](https://github.com/artcava/XPoster/issues/139)):
+  - Added `string.IsNullOrWhiteSpace(prompt)` guard at method entry, consistent with `FalAiImageService`.
+- **Prompt guard added to `AzureFoundryService.GenerateImageAsync`** ([#139](https://github.com/artcava/XPoster/issues/139)): rejects empty or whitespace-only prompts with `LogWarning` before any HTTP call, matching the pattern already in `FalAiImageService` and the newly updated `OpenAiService`.
+
 ### Added
 - Dynamic GitHub Actions build status badge in README ([#35](https://github.com/artcava/XPoster/issues/35))
 - This CHANGELOG.md file ([#36](https://github.com/artcava/XPoster/issues/36))
@@ -19,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/` folder reorganisation: analysis sub-folder reordered ([#143](https://github.com/artcava/XPoster/pull/143))
 - `docs/agent-graph.md`: new unified guide explaining what the agent graph is, node types, output formats, CI workflow, and how to use it with AI coding assistants; merges and supersedes `docs/integrations/graphify-ci.md`
 
-### Changed
+### Changed (continued)
 - `regenerate-agent-graph.yml` trigger changed from `pull_request[closed]` (post-merge) to `pull_request[opened, synchronize, reopened]` (pre-merge PR check); removed `peter-evans/create-pull-request` step that was the root cause of the CI loop ([#149](https://github.com/artcava/XPoster/issues/149))
 - `persist-agent-graph.yml` checkout step updated to use `BOT_PAT` token; `permissions.contents` downgraded to `read` (actual write delegated to the token) ([#149](https://github.com/artcava/XPoster/issues/149))
 - `docs/index.md`: replaced `graphify-ci.md` row with `agent-graph.md` in the Integrations section
@@ -29,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI loop on `develop`**: merging the auto-generated `chore/regenerate-agent-graph` PR was re-triggering the same workflow indefinitely; resolved by splitting generation (PR check) and persistence (push trigger) into two separate workflows with explicit loop-prevention guards ([#149](https://github.com/artcava/XPoster/issues/149))
 - `graphify-dotnet` install failure: tool requires .NET 10 SDK; `setup-dotnet` now pinned to `10.0.x`; install moved to `/tmp` to bypass `global.json` which pins the SDK to 8.0.x ([#144](https://github.com/artcava/XPoster/pull/144), [#145](https://github.com/artcava/XPoster/pull/145), [#146](https://github.com/artcava/XPoster/pull/146))
 - `regenerate-agent-graph.yml` NOTICE.md: corrected Generated nodes description from "every merge to develop" to "every PR against develop (pre-merge preview)" to accurately reflect the workflow trigger
+
+### Tests
+- **`OpenAiServiceTests`**: added G7 (`WhenPromptIsEmpty`) and G8 (`WhenPromptIsWhitespace`) — verify that `GenerateImageAsync` returns an empty array and makes zero HTTP calls when the prompt is blank ([#139](https://github.com/artcava/XPoster/issues/139))
+- **`AzureFoundryServiceTests`**: added G2–G8 for `GenerateImageAsync` — malformed JSON (G2), empty `data` array (G3), `b64_json: null` (G4), `url` fallback download (G5), cross-origin `url` fallback emits `LogWarning` (G6), empty prompt (G7), whitespace-only prompt (G8) ([#139](https://github.com/artcava/XPoster/issues/139))
 
 ---
 

--- a/src/Models/FalAiOptionsValidator.cs
+++ b/src/Models/FalAiOptionsValidator.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.Options;
+
+namespace XPoster.Models;
+
+/// <summary>
+/// Validates <see cref="FalAiOptions"/> when the fal.ai provider is resolved.
+/// Ensures required fields are present and that <see cref="FalAiOptions.ModelId"/> does
+/// not contain characters that would require percent-encoding when used as a URL path
+/// segment (defence-in-depth alongside the per-segment encoding in FalAiImageService).
+/// </summary>
+public sealed class FalAiOptionsValidator : IValidateOptions<FalAiOptions>
+{
+    // Characters that are valid inside a URL path segment without percent-encoding
+    // (RFC 3986 unreserved + sub-delimiters + ':' + '@' + '/') but that *could* appear
+    // in a model id string.  We intentionally allow '/' because ModelId is a multi-segment
+    // path such as "fal-ai/flux/schnell" and each segment is encoded individually.
+    private static readonly char[] AllowedSpecialChars = ['/', '-', '_', '.'];
+
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, FalAiOptions options)
+    {
+        var failures = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.ApiKey))
+        {
+            failures.Add($"{nameof(FalAiOptions.ApiKey)} is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.ModelId))
+        {
+            failures.Add($"{nameof(FalAiOptions.ModelId)} is required.");
+        }
+        else
+        {
+            // Validate that every character in ModelId is alphanumeric or in the allowed set.
+            // This prevents URL-injection at configuration time and provides a clear startup
+            // error rather than a silent malformed-request failure at runtime.
+            foreach (var ch in options.ModelId)
+            {
+                if (!char.IsLetterOrDigit(ch) && !AllowedSpecialChars.Contains(ch))
+                {
+                    failures.Add(
+                        $"{nameof(FalAiOptions.ModelId)} contains an invalid character '{ch}'. " +
+                        "Only alphanumeric characters, hyphens, underscores, dots, and forward slashes are allowed.");
+                    break;
+                }
+            }
+        }
+
+        return failures.Count > 0
+            ? ValidateOptionsResult.Fail(failures)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -50,11 +50,12 @@ builder.Services.AddTransient<IOrchestratorFactory, OrchestratorFactory>();
 builder.Services.AddTransient<ICryptoService, CryptoService>();
 builder.Services.AddTransient<IFeedService, FeedService>();
 builder.Services.Configure<OpenAiOptions>(builder.Configuration.GetSection("OpenAI"));
-builder.Services.Configure<FalAiOptions>(builder.Configuration.GetSection("FalAi"));
 builder.Services.AddSingleton<IValidateOptions<OpenAiOptions>, OpenAiOptionsValidator>();
 builder.Services.Configure<AzureFoundryOptions>(builder.Configuration.GetSection("AzureFoundry"));
 builder.Services.AddSingleton<IValidateOptions<AzureFoundryOptions>, AzureFoundryOptionsValidator>();
 builder.Services.Configure<DeepSeekOptions>(builder.Configuration.GetSection("DeepSeek"));
 builder.Services.AddSingleton<IValidateOptions<DeepSeekOptions>, DeepSeekOptionsValidator>();
+builder.Services.Configure<FalAiOptions>(builder.Configuration.GetSection("FalAi"));
+builder.Services.AddSingleton<IValidateOptions<FalAiOptions>, FalAiOptionsValidator>();
 
 builder.Build().Run();

--- a/src/Services/AzureFoundryService.cs
+++ b/src/Services/AzureFoundryService.cs
@@ -96,6 +96,12 @@ public sealed class AzureFoundryService : IAiService
     /// <inheritdoc/>
     public async Task<byte[]> GenerateImageAsync(string prompt, CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrWhiteSpace(prompt))
+        {
+            _logger.LogWarning("GenerateImageAsync called with an empty prompt.");
+            return Array.Empty<byte>();
+        }
+
         var requestBody = new
         {
             prompt,
@@ -106,13 +112,31 @@ public sealed class AzureFoundryService : IAiService
 
         var response = await _client.PostAsJsonAsync(GetImageGenerationEndpoint(), requestBody, cancellationToken);
 
+        // Intercept 429 before the generic success check — consistent with GetSummaryAsync
+        // and GetImagePromptAsync in this class, and with FalAiImageService (reference implementation).
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            _logger.LogWarning("Azure Foundry returned 429 during image generation.");
+            return Array.Empty<byte>();
+        }
+
         if (!response.IsSuccessStatusCode)
         {
             _logger.LogError("Azure Foundry image generation failed with status code {StatusCode}", response.StatusCode);
             return Array.Empty<byte>();
         }
 
-        var result = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+        JsonElement result;
+        try
+        {
+            result = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Azure Foundry image generation response contained invalid JSON.");
+            return Array.Empty<byte>();
+        }
+
         if (!result.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
         {
             _logger.LogError("Azure Foundry image generation response does not contain data entries.");
@@ -124,9 +148,21 @@ public sealed class AzureFoundryService : IAiService
         if (first.TryGetProperty("b64_json", out var b64Property))
         {
             var base64 = b64Property.GetString();
-            return string.IsNullOrWhiteSpace(base64)
-                ? Array.Empty<byte>()
-                : Convert.FromBase64String(base64);
+            if (string.IsNullOrWhiteSpace(base64))
+            {
+                _logger.LogError("Azure Foundry image generation response contained a null or empty b64_json value.");
+                return Array.Empty<byte>();
+            }
+
+            try
+            {
+                return Convert.FromBase64String(base64);
+            }
+            catch (FormatException ex)
+            {
+                _logger.LogError(ex, "Azure Foundry image generation response contained an invalid base64 string.");
+                return Array.Empty<byte>();
+            }
         }
 
         if (first.TryGetProperty("url", out var urlProperty))
@@ -134,12 +170,35 @@ public sealed class AzureFoundryService : IAiService
             var imageUrl = urlProperty.GetString();
             if (string.IsNullOrWhiteSpace(imageUrl))
             {
+                _logger.LogError("Azure Foundry image generation response contained an empty fallback URL.");
                 return Array.Empty<byte>();
             }
 
-            return await _client.GetByteArrayAsync(imageUrl, cancellationToken);
+            // Validate the fallback URL against the configured endpoint origin to prevent
+            // SSRF-style downloads from arbitrary hosts returned by the API response.
+            // If validation fails we still log and proceed rather than blocking — this is a
+            // defence-in-depth warning that enables audit in Application Insights.
+            var configuredOrigin = new Uri(_options.Endpoint.TrimEnd('/')).GetLeftPart(UriPartial.Authority);
+            if (!imageUrl.StartsWith(configuredOrigin, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning(
+                    "Azure Foundry image fallback URL {ImageUrl} does not originate from the configured endpoint {ConfiguredOrigin}. Proceeding with download.",
+                    imageUrl,
+                    configuredOrigin);
+            }
+
+            try
+            {
+                return await _client.GetByteArrayAsync(imageUrl, cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Azure Foundry failed to download image from fallback URL: {Url}", imageUrl);
+                return Array.Empty<byte>();
+            }
         }
 
+        _logger.LogError("Azure Foundry image generation response data entry is missing both b64_json and url.");
         return Array.Empty<byte>();
     }
 

--- a/src/Services/DeepSeekService.cs
+++ b/src/Services/DeepSeekService.cs
@@ -110,6 +110,11 @@ public class DeepSeekService : IAiService
             $"Use {nameof(HybridAiService)} to delegate image generation to fal.ai.");
     }
 
+    // No Uri.EscapeDataString call is needed here: the suffix "/chat/completions" is a
+    // static string constant with no dynamic path segments. The base Endpoint value is
+    // validated by DeepSeekOptionsValidator to be non-empty; its trailing slash is trimmed
+    // before concatenation. If dynamic path segments are added in the future, each segment
+    // must be wrapped with Uri.EscapeDataString, consistent with AzureFoundryService.
     private string GetChatCompletionsEndpoint() =>
         $"{_options.Endpoint.TrimEnd('/')}/chat/completions";
 

--- a/src/Services/FalAiImageService.cs
+++ b/src/Services/FalAiImageService.cs
@@ -58,7 +58,16 @@ public sealed class FalAiImageService
             output_format = "png"
         };
 
-        var endpoint = $"{FalApiBaseUrl}/{_options.ModelId}";
+        // ModelId may contain path separators (e.g. "fal-ai/flux/schnell").
+        // Each segment is encoded individually so that slashes are preserved as
+        // path delimiters while any reserved or unsafe characters within a segment
+        // are percent-encoded. This is consistent with the AzureFoundryService
+        // pattern that calls Uri.EscapeDataString on DeploymentName.
+        var encodedModelPath = string.Join(
+            "/",
+            _options.ModelId.Split('/').Select(Uri.EscapeDataString));
+
+        var endpoint = $"{FalApiBaseUrl}/{encodedModelPath}";
 
         HttpResponseMessage response;
         try

--- a/src/Services/OpenAiService.cs
+++ b/src/Services/OpenAiService.cs
@@ -97,6 +97,13 @@ public class OpenAiService : IAiService
     /// <inheritdoc/>
     public async Task<byte[]> GenerateImageAsync(string prompt, CancellationToken cancellationToken = default)
     {
+        // Guard against empty prompts — consistent with FalAiImageService (reference implementation).
+        if (string.IsNullOrWhiteSpace(prompt))
+        {
+            _logger.LogWarning("GenerateImageAsync called with an empty prompt.");
+            return Array.Empty<byte>();
+        }
+
         _logger.LogInformation("Generating image with model {ImageModel}, prompt: {Prompt}", _options.ImageModel, prompt);
 
         var body = new

--- a/src/Services/OpenAiService.cs
+++ b/src/Services/OpenAiService.cs
@@ -109,16 +109,57 @@ public class OpenAiService : IAiService
 
         var response = await _client.PostAsJsonAsync(_options.ImageEndpoint, body, cancellationToken);
 
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            _logger.LogWarning("OpenAI returned 429 during image generation.");
+            return Array.Empty<byte>();
+        }
+
         if (!response.IsSuccessStatusCode)
         {
             _logger.LogError("OpenAI image generation failed with status code {StatusCode}", response.StatusCode);
             return Array.Empty<byte>();
         }
 
-        var result = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
-        var base64 = result.GetProperty("data")[0].GetProperty("b64_json").GetString();
-        // base64 cannot be null if API responded with 200 and valid JSON structure
-        return Convert.FromBase64String(base64!);
+        JsonElement result;
+        try
+        {
+            result = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "OpenAI image generation response contained invalid JSON.");
+            return Array.Empty<byte>();
+        }
+
+        if (!result.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
+        {
+            _logger.LogError("OpenAI image generation response does not contain data entries.");
+            return Array.Empty<byte>();
+        }
+
+        if (!data[0].TryGetProperty("b64_json", out var b64Property))
+        {
+            _logger.LogError("OpenAI image generation response data entry is missing b64_json.");
+            return Array.Empty<byte>();
+        }
+
+        var base64 = b64Property.GetString();
+        if (string.IsNullOrWhiteSpace(base64))
+        {
+            _logger.LogError("OpenAI image generation response contained a null or empty b64_json value.");
+            return Array.Empty<byte>();
+        }
+
+        try
+        {
+            return Convert.FromBase64String(base64);
+        }
+        catch (FormatException ex)
+        {
+            _logger.LogError(ex, "OpenAI image generation response contained an invalid base64 string.");
+            return Array.Empty<byte>();
+        }
     }
 
     /// <summary>

--- a/src/Services/OpenAiService.cs
+++ b/src/Services/OpenAiService.cs
@@ -37,19 +37,21 @@ public class OpenAiService : IAiService
     {
         int tries = 0;
 
-        while (text != null && text.Length > messageMaxLength && tries <= 2)
+        // text is a non-nullable string — the `text != null` guard was redundant and has been removed.
+        // AzureFoundryService canonical pattern: guard only on Length and retry count.
+        while (text.Length > messageMaxLength && tries <= 2)
         {
             tries++;
             var response = await _client.PostAsJsonAsync(_options.ChatEndpoint, GetSummary(text, messageMaxLength), cancellationToken);
             if (response.StatusCode == HttpStatusCode.TooManyRequests)
             {
-                _logger.LogInformation("Too many requests. Please try again later.");
+                _logger.LogInformation("OpenAI returned 429 during summary generation.");
                 return string.Empty;
             }
 
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogInformation($"Error: {response.StatusCode}");
+                _logger.LogInformation("OpenAI summary request failed with status code {StatusCode}", response.StatusCode);
                 return string.Empty;
             }
 
@@ -62,8 +64,8 @@ public class OpenAiService : IAiService
 
             text = result.choices[0].message.content.Trim();
         }
-        // CS8603: text cannot be null here — while loop guard ensures non-null or early return
-        return text ?? string.Empty;
+
+        return text;
     }
 
     /// <inheritdoc/>
@@ -72,13 +74,13 @@ public class OpenAiService : IAiService
         var response = await _client.PostAsJsonAsync(_options.ChatEndpoint, GetPromptForImage(text), cancellationToken);
         if (response.StatusCode == HttpStatusCode.TooManyRequests)
         {
-            _logger.LogInformation("Too many requests. Please try again later.");
+            _logger.LogInformation("OpenAI returned 429 during image prompt generation.");
             return string.Empty;
         }
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger.LogInformation($"Error: {response.StatusCode}");
+            _logger.LogInformation("OpenAI image prompt request failed with status code {StatusCode}", response.StatusCode);
             return string.Empty;
         }
 
@@ -95,7 +97,7 @@ public class OpenAiService : IAiService
     /// <inheritdoc/>
     public async Task<byte[]> GenerateImageAsync(string prompt, CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation($"Generating image with {_options.ImageModel}, prompt: {prompt}");
+        _logger.LogInformation("Generating image with model {ImageModel}, prompt: {Prompt}", _options.ImageModel, prompt);
 
         var body = new
         {
@@ -109,7 +111,7 @@ public class OpenAiService : IAiService
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger.LogError($"Image generation failed: {response.StatusCode}");
+            _logger.LogError("OpenAI image generation failed with status code {StatusCode}", response.StatusCode);
             return Array.Empty<byte>();
         }
 

--- a/tests/Models/FalAiOptionsValidatorTests.cs
+++ b/tests/Models/FalAiOptionsValidatorTests.cs
@@ -1,0 +1,116 @@
+using Microsoft.Extensions.Options;
+using XPoster.Models;
+
+namespace XPoster.Tests.Models;
+
+public class FalAiOptionsValidatorTests
+{
+    private readonly FalAiOptionsValidator _sut = new();
+
+    private static FalAiOptions ValidOptions() => new()
+    {
+        ApiKey = "fake-api-key",
+        ModelId = "fal-ai/flux/schnell"
+    };
+
+    [Fact]
+    public void Validate_ValidOptions_Succeeds()
+    {
+        var result = _sut.Validate(null, ValidOptions());
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_MissingApiKey_Fails()
+    {
+        var options = ValidOptions();
+        options.ApiKey = string.Empty;
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains(nameof(FalAiOptions.ApiKey)));
+    }
+
+    [Fact]
+    public void Validate_WhitespaceApiKey_Fails()
+    {
+        var options = ValidOptions();
+        options.ApiKey = "   ";
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains(nameof(FalAiOptions.ApiKey)));
+    }
+
+    [Fact]
+    public void Validate_MissingModelId_Fails()
+    {
+        var options = ValidOptions();
+        options.ModelId = string.Empty;
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains(nameof(FalAiOptions.ModelId)));
+    }
+
+    [Fact]
+    public void Validate_WhitespaceModelId_Fails()
+    {
+        var options = ValidOptions();
+        options.ModelId = "   ";
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains(nameof(FalAiOptions.ModelId)));
+    }
+
+    [Theory]
+    [InlineData("fal-ai/flux?version=1")]  // query string delimiter
+    [InlineData("fal-ai/flux schnell")]     // space
+    [InlineData("fal-ai/flux#anchor")]      // fragment delimiter
+    [InlineData("fal-ai/flux[turbo]")]      // square bracket
+    public void Validate_ModelIdWithUnsafeCharacters_Fails(string modelId)
+    {
+        var options = ValidOptions();
+        options.ModelId = modelId;
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains(nameof(FalAiOptions.ModelId)));
+    }
+
+    [Theory]
+    [InlineData("fal-ai/flux/schnell")]          // default — slashes allowed
+    [InlineData("fal-ai/stable-diffusion-v3")]   // hyphens
+    [InlineData("fal-ai/model_v2.0")]            // underscores and dot
+    [InlineData("provider/org/model123")]         // multi-segment alphanumeric
+    public void Validate_ModelIdWithAllowedSpecialChars_Succeeds(string modelId)
+    {
+        var options = ValidOptions();
+        options.ModelId = modelId;
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_BothRequiredFieldsMissing_ReportsBothFailures()
+    {
+        var options = ValidOptions();
+        options.ApiKey = string.Empty;
+        options.ModelId = string.Empty;
+
+        var result = _sut.Validate(null, options);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures!, f => f.Contains(nameof(FalAiOptions.ApiKey)));
+        Assert.Contains(result.Failures!, f => f.Contains(nameof(FalAiOptions.ModelId)));
+    }
+}

--- a/tests/Services/AzureFoundryServiceTests.cs
+++ b/tests/Services/AzureFoundryServiceTests.cs
@@ -47,6 +47,8 @@ public class AzureFoundryServiceTests
     private static string ChatCompletionJson(string content) =>
         "{\"choices\":[{\"message\":{\"content\":\"" + content + "\"}}]}";
 
+    // ── GetSummaryAsync ──────────────────────────────────────────────────────
+
     [Fact]
     public async Task GetSummaryAsync_WhenTextExceedsLimit_CallsApiAndReturnsTrimmedContent()
     {
@@ -103,6 +105,8 @@ public class AzureFoundryServiceTests
         Assert.Equal(string.Empty, result);
     }
 
+    // ── GetImagePromptAsync ───────────────────────────────────────────────
+
     [Fact]
     public async Task GetImagePromptAsync_WhenApiReturnsValidResponse_ReturnsPrompt()
     {
@@ -133,6 +137,8 @@ public class AzureFoundryServiceTests
         Assert.Equal(string.Empty, result);
     }
 
+    // ── GenerateImageAsync ──────────────────────────────────────────────────
+
     [Fact]
     public async Task GenerateImageAsync_WhenApiReturnsValidResponse_ReturnsByteArray()
     {
@@ -150,6 +156,17 @@ public class AzureFoundryServiceTests
     public async Task GenerateImageAsync_WhenApiReturnsNonSuccess_ReturnsEmptyByteArray()
     {
         var svc = BuildService(MakeHandlerMock(HttpStatusCode.BadRequest, "{}").Object, out _);
+
+        var result = await svc.GenerateImageAsync("image prompt");
+
+        Assert.Empty(result);
+    }
+
+    /// <summary>G1 — 429 on image generation must return empty, not fall through to success path.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenApiReturnsTooManyRequests_ReturnsEmptyByteArray()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.TooManyRequests, "{}").Object, out _);
 
         var result = await svc.GenerateImageAsync("image prompt");
 

--- a/tests/Services/AzureFoundryServiceTests.cs
+++ b/tests/Services/AzureFoundryServiceTests.cs
@@ -105,7 +105,7 @@ public class AzureFoundryServiceTests
         Assert.Equal(string.Empty, result);
     }
 
-    // ── GetImagePromptAsync ───────────────────────────────────────────────
+    // ── GetImagePromptAsync ─────────────────────────────────────────────────
 
     [Fact]
     public async Task GetImagePromptAsync_WhenApiReturnsValidResponse_ReturnsPrompt()
@@ -171,5 +171,161 @@ public class AzureFoundryServiceTests
         var result = await svc.GenerateImageAsync("image prompt");
 
         Assert.Empty(result);
+    }
+
+    /// <summary>G2 — Malformed JSON on 200 must not throw; must return empty array.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenResponseBodyIsMalformedJson_ReturnsEmptyByteArray()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "NOT_JSON").Object, out _);
+
+        var result = await svc.GenerateImageAsync("image prompt");
+
+        Assert.Empty(result);
+    }
+
+    /// <summary>G3 — Empty data array on 200 must return empty array without throwing IndexOutOfRangeException.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenDataArrayIsEmpty_ReturnsEmptyByteArray()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{\"data\":[]}").Object, out _);
+
+        var result = await svc.GenerateImageAsync("image prompt");
+
+        Assert.Empty(result);
+    }
+
+    /// <summary>G4 — b64_json null must return empty array, not throw FormatException.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenB64JsonIsNull_ReturnsEmptyByteArray()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{\"data\":[{\"b64_json\":null}]}").Object, out _);
+
+        var result = await svc.GenerateImageAsync("image prompt");
+
+        Assert.Empty(result);
+    }
+
+    /// <summary>
+    /// G5 — When b64_json is absent but a url is present, the service downloads from the url
+    /// and returns the bytes. In this test the url points to a second endpoint served by the
+    /// same mock handler, which returns a fixed byte payload.
+    /// </summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenB64JsonAbsentAndUrlPresent_DownloadsFromUrl()
+    {
+        // The image download call is also intercepted by the same HttpClient/handler.
+        // We configure the handler to return the image bytes for any request.
+        var imageBytes = new byte[] { 10, 20, 30 };
+        var mock = new Mock<HttpMessageHandler>();
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
+            {
+                // First call is the POST to the image generation endpoint.
+                // Second call is the GET for the image URL.
+                if (req.Method == HttpMethod.Post)
+                {
+                    var json = "{\"data\":[{\"url\":\"https://myfoundry.openai.azure.com/generated/img.png\"}]}";
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(imageBytes)
+                });
+            });
+
+        var svc = BuildService(mock.Object, out _);
+
+        var result = await svc.GenerateImageAsync("image prompt");
+
+        Assert.Equal(imageBytes, result);
+    }
+
+    /// <summary>
+    /// G6 — A fallback url that does not originate from the configured endpoint must emit a
+    /// LogWarning. The download is still attempted (defence-in-depth, not a hard block).
+    /// </summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenFallbackUrlIsFromDifferentOrigin_LogsWarning()
+    {
+        var imageBytes = new byte[] { 1 };
+        var mock = new Mock<HttpMessageHandler>();
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
+            {
+                if (req.Method == HttpMethod.Post)
+                {
+                    // URL originates from a different host — should trigger LogWarning.
+                    var json = "{\"data\":[{\"url\":\"https://cdn.unknown.example.com/img.png\"}]}";
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(imageBytes)
+                });
+            });
+
+        var svc = BuildService(mock.Object, out var loggerMock);
+
+        await svc.GenerateImageAsync("image prompt");
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("cdn.unknown.example.com")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    /// <summary>G7 — Empty prompt must return empty array immediately, without making any HTTP call.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenPromptIsEmpty_ReturnsEmptyByteArrayWithoutCallingApi()
+    {
+        var handler = MakeHandlerMock(HttpStatusCode.OK, "{}");
+        var svc = BuildService(handler.Object, out _);
+
+        var result = await svc.GenerateImageAsync(string.Empty);
+
+        Assert.Empty(result);
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    /// <summary>G8 — Whitespace-only prompt must also be rejected before any HTTP call.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenPromptIsWhitespace_ReturnsEmptyByteArrayWithoutCallingApi()
+    {
+        var handler = MakeHandlerMock(HttpStatusCode.OK, "{}");
+        var svc = BuildService(handler.Object, out _);
+
+        var result = await svc.GenerateImageAsync("   ");
+
+        Assert.Empty(result);
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
     }
 }

--- a/tests/Services/FalAiImageServiceTests.cs
+++ b/tests/Services/FalAiImageServiceTests.cs
@@ -1,0 +1,254 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using XPoster.Models;
+using XPoster.Services;
+
+namespace XPoster.Tests.Services;
+
+public class FalAiImageServiceTests
+{
+    // Builds a FalAiImageService with a controllable HttpMessageHandler.
+    // The same handler is reused for both the POST (image generation) and the
+    // GET (image download) calls, or a dedicated download handler can be provided.
+    private static FalAiImageService BuildService(
+        HttpMessageHandler handler,
+        out Mock<ILogger<FalAiImageService>> loggerMock,
+        FalAiOptions? opts = null)
+    {
+        loggerMock = new Mock<ILogger<FalAiImageService>>();
+        var factory = new Mock<IHttpClientFactory>();
+        var client = new HttpClient(handler);
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        var options = Options.Create(opts ?? new FalAiOptions
+        {
+            ApiKey = "fake-api-key",
+            ModelId = "fal-ai/flux/schnell"
+        });
+
+        return new FalAiImageService(factory.Object, options, loggerMock.Object);
+    }
+
+    // Creates a handler mock that returns the same response for every request.
+    private static Mock<HttpMessageHandler> MakeHandlerMock(HttpStatusCode code, string body)
+    {
+        var mock = new Mock<HttpMessageHandler>();
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(code)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        return mock;
+    }
+
+    // Builds the fal.ai image generation response JSON with a single image URL entry.
+    private static string FalImageJson(string imageUrl) =>
+        $"{{\"images\":[{{\"url\":\"{imageUrl}\"}}]}}";
+
+    // -------------------------------------------------------------------------
+    // Prompt guard
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GenerateImageAsync_EmptyPrompt_ReturnsEmptyArray()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{}").Object, out _);
+
+        var result = await svc.GenerateImageAsync(string.Empty);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GenerateImageAsync_WhitespacePrompt_ReturnsEmptyArray()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{}").Object, out _);
+
+        var result = await svc.GenerateImageAsync("   ");
+
+        Assert.Empty(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // HTTP error codes
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GenerateImageAsync_Returns429_ReturnsEmptyArray()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.TooManyRequests, "{}").Object, out _);
+
+        var result = await svc.GenerateImageAsync("a prompt");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GenerateImageAsync_ReturnsNonSuccess_ReturnsEmptyArray()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.InternalServerError, "{}").Object, out _);
+
+        var result = await svc.GenerateImageAsync("a prompt");
+
+        Assert.Empty(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // JSON parsing
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GenerateImageAsync_MalformedJson_ReturnsEmptyArray()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "NOT-JSON").Object, out _);
+
+        var result = await svc.GenerateImageAsync("a prompt");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GenerateImageAsync_EmptyImagesArray_ReturnsEmptyArray()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{\"images\":[]}").Object, out _);
+
+        var result = await svc.GenerateImageAsync("a prompt");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GenerateImageAsync_MissingImagesProperty_ReturnsEmptyArray()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.OK, "{\"other\":\"value\"}").Object, out _);
+
+        var result = await svc.GenerateImageAsync("a prompt");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GenerateImageAsync_MissingUrlProperty_ReturnsEmptyArray()
+    {
+        var svc = BuildService(
+            MakeHandlerMock(HttpStatusCode.OK, "{\"images\":[{\"width\":512}]}").Object, out _);
+
+        var result = await svc.GenerateImageAsync("a prompt");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GenerateImageAsync_EmptyUrlProperty_ReturnsEmptyArray()
+    {
+        var svc = BuildService(
+            MakeHandlerMock(HttpStatusCode.OK, "{\"images\":[{\"url\":\"\"}]}").Object, out _);
+
+        var result = await svc.GenerateImageAsync("a prompt");
+
+        Assert.Empty(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path — successful image download
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GenerateImageAsync_ValidResponse_ReturnsImageBytes()
+    {
+        var expectedBytes = new byte[] { 137, 80, 78, 71 }; // PNG magic bytes
+
+        // First call: POST to fal.run/{model} — returns JSON with image URL
+        // Second call: GET the image URL — returns raw bytes
+        // We use a sequential setup on the same mock handler.
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var imageUrl = "https://cdn.fal.ai/output/image.png";
+
+        handlerMock.Protected()
+            .SetupSequence<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            // First call: the POST to generate the image
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(FalImageJson(imageUrl), Encoding.UTF8, "application/json")
+            })
+            // Second call: the GET to download the image
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(expectedBytes)
+            });
+
+        var svc = BuildService(handlerMock.Object, out _);
+
+        var result = await svc.GenerateImageAsync("a prompt");
+
+        Assert.Equal(expectedBytes, result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Endpoint URL encoding — ModelId percent-encoding (Point 1, issue #139)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GenerateImageAsync_ModelIdWithUnsafeChars_PercentEncodesInRequestUri()
+    {
+        // ModelId containing a space — should be encoded as %20 in the request URI.
+        // The validator would normally block this at startup; this test verifies that
+        // even if an unsafe value reaches the service, the URL construction is safe.
+        var opts = new FalAiOptions { ApiKey = "key", ModelId = "fal-ai/model with space" };
+
+        HttpRequestMessage? capturedRequest = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.TooManyRequests));
+
+        var svc = BuildService(handlerMock.Object, out _, opts);
+
+        await svc.GenerateImageAsync("a prompt");
+
+        Assert.NotNull(capturedRequest);
+        // The path must not contain a raw space; it must be percent-encoded.
+        var path = capturedRequest!.RequestUri!.AbsolutePath;
+        Assert.DoesNotContain(" ", path);
+        Assert.Contains("%20", path, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GenerateImageAsync_ModelIdWithMultipleSegments_PreservesSlashesInUri()
+    {
+        // Default ModelId "fal-ai/flux/schnell" — slashes must remain as path separators.
+        HttpRequestMessage? capturedRequest = null;
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => capturedRequest = req)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.TooManyRequests));
+
+        var svc = BuildService(handlerMock.Object, out _);
+
+        await svc.GenerateImageAsync("a prompt");
+
+        Assert.NotNull(capturedRequest);
+        var path = capturedRequest!.RequestUri!.AbsolutePath;
+        // fal-ai, flux, schnell must all appear as distinct path segments.
+        Assert.Contains("/fal-ai/flux/schnell", path, StringComparison.Ordinal);
+    }
+}

--- a/tests/Services/OpenAiServiceTests.cs
+++ b/tests/Services/OpenAiServiceTests.cs
@@ -252,4 +252,38 @@ public class OpenAiServiceTests
         var result = await svc.GenerateImageAsync("a prompt");
         Assert.Empty(result);
     }
+
+    /// <summary>G7 — Empty prompt must return empty array immediately, without making any HTTP call.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenPromptIsEmpty_ReturnsEmptyArrayWithoutCallingApi()
+    {
+        var handler = MakeHandlerMock(HttpStatusCode.OK, "{}");
+        var svc = BuildService(handler.Object, out _);
+
+        var result = await svc.GenerateImageAsync(string.Empty);
+
+        Assert.Empty(result);
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    /// <summary>G8 — Whitespace-only prompt must also be rejected before any HTTP call.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenPromptIsWhitespace_ReturnsEmptyArrayWithoutCallingApi()
+    {
+        var handler = MakeHandlerMock(HttpStatusCode.OK, "{}");
+        var svc = BuildService(handler.Object, out _);
+
+        var result = await svc.GenerateImageAsync("   ");
+
+        Assert.Empty(result);
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
 }

--- a/tests/Services/OpenAiServiceTests.cs
+++ b/tests/Services/OpenAiServiceTests.cs
@@ -24,6 +24,9 @@ public class OpenAiServiceTests
         return new OpenAiService(factory.Object, options, loggerMock.Object);
     }
 
+    /// <summary>
+    /// Single-use handler: returns one fixed response. Safe for single-call tests.
+    /// </summary>
     private static HttpMessageHandler MakeHandler(HttpStatusCode code, string json)
     {
         var mock = new Mock<HttpMessageHandler>();
@@ -39,6 +42,10 @@ public class OpenAiServiceTests
         return mock.Object;
     }
 
+    /// <summary>
+    /// Multi-use handler: creates a fresh HttpResponseMessage on every SendAsync call.
+    /// Required for tests that exercise the retry loop (stream cannot be read twice).
+    /// </summary>
     private static Mock<HttpMessageHandler> MakeHandlerMock(HttpStatusCode code, string json)
     {
         var mock = new Mock<HttpMessageHandler>();
@@ -47,10 +54,10 @@ public class OpenAiServiceTests
                 "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage(code)
+            .Returns(() => Task.FromResult(new HttpResponseMessage(code)
             {
                 Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
-            });
+            }));
         return mock;
     }
 
@@ -108,19 +115,20 @@ public class OpenAiServiceTests
         Assert.Equal(string.Empty, result);
     }
 
-    /// <summary>G5 — The retry loop must stop after at most 3 HTTP calls (tries 0,1,2; guard: tries &lt;= 2).</summary>
+    /// <summary>
+    /// G5 — The retry loop must stop after at most 3 HTTP calls (tries 1,2,3; guard: tries &lt;= 2
+    /// checked before increment means the loop runs while tries is 0, 1, 2 — exactly 3 iterations).
+    /// Uses MakeHandlerMock so each call receives a fresh HttpResponseMessage with a readable stream.
+    /// </summary>
     [Fact]
     public async Task GetSummaryAsync_WhenSummaryAlwaysTooLong_StopsAfterThreeAttempts()
     {
-        // Response always returns text longer than the limit so the loop never exits via length.
-        // After tries==2 the loop condition fails and the last API response text is returned.
         var longResponse = new string('b', 200);
         var handler = MakeHandlerMock(HttpStatusCode.OK, ChatCompletionJson(longResponse));
         var svc = BuildService(handler.Object, out _);
 
         var result = await svc.GetSummaryAsync(new string('a', 300), 100);
 
-        // Exactly 3 HTTP calls: tries=1, tries=2, tries=3 (while condition: tries <= 2 checked after increment)
         handler.Protected().Verify(
             "SendAsync",
             Times.Exactly(3),
@@ -209,7 +217,7 @@ public class OpenAiServiceTests
         Assert.Empty(result);
     }
 
-    /// <summary>G1 — 429 on image generation must return empty, not throw.</summary>
+    /// <summary>G1 — 429 on image generation must return empty, not fall through to success path.</summary>
     [Fact]
     public async Task GenerateImageAsync_WhenApiReturnsTooManyRequests_ReturnsEmptyArray()
     {

--- a/tests/Services/OpenAiServiceTests.cs
+++ b/tests/Services/OpenAiServiceTests.cs
@@ -39,6 +39,21 @@ public class OpenAiServiceTests
         return mock.Object;
     }
 
+    private static Mock<HttpMessageHandler> MakeHandlerMock(HttpStatusCode code, string json)
+    {
+        var mock = new Mock<HttpMessageHandler>();
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(code)
+            {
+                Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json")
+            });
+        return mock;
+    }
+
     private static string ChatCompletionJson(string content) =>
         "{\"choices\":[{\"message\":{\"content\":\"" + content + "\"}}]}";
 
@@ -93,6 +108,27 @@ public class OpenAiServiceTests
         Assert.Equal(string.Empty, result);
     }
 
+    /// <summary>G5 — The retry loop must stop after at most 3 HTTP calls (tries 0,1,2; guard: tries &lt;= 2).</summary>
+    [Fact]
+    public async Task GetSummaryAsync_WhenSummaryAlwaysTooLong_StopsAfterThreeAttempts()
+    {
+        // Response always returns text longer than the limit so the loop never exits via length.
+        // After tries==2 the loop condition fails and the last API response text is returned.
+        var longResponse = new string('b', 200);
+        var handler = MakeHandlerMock(HttpStatusCode.OK, ChatCompletionJson(longResponse));
+        var svc = BuildService(handler.Object, out _);
+
+        var result = await svc.GetSummaryAsync(new string('a', 300), 100);
+
+        // Exactly 3 HTTP calls: tries=1, tries=2, tries=3 (while condition: tries <= 2 checked after increment)
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(3),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+        Assert.Equal(longResponse, result);
+    }
+
     // ── GetImagePromptAsync ──────────────────────────────────────────────────
 
     [Fact]
@@ -109,6 +145,23 @@ public class OpenAiServiceTests
         var svc = BuildService(MakeHandler(HttpStatusCode.TooManyRequests, "{}"), out _);
         var result = await svc.GetImagePromptAsync("some summary");
         Assert.Equal(string.Empty, result);
+    }
+
+    /// <summary>G6 — 429 must emit a log entry, not only return empty.</summary>
+    [Fact]
+    public async Task GetImagePromptAsync_WhenApiReturnsTooManyRequests_LogsInformation()
+    {
+        var svc = BuildService(MakeHandler(HttpStatusCode.TooManyRequests, "{}"), out var loggerMock);
+        await svc.GetImagePromptAsync("some summary");
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("429") || v.ToString()!.Contains("TooManyRequests")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 
     [Fact]
@@ -152,6 +205,42 @@ public class OpenAiServiceTests
     public async Task GenerateImageAsync_WhenApiReturnsError_ReturnsEmptyArray()
     {
         var svc = BuildService(MakeHandler(HttpStatusCode.BadRequest, "{}"), out _);
+        var result = await svc.GenerateImageAsync("a prompt");
+        Assert.Empty(result);
+    }
+
+    /// <summary>G1 — 429 on image generation must return empty, not throw.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenApiReturnsTooManyRequests_ReturnsEmptyArray()
+    {
+        var svc = BuildService(MakeHandler(HttpStatusCode.TooManyRequests, "{}"), out _);
+        var result = await svc.GenerateImageAsync("a prompt");
+        Assert.Empty(result);
+    }
+
+    /// <summary>G2 — Malformed JSON on 200 must not throw; must return empty array.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenResponseBodyIsMalformedJson_ReturnsEmptyArray()
+    {
+        var svc = BuildService(MakeHandler(HttpStatusCode.OK, "NOT_JSON"), out _);
+        var result = await svc.GenerateImageAsync("a prompt");
+        Assert.Empty(result);
+    }
+
+    /// <summary>G3 — Empty data array on 200 must return empty array, not throw IndexOutOfRangeException.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenDataArrayIsEmpty_ReturnsEmptyArray()
+    {
+        var svc = BuildService(MakeHandler(HttpStatusCode.OK, "{\"data\":[]}"), out _);
+        var result = await svc.GenerateImageAsync("a prompt");
+        Assert.Empty(result);
+    }
+
+    /// <summary>G4 — b64_json null in response must return empty array, not throw FormatException.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenB64JsonIsNull_ReturnsEmptyArray()
+    {
+        var svc = BuildService(MakeHandler(HttpStatusCode.OK, "{\"data\":[{\"b64_json\":null}]}"), out _);
         var result = await svc.GenerateImageAsync("a prompt");
         Assert.Empty(result);
     }


### PR DESCRIPTION
## Summary

Hardens `GenerateImageAsync` in `AzureFoundryService` and `OpenAiService` to match `FalAiImageService` as the reference implementation, closing point 3 of issue #139.

---

## Changes

### `AzureFoundryService.GenerateImageAsync`
- **Prompt guard**: rejects empty/whitespace prompts with `LogWarning` before any HTTP call
- **429 intercept**: explicit check before `IsSuccessStatusCode`, consistent with `GetSummaryAsync` / `GetImagePromptAsync` in the same class
- **`JsonException` guard**: `ReadFromJsonAsync<JsonElement>` wrapped in `try/catch` — malformed responses return empty array without throwing
- **`b64_json` null + `FormatException`**: `IsNullOrWhiteSpace` check + `try/catch` on `Convert.FromBase64String`
- **URL fallback origin validation**: emits `LogWarning` with the full URL when the download origin does not match `_options.Endpoint` (audit trail for Application Insights); download proceeds as defence-in-depth
- **`HttpRequestException` guard**: `GetByteArrayAsync` on the `url` fallback path wrapped in `try/catch`
- **Explicit `LogError`**: emitted when a response data entry contains neither `b64_json` nor `url`

### `OpenAiService.GenerateImageAsync`
- **Prompt guard**: `string.IsNullOrWhiteSpace(prompt)` added at method entry — all other hardening was already present on this branch

### `CHANGELOG.md`
- `[Unreleased]` section updated with `### Changed` and `### Tests` entries for #139, following Keep a Changelog format

---

## Tests

| Suite | New tests | Behaviour covered |
|---|---|---|
| `OpenAiServiceTests` | G7, G8 | Empty prompt and whitespace-only prompt → empty array, zero HTTP calls |
| `AzureFoundryServiceTests` | G2–G8 | Malformed JSON (G2), empty `data[]` (G3), `b64_json: null` (G4), `url` fallback download (G5), cross-origin `url` emits `LogWarning` (G6), empty prompt (G7), whitespace prompt (G8) |

All new tests follow xUnit + Moq conventions from `.github/agents/qa.md`: one behavioural idea per test, no implementation details in assertions.

---

## Checklist

- [x] Closes point 3 of #139
- [x] All new guards return gracefully (empty array or log + continue) — no new thrown exceptions in the happy path
- [x] Behaviour aligned with `FalAiImageService` reference implementation
- [x] CHANGELOG updated
- [x] No breaking changes to `IAiService` contract
