### PR TITLE
docs: fix documentation inconsistencies post-KeyVault introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ XPoster is a **serverless, event-driven pipeline** built on four structural pill
 
 The AI layer is abstracted behind `IAiService` and resolved at runtime by `AiServiceFactory`, enabling per-slot provider assignment and global override via configuration without touching orchestrator code.
 
+Secret resolution for platform tokens is handled by **`KeyVaultService`** (`IKeyVaultService`), which wraps `Azure.Security.KeyVault.Secrets` and is consumed by sender plugins at runtime to retrieve OAuth credentials from Azure Key Vault.
+
 ```
 ┌────────────────────────────┐
 │   Azure Timer Trigger      │
@@ -99,8 +101,10 @@ The AI layer is abstracted behind `IAiService` and resolved at runtime by `AiSer
     │   Services         │
     ├────────────────────┤
     │ • AiServiceFactory │ ◄─── Resolves IAiService by AiProvider
+    │ • AiServiceHelper  │ ◄─── HTTP response parsing / 429 handling
     │ • Feed Service     │ ◄─── RSS Parser
     │ • Crypto Service   │ ◄─── CryptoPrices HTTP client
+    │ • KeyVaultService  │ ◄─── Azure Key Vault secret resolution
     └────────┬───────────┘
              │
              ▼
@@ -150,7 +154,9 @@ The AI layer is built on **Microsoft.Extensions.AI**, the provider-agnostic abst
 |-------------------------|-----------------|--------------|---------------|
 | `OpenAi` | `OpenAiService` | Azure OpenAI / OpenAI-compatible endpoint | Same endpoint (e.g. `dall-e-3`, `gpt-image-1`) |
 | `AzureFoundry` | `AzureFoundryService` | Azure AI Foundry deployment | Azure AI Foundry deployment |
-| `DeepSeekWithFal` | `HybridAiService` | DeepSeek API | fal.ai — FLUX.2 Turbo |
+| `DeepSeekWithFal` | `HybridAiService` | `DeepSeekService` → DeepSeek API | `FalAiImageService` → fal.ai FLUX.2 Turbo |
+
+> ℹ️ `DeepSeekService` and `FalAiImageService` are independent services, each with their own registration and test coverage. `HybridAiService` composes the two, delegating text requests to `DeepSeekService` and image requests to `FalAiImageService`. This composition is transparent to orchestrators, which always program to `IAiService`.
 
 ### Social Media APIs
 
@@ -168,13 +174,16 @@ The AI layer is built on **Microsoft.Extensions.AI**, the provider-agnostic abst
 | `Microsoft.ApplicationInsights.WorkerService` | 2.23.0 | Telemetry pipeline for background services |
 | `ILogger<T>` | (built-in) | Structured logging via `Microsoft.Extensions.Logging` |
 
-### Utilities
+### Utilities & Security
 
 | Package | Version | Role |
 |---------|---------|------|
-| `Microsoft.Extensions.Http` | 9.0.10 | `IHttpClientFactory` — typed/named HTTP clients |
+| `Microsoft.Extensions.Http.Resilience` | 9.1.0 | Retry / resilience pipelines for outbound HTTP clients (`IHttpClientFactory`) |
 | `System.Text.Json` | 10.0.8 | JSON serialization / deserialization |
+| `Azure.Security.KeyVault.Secrets` | 4.7.0 | Azure Key Vault secret retrieval (used by `KeyVaultService`) |
 | `Microsoft.AspNetCore.App` (framework ref) | 8.0 | ASP.NET Core primitives used by the Functions host |
+
+> ℹ️ `Microsoft.Extensions.Http` is resolved transitively and is not pinned explicitly in the project file to avoid NU1603 version conflicts.
 
 ---
 
@@ -199,7 +208,7 @@ The AI layer is built on **Microsoft.Extensions.AI**, the provider-agnostic abst
 
 > ℹ️ **DeepSeek** and **fal.ai** are used together as the `HybridAiService` — DeepSeek handles text generation and fal.ai handles image generation. See [docs/architecture.md](docs/architecture.md) for details.
 >
