### PR TITLE
Chore/update agents from generators to orchestrators

### DIFF
--- a/.github/agents/.net-architect.md
+++ b/.github/agents/.net-architect.md
@@ -18,7 +18,7 @@ XPoster is a .NET 8 Azure Functions v4 application using the isolated worker mod
 - Composition root: Program.cs
 - Function entrypoint: XFunction
 - Main patterns in use:
-  - Strategy pattern for generators
+  - Strategy pattern for orchestrators
   - Factory pattern for schedule-based selection
   - Plugin pattern for senders
 - Test stack: xUnit + Moq
@@ -27,7 +27,7 @@ XPoster is a .NET 8 Azure Functions v4 application using the isolated worker mod
 
 - Keep function entrypoints thin.
 - Preserve current Strategy + Factory + Plugin model.
-- Keep orchestration in function classes and business logic in generators, services, and senders.
+- Keep orchestration in function classes and business logic in orchestrators, services, and senders.
 - Prefer extending existing abstractions over introducing parallel architectural styles.
 
 ## Primary Responsibilities
@@ -62,16 +62,16 @@ XPoster is a .NET 8 Azure Functions v4 application using the isolated worker mod
 - Reuse existing abstractions and registrations where possible.
 - Keep service lifetimes intentional and consistent with the repository.
 
-### Generators And Factory
+### Orchestrators And Factory
 
-- Keep generator selection centralized in GeneratorFactory.
+- Keep orchestrator selection centralized in OrchestratorFactory.
 - Any scheduling or slot mapping change must be reflected in tests.
-- Keep generators focused on content production flow.
+- Keep orchestrators focused on content production flow.
 
 ### Sender Plugins
 
 - Keep platform-specific publishing logic inside sender plugins.
-- Preserve sender boundaries: generators produce content, senders publish content.
+- Preserve sender boundaries: orchestrators produce content, senders publish content.
 - Keep sender constraints encapsulated in the sender implementation.
 
 ### External Integrations
@@ -87,7 +87,7 @@ XPoster is a .NET 8 Azure Functions v4 application using the isolated worker mod
 - Preserve Application Insights compatibility.
 - Ensure logs help diagnose:
   - schedule decisions
-  - selected generator/sender
+  - selected orchestrator/sender
   - generation failures
   - publish failures
   - external API failures
@@ -98,7 +98,7 @@ Use subagents only when they reduce ambiguity or separate concerns cleanly.
 
 ### Delegate to C# Expert when
 
-- The task is mainly implementation in generators, services, senders, or Function code.
+- The task is mainly implementation in orchestrators, services, senders, or Function code.
 - The task is a focused bug fix or feature change in C#.
 
 ### Delegate to QA when
@@ -129,7 +129,7 @@ Prefer these repository anchors:
 - Program.cs for composition root
 - XFunction.cs for trigger orchestration
 - ARCHITECTURE.md for design intent
-- GeneratorFactory and generator implementations for behavior routing
+- OrchestratorFactory and orchestrator implementations for behavior routing
 - SenderPlugins for platform boundaries
 - tests/ for current test conventions
 

--- a/.github/agents/c_sharp_expert.md
+++ b/.github/agents/c_sharp_expert.md
@@ -13,15 +13,15 @@ This agent works on XPoster. Apply these rules before any generic .NET guidance.
 - It is a timer-triggered automation pipeline.
 - Business behavior is split across:
   - function orchestration
-  - generators
+  - orchestrators
   - services
   - sender plugins
 
 ## Required Architecture Fit
 
 - Keep XFunction thin and orchestration-focused.
-- Keep generator selection in GeneratorFactory.
-- Keep content production in generators.
+- Keep orchestrator selection in OrchestratorFactory.
+- Keep content production in orchestrators.
 - Keep platform publishing in sender plugins.
 - Keep infrastructure wiring in Program.cs.
 - Reuse current abstractions before introducing new ones.
@@ -78,8 +78,8 @@ This agent works on XPoster. Apply these rules before any generic .NET guidance.
 - Prefer focused Arrange / Act / Assert tests.
 - Prioritize tests for:
   - XFunction orchestration behavior
-  - GeneratorFactory schedule mapping
-  - generator success/failure paths
+  - OrchestratorFactory schedule mapping
+  - orchestrator success/failure paths
   - sender success/failure behavior
   - service edge cases around external API responses
 

--- a/.github/agents/qa.md
+++ b/.github/agents/qa.md
@@ -15,7 +15,7 @@ XPoster is a .NET 8 Azure Functions v4 application using the isolated worker mod
 - Mocking library: Moq
 - Main validation targets:
   - function orchestration
-  - generator selection and scheduling
+  - orchestrator selection and scheduling
   - content generation behavior
   - sender plugin behavior
   - service behavior for external APIs
@@ -27,14 +27,14 @@ XPoster is a .NET 8 Azure Functions v4 application using the isolated worker mod
 - Verify failures are logged and surfaced as intended.
 - Verify disabled or no-op generator behavior is handled correctly.
 
-2. GeneratorFactory schedule mapping
-- Verify the correct generator/sender combination is selected for configured time slots.
+2. OrchestratorFactory schedule mapping
+- Verify the correct orchestrator/sender combination is selected for configured time slots.
 - Verify unmapped slots resolve safely.
 
-3. Generator behavior
-- Verify generation success and failure paths.
-- Verify null or invalid generation results are handled correctly.
-- Verify generator behavior stays independent from sender implementation details.
+3. Orchestrator behavior
+- Verify orchestrator success and failure paths.
+- Verify null or invalid orchestrator results are handled correctly.
+- Verify orchestrator behavior stays independent from sender implementation details.
 
 4. Sender plugin behavior
 - Verify platform-specific success/failure handling.


### PR DESCRIPTION
## Update agent terminology: Generators → Orchestrators

This PR updates the three agent instruction files to align terminology
with the current codebase, where `Generators` have been renamed to `Orchestrators`.

### Motivation

The agent files still referenced `Generator`/`GeneratorFactory` as the
canonical architectural term. Since the codebase refactoring, the correct
terms are `Orchestrator`/`OrchestratorFactory`. Keeping stale terminology
in agent instructions causes misdirection during AI-assisted development.

### Changes

| File | Updates |
|---|---|
| `.github/agents/.net-architect.md` | 8 occurrences: patterns list, architecture rules, section header, sender boundary description, observability log fields, delegation protocol, source of truth anchors |
| `.github/agents/c_sharp_expert.md` | 4 occurrences: project context layers, architecture fit rules, testing guidance targets |
| `.github/agents/qa.md` | 2 occurrences: validation targets list, factory schedule mapping section |

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / agent instructions update
- [ ] Refactor

### Notes

- No runtime behavior is affected.
- No C# code has been modified.
- All changes are terminology-only, scoped to agent instruction files.