-> ⚠️ Setup guides are located under `docs/integrations/`. See the [Roadmap](#roadmap) for the current documentation status.
+> ⚠️ The setup guides above are present and cover account creation, API key configuration, and troubleshooting. Some validation tasks (model names, key naming, SDK version checks) are tracked in issues [#130](https://github.com/artcava/XPoster/issues/130), [#131](https://github.com/artcava/XPoster/issues/131), and [#132](https://github.com/artcava/XPoster/issues/132) and will be completed before the next stable release.
 
 ### Clone the Repository
 
@@ -263,8 +272,9 @@ The example file documents every key inline. The variables are grouped into four
 | **LinkedIn** | `LINKEDIN_ACCESS_TOKEN`, `LINKEDIN_ORGANIZATION_ID` |
 | **Instagram** | `INSTAGRAM_ACCESS_TOKEN`, `INSTAGRAM_BUSINESS_ACCOUNT_ID` |
 | **AI Provider** | Varies by provider — see [Getting Started → Supported AI Providers](#supported-ai-providers) |
+| **Azure Key Vault** | `KEY_VAULT_URI` — URI of the Azure Key Vault instance used by `KeyVaultService` to resolve platform OAuth secrets at runtime |
 
-**For Azure**, add the same variables as Application Settings (**Azure Portal → Function App → Configuration**). For production environments, [Azure Managed Identity](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) is recommended over API keys.
+**For Azure**, add the same variables as Application Settings (**Azure Portal → Function App → Configuration**). For production environments, [Azure Managed Identity](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) is recommended over API keys — `KeyVaultService` uses `DefaultAzureCredential` and will transparently pick up the Function App's Managed Identity when available.
 
 > 📖 Full reference with types, defaults, allowed values, and instructions on where to obtain each credential: **[docs/configuration.md](docs/configuration.md)**.
 
@@ -279,6 +289,15 @@ Three deployment methods are supported. **GitHub Actions (Option 1) is recommend
 | **1. GitHub Actions** | Production — automated CI/CD on every push to `master` |
 | **2. Azure CLI** | Scripted / IaC provisioning, staging environments |
 | **3. Visual Studio Code** | One-off deploys during early development |
+
+### Branching Strategy
+
+| Branch | Purpose |
+|---|---|
+| `develop` | Active development branch — all feature and fix work targets here |
+| `master` | Production branch — holds the deployable state currently running on Azure; the CI/CD workflow deploys on every push to `master` |
+
+Work is developed on `develop` (or short-lived feature branches off it) and promoted to `master` when ready for release. The GitHub Actions workflow is scoped to `master` and does not trigger on `develop` pushes.
 
 ### Quick Start: GitHub Actions
 
@@ -420,6 +439,8 @@ tests/
 ├── XFunctionMissingBranchTests.cs
 ├── Abstraction/
 │   └── BaseOrchestratorTests.cs
+├── Helpers/
+│   └── ResilienceTestHelpers.cs
 ├── Implementation/
 │   ├── AiServiceFactoryTests.cs
 │   ├── FeedOrchestratorTests.cs
@@ -428,34 +449,48 @@ tests/
 │   └── PowerLawOrchestratorTests.cs
 ├── Models/
 │   ├── AzureFoundryOptionsValidatorTests.cs
+│   ├── DeepSeekOptionsTests.cs
+│   ├── DeepSeekOptionsValidatorTests.cs
+│   ├── FalAiOptionsValidatorTests.cs
 │   ├── ModelsTests.cs
 │   ├── OpenAiOptionsValidatorTests.cs
 │   ├── PostMissingBranchTests.cs
 │   └── RSSFeedMissingBranchTests.cs
 ├── SenderPlugins/
+│   ├── IgSenderResilienceTests.cs
 │   ├── IgSenderTests.cs
 │   ├── InSenderMissingBranchTests.cs
+│   ├── InSenderResilienceTests.cs
 │   ├── InSenderSendAsyncTests.cs
 │   ├── InSenderTests.cs
 │   ├── XSenderMissingBranchTests.cs
 │   ├── XSenderSendAsyncTests.cs
 │   └── XSenderTests.cs
-└── Services/
-    ├── AzureFoundryServiceTests.cs
-    ├── CryptoServiceTests.cs
-    ├── FeedServiceTests.cs
-    ├── OpenAiServiceTests.cs
-    └── TimeProviderTests.cs
+├── Services/
+│   ├── AiServiceHelperTests.cs
+│   ├── AzureFoundryServiceTests.cs
+│   ├── CryptoServiceTests.cs
+│   ├── DeepSeekServiceTests.cs
+│   ├── FalAiImageServiceTests.cs
+│   ├── FeedServiceTests.cs
+│   ├── HybridAiServiceTests.cs
+│   ├── OpenAiServiceTests.cs
+│   └── TimeProviderTests.cs
+└── XPoster.Tests/
+    └── Services/
+        └── KeyVaultServiceTests.cs
 ```
 
 | Folder | What is covered |
 |---|---|
 | *(root)* | `XFunction` entry point — happy path and missing-branch edge cases |
 | `Abstraction/` | `BaseOrchestrator` abstract class contracts |
+| `Helpers/` | Shared test utilities for resilience and HTTP mock setup (`ResilienceTestHelpers`) |
 | `Implementation/` | `FeedOrchestrator`, `PowerLawOrchestrator`, `NoOrchestrator`, `OrchestratorFactory`, and `AiServiceFactory` resolution logic |
-| `Models/` | Domain model invariants, `Post` and `RSSFeed` missing-branch cases, OpenAI and Azure Foundry options validators |
-| `SenderPlugins/` | `XSender` and `InSender` (happy path, `SendAsync`, missing-branch); `IgSender` (in-development coverage) |
-| `Services/` | `OpenAiService`, `AzureFoundryService`, `CryptoService`, `FeedService`, and `TimeProvider` unit tests |
+| `Models/` | Domain model invariants, `Post` and `RSSFeed` missing-branch cases, options validators for OpenAI, Azure Foundry, DeepSeek, and fal.ai |
+| `SenderPlugins/` | `XSender` and `InSender` (happy path, `SendAsync`, missing-branch, resilience); `IgSender` (happy path, resilience) |
+| `Services/` | `OpenAiService`, `AzureFoundryService`, `DeepSeekService`, `FalAiImageService`, `HybridAiService`, `AiServiceHelper`, `CryptoService`, `FeedService`, and `TimeProvider` unit tests |
+| `XPoster.Tests/Services/` | `KeyVaultService` unit tests |
 
 ### Running Tests
 
@@ -533,7 +568,7 @@ Key monitoring capabilities at a glance:
 - [x] Configuration externalization
 - [x] AI provider expansion
 - [ ] Retry & resilience for external HTTP calls [Issue #133](https://github.com/artcava/XPoster/issues/133)
-- [ ] Extension-point refactoring [see ADR-005](docs/analysis/ADR-005-capability-based-extension-points.md)
+- [ ] Extension-point refactoring — ADR-005 status: **Proposed** — implementation tracked in [Issue #134](https://github.com/artcava/XPoster/issues/134)
 - [ ] Test coverage gate at 80%
 
 ### 🎨 Phase 3: Admin Dashboard (TBD)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,8 +47,10 @@ XPoster is a **serverless, event-driven pipeline** that runs on a timer, selects
     │   Services         │
     ├────────────────────┤
     │ • AiServiceFactory │ ◄─── Resolves IAiService by AiProvider
+    │ • AiServiceHelper  │ ◄─── HTTP response parsing / 429 handling
     │ • Feed Service     │ ◄─── RSS Parser
     │ • Crypto Service   │ ◄─── CryptoPrices HTTP client
+    │ • KeyVaultService  │ ◄─── Azure Key Vault secret resolution
     └────────┬───────────┘
              │
              ▼
@@ -63,7 +65,7 @@ XPoster is a **serverless, event-driven pipeline** that runs on a timer, selects
 
 **System boundaries:**
 - **Inbound**: Azure Timer Trigger (no external HTTP surface in production)
-- **Outbound**: Configured AI provider API, Twitter/X API, LinkedIn API, Instagram Graph API, RSS feeds
+- **Outbound**: Configured AI provider API, Twitter/X API, LinkedIn API, Instagram Graph API, RSS feeds, Azure Key Vault
 - **Observability**: Azure Application Insights
 
 ---
@@ -99,15 +101,26 @@ Each orchestrator extends `BaseOrchestrator` and encapsulates a specific **conte
 
 ### Services Layer — Shared Infrastructure
 
-Services are registered as singletons or transients in the DI container and are consumed by orchestrators:
+Services are registered as singletons or transients in the DI container and are consumed by orchestrators and sender plugins:
 
 - **AiServiceFactory**: resolves the correct `IAiService` implementation by `AiProvider` enum value. Supported providers: `OpenAi`, `Perplexity`, `AzureFoundry`, `DeepSeekWithFal`. The active provider is determined per slot by the `ScheduledOrchestrationProfile` and can be overridden globally via the `AiProvider` configuration key.
+- **AiServiceHelper**: a shared utility class used internally by AI service implementations (`DeepSeekService`, `FalAiImageService`, and others). It encapsulates HTTP response parsing logic and rate-limit (HTTP 429) handling, keeping individual service classes focused on their provider-specific contracts.
 - **FeedService**: RSS parser with in-memory caching and deduplication; exposes a clean `IEnumerable<FeedItem>` contract.
 - **CryptoService**: thin HTTP client that polls `cryptoprices.cc` to retrieve the current market price for a given cryptocurrency symbol. Returns `0` on failure to allow graceful degradation in orchestrators.
+- **KeyVaultService** (`IKeyVaultService`): wraps `Azure.Security.KeyVault.Secrets` to retrieve OAuth tokens and API secrets from Azure Key Vault at runtime. Used by `XSender` and `InSender` to resolve platform credentials without storing secrets in application settings. Uses `DefaultAzureCredential`, so it transparently leverages the Function App's Managed Identity in production.
+
+**AI Provider Services** (consumed via `IAiService` abstraction):
+- **OpenAiService**: bridges `Microsoft.Extensions.AI` to the OpenAI / Azure OpenAI endpoint for both text and image generation.
+- **AzureFoundryService**: bridges `Microsoft.Extensions.AI` to an Azure AI Foundry deployment.
+- **DeepSeekService**: direct HTTP client to the DeepSeek API (`api.deepseek.com/v1`), OpenAI-compatible. Used standalone or as the text leg of `HybridAiService`.
+- **FalAiImageService**: HTTP client to the fal.ai API for FLUX.2 Turbo image generation. Used standalone or as the image leg of `HybridAiService`.
+- **HybridAiService**: composes `DeepSeekService` (text) and `FalAiImageService` (image) behind a single `IAiService` contract, enabling the `DeepSeekWithFal` provider option. It introduces no additional API surface and is the only consumer of both inner services.
 
 ### Sender Plugins — Platform Abstraction
 
 Each sender implements `ISender`, which exposes `Task<bool> SendAsync(Post post)` and `int MessageMaxLength`. Senders are **exclusively responsible for platform-specific serialisation and API communication**; they receive a fully-formed `Post` and return a success/failure signal. This contract guarantees that orchestrators never reference platform SDKs directly.
+
+Senders that require OAuth tokens not available in plain application settings (`XSender`, `InSender`) resolve them at runtime via `IKeyVaultService`.
 
 ---
 
@@ -160,7 +173,7 @@ Each ADR is maintained as a standalone document in [`docs/analysis/`](analysis/)
 | [ADR-002](analysis/ADR-002-strategy-pattern-generators.md) | Strategy Pattern for Content Orchestrators | Accepted |
 | [ADR-003](analysis/ADR-003-plugin-pattern-senders.md) | Plugin Pattern for Senders | Accepted |
 | [ADR-004](analysis/ADR-004-provider-agnostic-ai.md) | Provider-Agnostic AI Integration | Accepted |
-| [ADR-005](analysis/ADR-005-capability-based-extension-points.md) | Capability-based Extension Points | Proposed |
+| [ADR-005](analysis/ADR-005-capability-based-extension-points.md) | Capability-based Extension Points | **Proposed** — implementation tracked in [Issue #134](https://github.com/artcava/XPoster/issues/134) |
 
 ---
 
@@ -202,6 +215,7 @@ sequenceDiagram
     participant AI as IAiService<br/>(resolved by AiProvider)
     participant Feed as FeedService<br/>(RSS)
     participant Crypto as CryptoService<br/>(cryptoprices.cc)
+    participant KV as KeyVaultService<br/>(Azure Key Vault)
     participant Sender as ISender<br/>(X / LinkedIn / Instagram)
     participant Platform as Social Platform API
 
@@ -235,6 +249,8 @@ sequenceDiagram
         Fn->>Fn: Log skip, exit
     else Post is valid
         Fn->>Sender: SendAsync(post)
+        Sender->>KV: ResolveSecretAsync(key)
+        KV-->>Sender: OAuth token / API secret
         Sender->>Platform: HTTP API call
         Platform-->>Sender: 200 OK / error
         Sender-->>Fn: true / false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,10 @@
 # Configuration Reference
 
-All configuration is passed via environment variables — locally in `src/local.settings.json`, in production via Azure App Settings (or Key Vault references).
+All configuration is passed via environment variables — locally in `src/local.settings.json`, in production via Azure App Settings.
 
 The file [`src/local.settings.json.example`](../src/local.settings.json.example) is the canonical starting template: copy it to `src/local.settings.json`, fill in the empty strings, and the function is ready to run locally.
+
+> ⚠️ Sender credentials (Twitter/X, LinkedIn, Instagram) are **no longer configured via environment variables**. They are resolved at runtime by `KeyVaultService` directly from Azure Key Vault. See the [Key Vault](#key-vault) section below.
 
 ---
 
@@ -11,8 +13,7 @@ The file [`src/local.settings.json.example`](../src/local.settings.json.example)
 For a minimal local setup with the default provider (`OpenAi`) you need at minimum:
 
 - [ ] `AzureWebJobsStorage` — Azurite or a real Storage Account connection string
-- [ ] `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`
-- [ ] `IN_ACCESS_TOKEN` + one of `IN_OWNER` / `IN_ORG_ID`
+- [ ] `KEYVAULT_URI` — URI of the Azure Key Vault instance holding all sender credentials
 - [ ] `OpenAI__ApiKey`
 - [ ] (Optional) `APPLICATIONINSIGHTS_CONNECTION_STRING` for local telemetry
 
@@ -20,6 +21,8 @@ For the `DeepSeekWithFal` provider (HybridAiService), replace the OpenAI block w
 
 - [ ] `DeepSeek__ApiKey`
 - [ ] `FalAi__ApiKey`
+
+> 💡 For local development, run `az login` before starting the function. `KeyVaultService` uses `DefaultAzureCredential`, which picks up your Azure CLI session automatically.
 
 ---
 
@@ -35,7 +38,6 @@ The file below mirrors [`src/local.settings.json.example`](../src/local.settings
     // ── Azure Functions Runtime ──────────────────────────────────────────
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     // Use Azurite (local emulator) or a real Storage Account connection string.
-    // Production example: "DefaultEndpointsProtocol=https;AccountName=...;AccountKey=...;EndpointSuffix=core.windows.net"
 
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     // Required by the .NET 8 isolated worker model. Do not change.
@@ -50,45 +52,23 @@ The file below mirrors [`src/local.settings.json.example`](../src/local.settings
     "AiProvider": "OpenAi",
     // Selects the IAiService implementation injected into AI-enabled orchestrators.
     // Supported values: OpenAi | AzureFoundry | DeepSeekWithFal
-    // Only the configuration block that matches this value is required at runtime.
 
-    // ── Twitter / X ──────────────────────────────────────────────────────
-    "X_API_KEY": "",
-    // Twitter App Consumer Key. Obtain from developer.twitter.com > Your App > Keys and Tokens.
-    // The app must have Read and Write permissions.
-
-    "X_API_SECRET": "",
-    // Twitter App Consumer Secret (same location as above).
-
-    "X_ACCESS_TOKEN": "",
-    // User Access Token (OAuth 1.0a). Generated per-user from the developer portal.
-
-    "X_ACCESS_TOKEN_SECRET": "",
-    // User Access Token Secret (OAuth 1.0a).
-
-    // ── LinkedIn ─────────────────────────────────────────────────────────
-    "IN_ACCESS_TOKEN": "",
-    // LinkedIn OAuth 2.0 access token. Obtain from developer.linkedin.com > OAuth credentials.
-    // IMPORTANT: expires every 60 days — manual rotation is currently required.
-    // See Roadmap for the automated refresh milestone.
-
-    "IN_OWNER": "",
-    // Numeric LinkedIn person ID of the account that will author posts (e.g. "123456789").
-    // Resolve via: GET https://api.linkedin.com/v2/userinfo
-    // Posts are published as urn:li:person:{IN_OWNER}. Ignored when IN_ORG_ID is set.
-
-    "IN_ORG_ID": "",
-    // Numeric LinkedIn organization ID for publishing on behalf of a company page (e.g. "98765432").
-    // When set, takes precedence over IN_OWNER. Posts are published as urn:li:organization:{IN_ORG_ID}.
-    // Provide exactly ONE of IN_OWNER or IN_ORG_ID.
-
-    // ── Instagram (currently disabled — see issue #72) ────────────────────
-    "IG_ACCESS_TOKEN": "",
-    // Long-lived Instagram Graph API access token.
-    // These keys are read by IgSender but the slot is disabled in OrchestratorFactory.
-
-    "IG_ACCOUNT_ID": "",
-    // Numeric Instagram Business Account ID used in Graph API calls.
+    // ── Key Vault ────────────────────────────────────────────────────────
+    "KEYVAULT_URI": "https://<your-keyvault-name>.vault.azure.net/",
+    // URI of the Azure Key Vault instance holding all sender OAuth credentials.
+    // Local dev: run `az login` — DefaultAzureCredential picks up your CLI session.
+    // Azure deployment: Managed Identity handles authentication automatically.
+    //
+    // Required secrets in Key Vault (exact casing enforced):
+    //   XApiKey               — X (Twitter) API key
+    //   XApiSecret            — X (Twitter) API secret
+    //   XAccessToken          — X (Twitter) access token
+    //   XAccessTokenSecret    — X (Twitter) access token secret
+    //   LinkedInAccessToken   — LinkedIn OAuth 2.0 Bearer token
+    //   LinkedInOwnerCode     — LinkedIn person/owner ID
+    //   LinkedInOrgId         — LinkedIn organization ID (optional; org posts)
+    //   IgAccessToken         — Instagram Graph API access token
+    //   IgAccountId           — Instagram account ID
 
     // ══ AI — OpenAI (AiProvider = "OpenAi") ═════════════════════════════
     "OpenAI__ApiKey": "",
@@ -96,68 +76,29 @@ The file below mirrors [`src/local.settings.json.example`](../src/local.settings
 
     "OpenAI__ChatEndpoint": "https://api.openai.com/v1/chat/completions",
     // Chat Completions API URL. Override to point at an Azure OpenAI or other
-    // OpenAI-compatible endpoint (e.g. https://<resource>.openai.azure.com/...).
+    // OpenAI-compatible endpoint.
 
     "OpenAI__ChatModel": "gpt-4.1-nano",
-    // Model used for text summarisation and image prompt generation.
-
     "OpenAI__SummaryTemperature": "0.5",
-    // Temperature for summary generation (0.0–2.0). Lower = more deterministic.
-
     "OpenAI__SummaryMaxTokensPerChar": "5",
-    // Divisor to convert a character budget to max_tokens (budget ÷ value).
-
     "OpenAI__SummarySafetyMarginChars": "50",
-    // Character margin subtracted from the platform character limit before
-    // the {MaxChars} placeholder is passed to the prompt.
-
     "OpenAI__SummarySystemPromptTemplate": "You are an assistant that summarizes text concisely. It's very important that you keep summaries under {MaxChars} characters.",
-    // System prompt for summarisation. Supports {MaxChars} placeholder.
-
     "OpenAI__SummaryUserPromptTemplate": "Summarize this text in a few sentences. text: {Text}",
-    // User prompt for summarisation. Supports {Text} placeholder.
-
     "OpenAI__ImageEndpoint": "https://api.openai.com/v1/images/generations",
-    // Image Generations API URL.
-
     "OpenAI__ImageModel": "gpt-image-1.5",
-    // Model used for image generation (e.g. "gpt-image-1.5", "dall-e-3").
-
     "OpenAI__ImageSize": "1024x1024",
-    // Output image dimensions. Supported values depend on the model
-    // (e.g. "1024x1024", "1792x1024", "1024x1792").
-
     "OpenAI__ImageCount": "1",
-    // Number of images to generate per request.
-
     "OpenAI__ImagePromptSystemTemplate": "You are an assistant that generates image prompts for an AI image generation model based on text summaries. Create a concise, vivid prompt in English that reflects the summary's content, includes a Bitcoin-related element (e.g., a coin), and avoids text, signs, or words in the image. Respect content policy for generating images.",
-    // System prompt for image-prompt generation. No placeholders.
-
     "OpenAI__ImagePromptUserTemplate": "Generate an image prompt based on this summary: {Summary}",
-    // User prompt for image-prompt generation. Supports {Summary} placeholder.
-
     "OpenAI__ImagePromptMaxTokens": "60",
-    // Max tokens for image-prompt generation requests.
-
     "OpenAI__ImagePromptTemperature": "0.7",
-    // Temperature for image-prompt generation (0.0–2.0). Higher = more creative prompts.
 
     // ══ AI — Azure AI Foundry (AiProvider = "AzureFoundry") ══════════════
     "AzureFoundry__Endpoint": "",
-    // Azure OpenAI resource endpoint, e.g. https://<resource>.openai.azure.com/
-
     "AzureFoundry__ApiKey": "",
-    // Azure OpenAI resource key (or leave empty to use Managed Identity).
-
     "AzureFoundry__DeploymentName": "",
-    // Chat deployment name as configured in Azure AI Foundry (e.g. "gpt-4o-mini").
-
     "AzureFoundry__ImageDeploymentName": "",
-    // Image generation deployment name (e.g. "dall-e-3").
-
     "AzureFoundry__ApiVersion": "2024-02-01",
-    // Azure OpenAI REST API version.
-
     "AzureFoundry__SummaryTemperature": "0.5",
     "AzureFoundry__SummaryMaxTokensPerChar": "5",
     "AzureFoundry__SummarySafetyMarginChars": "50",
@@ -167,18 +108,11 @@ The file below mirrors [`src/local.settings.json.example`](../src/local.settings
     "AzureFoundry__ImagePromptUserTemplate": "Generate an image prompt based on this summary: {Summary}",
     "AzureFoundry__ImagePromptMaxTokens": "60",
     "AzureFoundry__ImagePromptTemperature": "0.7",
-    // Same semantics as OpenAI__ equivalents; see above for descriptions.
 
     // ══ AI — DeepSeek (AiProvider = "DeepSeekWithFal", text half) ═════════
     "DeepSeek__Endpoint": "https://api.deepseek.com",
-    // DeepSeek API base URL. Keep the default unless using a custom proxy.
-
     "DeepSeek__ApiKey": "",
-    // DeepSeek API key. Obtain from platform.deepseek.com > API Keys.
-
     "DeepSeek__DeploymentName": "deepseek-chat",
-    // DeepSeek model name (e.g. "deepseek-chat", "deepseek-reasoner").
-
     "DeepSeek__SummaryTemperature": "0.5",
     "DeepSeek__SummaryMaxTokensPerChar": "5",
     "DeepSeek__SummarySafetyMarginChars": "50",
@@ -191,27 +125,14 @@ The file below mirrors [`src/local.settings.json.example`](../src/local.settings
 
     // ══ AI — fal.ai (AiProvider = "DeepSeekWithFal", image half) ══════════
     "FalAi__ApiKey": "",
-    // fal.ai API key. Obtain from fal.ai/dashboard > API Keys.
-
     "FalAi__ModelId": "fal-ai/flux/schnell",
-    // fal.ai model identifier.
-    // "fal-ai/flux/schnell" is optimised for speed (default).
-    // Use "fal-ai/flux-pro" for higher-quality output at increased cost.
-
     "FalAi__ImageSize": "landscape_4_3",
-    // Named size preset accepted by the fal.ai API.
-    // Supported: landscape_4_3 | square | portrait_4_3 | landscape_16_9
-
     "FalAi__NumInferenceSteps": "4",
-    // Number of diffusion inference steps. Lower = faster and cheaper; higher = better quality.
-    // Range: 1–50 (FLUX Schnell is tuned for 1–4 steps).
 
     // ── Observability ─────────────────────────────────────────────────────
     "APPLICATIONINSIGHTS_CONNECTION_STRING": ""
     // Application Insights connection string.
     // When present, the isolated worker SDK automatically registers the telemetry pipeline.
-    // Format: "InstrumentationKey=<key>;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/"
-    // Leave empty to disable telemetry locally.
   }
 }
 ```
@@ -262,39 +183,56 @@ The file below mirrors [`src/local.settings.json.example`](../src/local.settings
 
 ---
 
-## Twitter / X
+## Key Vault
 
-Obtain all four values from [developer.twitter.com](https://developer.twitter.com) → **Your App** → **Keys and Tokens**. The app must have **Read and Write** permissions.
-
-| Variable | Type | Required | Description |
-|---|---|---|---|
-| `X_API_KEY` | string | ✅ Yes | Twitter App API Key (Consumer Key). |
-| `X_API_SECRET` | string | ✅ Yes | Twitter App API Secret (Consumer Secret). |
-| `X_ACCESS_TOKEN` | string | ✅ Yes | User Access Token (OAuth 1.0a). |
-| `X_ACCESS_TOKEN_SECRET` | string | ✅ Yes | User Access Token Secret (OAuth 1.0a). |
-
----
-
-## LinkedIn
+All sender OAuth credentials (Twitter/X, LinkedIn, Instagram) are resolved at runtime by `KeyVaultService` (`IKeyVaultService`) directly from Azure Key Vault. They are **not** stored in environment variables or App Settings.
 
 | Variable | Type | Required | Description |
 |---|---|---|---|
-| `IN_ACCESS_TOKEN` | string | ✅ Yes | LinkedIn OAuth 2.0 access token. Obtain from [LinkedIn Developer Portal](https://developer.linkedin.com) → OAuth credentials. **Expires every 60 days** — manual rotation is currently required. |
-| `IN_OWNER` | string | ⚠️ One of `IN_OWNER` / `IN_ORG_ID` | Numeric LinkedIn person ID of the account that will author posts (e.g. `123456789`). Resolve via `GET https://api.linkedin.com/v2/userinfo`. Posts are published as `urn:li:person:{IN_OWNER}`. Ignored when `IN_ORG_ID` is set. |
-| `IN_ORG_ID` | string | ⚠️ One of `IN_OWNER` / `IN_ORG_ID` | Numeric LinkedIn organization ID for publishing on behalf of a company page (e.g. `98765432`). When set, takes precedence over `IN_OWNER`. Posts are published as `urn:li:organization:{IN_ORG_ID}`. |
+| `KEYVAULT_URI` | string | ✅ Yes | Full URI of the Azure Key Vault instance, e.g. `https://<vault-name>.vault.azure.net/`. |
 
-> ⚠️ LinkedIn token refresh is currently limited to organization accounts (`IN_ORG_ID`). Personal member accounts require manual renewal every 60 days. See the [Roadmap](../README.md#roadmap) for the automated refresh milestone.
+### Authentication
 
----
+`KeyVaultService` uses `DefaultAzureCredential` from `Azure.Identity`, which resolves credentials in the following order:
 
-## Instagram
+| Environment | Credential used |
+|---|---|
+| Local development | Azure CLI session (`az login`) |
+| Azure (production) | Function App Managed Identity (no secrets required) |
 
-> ⚠️ Instagram publishing is **not yet active in production**. These variables are read by `IgSender` but the slot is disabled in `OrchestratorFactory`. See issue [#72](https://github.com/artcava/XPoster/issues/72) for the full enablement checklist.
+For local development, ensure the identity used with `az login` has the **Key Vault Secrets User** role on the vault.
 
-| Variable | Type | Required | Description |
-|---|---|---|---|
-| `IG_ACCESS_TOKEN` | string | ✅ Yes (when enabled) | Long-lived Instagram Graph API access token. |
-| `IG_ACCOUNT_ID` | string | ✅ Yes (when enabled) | Numeric Instagram Business Account ID used in Graph API calls. |
+### Required Secrets in Key Vault
+
+Secret names are case-sensitive. The following secrets must be present in the vault:
+
+#### Twitter / X
+
+| Secret name | Description |
+|---|---|
+| `XApiKey` | Twitter App API Key (Consumer Key). Obtain from [developer.twitter.com](https://developer.twitter.com) → Your App → Keys and Tokens. The app must have **Read and Write** permissions. |
+| `XApiSecret` | Twitter App API Secret (Consumer Secret). |
+| `XAccessToken` | User Access Token (OAuth 1.0a). |
+| `XAccessTokenSecret` | User Access Token Secret (OAuth 1.0a). |
+
+#### LinkedIn
+
+| Secret name | Required | Description |
+|---|---|---|
+| `LinkedInAccessToken` | ✅ Yes | LinkedIn OAuth 2.0 access token. Obtain from [LinkedIn Developer Portal](https://developer.linkedin.com) → OAuth credentials. **Expires every 60 days** — manual rotation is currently required. |
+| `LinkedInOwnerCode` | ⚠️ One of `LinkedInOwnerCode` / `LinkedInOrgId` | Numeric LinkedIn person ID of the account that will author posts (e.g. `123456789`). Resolve via `GET https://api.linkedin.com/v2/userinfo`. Posts are published as `urn:li:person:{id}`. Ignored when `LinkedInOrgId` is set. |
+| `LinkedInOrgId` | ⚠️ One of `LinkedInOwnerCode` / `LinkedInOrgId` | Numeric LinkedIn organization ID for publishing on behalf of a company page (e.g. `98765432`). When set, takes precedence over `LinkedInOwnerCode`. Posts are published as `urn:li:organization:{id}`. |
+
+> ⚠️ LinkedIn token refresh is currently limited to organization accounts. Personal member accounts require manual renewal every 60 days. See the [Roadmap](../README.md#roadmap) for the automated refresh milestone.
+
+#### Instagram
+
+> ⚠️ Instagram publishing is **not yet active in production**. These secrets are read by `IgSender` but the slot is disabled in `OrchestratorFactory`. See issue [#72](https://github.com/artcava/XPoster/issues/72) for the full enablement checklist.
+
+| Secret name | Description |
+|---|---|
+| `IgAccessToken` | Long-lived Instagram Graph API access token. |
+| `IgAccountId` | Numeric Instagram Business Account ID used in Graph API calls. |
 
 ---
 
@@ -420,16 +358,6 @@ Configuration bound from the `AzureFoundry` prefix using double-underscore notat
 
 - Never commit `local.settings.json` — it is listed in `.gitignore`.
 - Use [`src/local.settings.json.example`](../src/local.settings.json.example) as the starting template; it contains no real secrets.
+- Sender credentials live exclusively in Azure Key Vault and are never stored as environment variables or App Settings, in any environment.
 - For CI/CD, store secrets as **GitHub Actions Secrets**; never embed them in workflow YAML files.
-- In production, consider using **Azure Key Vault references** in App Settings to avoid storing secrets as plain-text values in the portal.
-
----
-
-## Future / Planned
-
-The following keys are reserved for future features and are not read by any code in the current version.
-
-| Key | Notes |
-|---|---|
-| `LINKEDIN_CLIENT_ID` / `LINKEDIN_CLIENT_SECRET` | Required for automated LinkedIn token refresh (OAuth 2.0 PKCE flow — planned). |
-| `KEYVAULT_URI` | Azure Key Vault integration for secrets management (planned). |
+- In production, the Function App Managed Identity must be granted the **Key Vault Secrets User** role on the vault — no manual credential management is required.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ This guide walks you through cloning, configuring, and running XPoster locally f
 |---|---|---|
 | .NET SDK | 8.0+ | [Download](https://dotnet.microsoft.com/download/dotnet/8.0) |
 | Azure Functions Core Tools | v4 | [Install](https://docs.microsoft.com/azure/azure-functions/functions-run-local) |
-| Visual Studio / VS Code | Latest | — |
+| Visual Studio Code | Latest | [Download](https://code.visualstudio.com/download) |
 | Azure Account | Active subscription | [Sign up](https://azure.microsoft.com/free/) |
 | Azure OpenAI Service | GPT-4 + DALL-E 3 deployments | [Docs](https://learn.microsoft.com/azure/cognitive-services/openai/) |
 


### PR DESCRIPTION
## Summary

This PR addresses a set of documentation inconsistencies accumulated after the introduction of `KeyVaultService` and the recent addition of new services (`HybridAiService`, `DeepSeekService`, `FalAiImageService`, `AiServiceHelper`, `KeyVaultService`).

---

## Changes

### `README.md`
- Added `KeyVaultService` / `IKeyVaultService` to the architecture diagram and description
- Added `AiServiceHelper` to the architecture diagram and services table
- Added `HybridAiService` disambiguation note (independent services composed via `HybridAiService`)
- Added `Microsoft.Extensions.Http.Resilience` and `Azure.Security.KeyVault.Secrets` to the NuGet table; clarified why `Microsoft.Extensions.Http` is not pinned explicitly
- Added `KEY_VAULT_URI` to the Configuration group table
- Updated test tree with all missing test files (`ResilienceTestHelpers`, `AiServiceHelperTests`, `DeepSeekServiceTests`, `FalAiImageServiceTests`, `HybridAiServiceTests`, `KeyVaultServiceTests`)
- Added integration setup guides warning with reference to issues #130, #131, #132
- Added `ADR-005` status (**Proposed**) with link to issue #134
- Added **Branching Strategy** table (`develop` = active development, `master` = production)

### `docs/getting-started.md`
- Removed `Visual Studio` (full IDE) from prerequisites
- Kept only **Visual Studio Code** with the official Microsoft download link

### `docs/configuration.md` *(major revision)*
- Removed `Twitter/X`, `LinkedIn`, `Instagram` environment variable sections — sender credentials are now resolved exclusively from Azure Key Vault via `KeyVaultService`
- Removed sender variables (`X_*`, `IN_*`, `IG_*`) from the `jsonc` example and Quick-Start checklist
- Added dedicated **Key Vault** section with:
  - `KEYVAULT_URI` variable table
  - `DefaultAzureCredential` authentication flow (CLI locally, Managed Identity in production)
  - Secret name tables per platform (Twitter/X, LinkedIn, Instagram) with obtaining instructions
- Removed `KEYVAULT_URI` from **Future / Planned** (now active) and dropped the entire section as no longer needed
- Updated Security Notes to reflect that sender credentials live exclusively in Key Vault

---

## Related Issues

- #130, #131, #132 — integration setup guide validation (referenced, not resolved)
- #134 — ADR-005 extension-point refactoring (referenced)
