### PR TITLE
fix: align Azure Foundry image generation API call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -269,5 +269,6 @@ __pycache__/
 *.lscache
 
 # Microsoft Azurite Dev Spaces
+.azurite/
 __blobstorage__/*
 __azurite_*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    // Azurite local storage emulator — required for local Function development.
+    "Azurite.azurite",
+    // Azure Functions extension — provides func host integration and local debugging.
+    "ms-azuretools.vscode-azurefunctions",
+    // C# Dev Kit — language server, test runner, and solution explorer.
+    "ms-dotnettools.csdevkit"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to .NET Functions",
+      "type": "coreclr",
+      "request": "attach",
+      // preLaunchTask starts Azurite → builds src → starts func host in sequence.
+      // The debugger attaches once the host process is ready.
+      "preLaunchTask": "func: start",
+      "processId": "${command:pickProcess}"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,14 +1,12 @@
 {
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "name": "Attach to .NET Functions",
-      "type": "coreclr",
-      "request": "attach",
-      // preLaunchTask starts Azurite → builds src → starts func host in sequence.
-      // The debugger attaches once the host process is ready.
-      "preLaunchTask": "func: start",
-      "processId": "${command:pickProcess}"
-    }
-  ]
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to .NET Functions",
+            "type": "coreclr",
+            "request": "attach",
+            "preLaunchTask": "func: host start",
+            "processId": "${command:azureFunctions.pickProcess}"
+        }
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,95 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      // Starts the Azurite local storage emulator.
+      // Required before the Azure Functions host can start.
+      "label": "azurite: start",
+      "type": "shell",
+      "command": "azurite",
+      "args": [
+        "--silent",
+        "--location",
+        "${workspaceFolder}/.azurite",
+        "--debug",
+        "${workspaceFolder}/.azurite/debug.log"
+      ],
+      "isBackground": true,
+      "problemMatcher": {
+        "pattern": [
+          {
+            "regexp": ".",
+            "file": 1,
+            "location": 2,
+            "message": 3
+          }
+        ],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "Azurite",
+          "endsPattern": "Azurite Blob service is successfully listening"
+        }
+      },
+      "presentation": {
+        "reveal": "silent",
+        "panel": "dedicated",
+        "group": "infrastructure"
+      }
+    },
+    {
+      // Builds the Azure Functions project in the src/ folder.
+      "label": "build: src",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "${workspaceFolder}/src",
+        "--configuration",
+        "Debug",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "type": "process",
+      "group": "build",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared",
+        "group": "infrastructure"
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      // Starts the Azure Functions host.
+      // Depends on Azurite being ready and the project being built.
+      "label": "func: start",
+      "type": "shell",
+      "command": "func",
+      "args": ["start", "--dotnet-isolated-debug"],
+      "options": {
+        "cwd": "${workspaceFolder}/src"
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "pattern": [
+          {
+            "regexp": ".",
+            "file": 1,
+            "location": 2,
+            "message": 3
+          }
+        ],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "Azure Functions Core Tools",
+          "endsPattern": "Host started"
+        }
+      },
+      "dependsOn": ["azurite: start", "build: src"],
+      "dependsOrder": "sequence",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "infrastructure"
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,95 +1,118 @@
 {
-  "version": "2.0.0",
-  "tasks": [
-    {
-      // Starts the Azurite local storage emulator.
-      // Required before the Azure Functions host can start.
-      "label": "azurite: start",
-      "type": "shell",
-      "command": "azurite",
-      "args": [
-        "--silent",
-        "--location",
-        "${workspaceFolder}/.azurite",
-        "--debug",
-        "${workspaceFolder}/.azurite/debug.log"
-      ],
-      "isBackground": true,
-      "problemMatcher": {
-        "pattern": [
-          {
-            "regexp": ".",
-            "file": 1,
-            "location": 2,
-            "message": 3
-          }
-        ],
-        "background": {
-          "activeOnStart": true,
-          "beginsPattern": "Azurite",
-          "endsPattern": "Azurite Blob service is successfully listening"
-        }
-      },
-      "presentation": {
-        "reveal": "silent",
-        "panel": "dedicated",
-        "group": "infrastructure"
-      }
-    },
-    {
-      // Builds the Azure Functions project in the src/ folder.
-      "label": "build: src",
-      "command": "dotnet",
-      "args": [
-        "build",
-        "${workspaceFolder}/src",
-        "--configuration",
-        "Debug",
-        "/property:GenerateFullPaths=true",
-        "/consoleloggerparameters:NoSummary"
-      ],
-      "type": "process",
-      "group": "build",
-      "presentation": {
-        "reveal": "silent",
-        "panel": "shared",
-        "group": "infrastructure"
-      },
-      "problemMatcher": "$msCompile"
-    },
-    {
-      // Starts the Azure Functions host.
-      // Depends on Azurite being ready and the project being built.
-      "label": "func: start",
-      "type": "shell",
-      "command": "func",
-      "args": ["start", "--dotnet-isolated-debug"],
-      "options": {
-        "cwd": "${workspaceFolder}/src"
-      },
-      "isBackground": true,
-      "problemMatcher": {
-        "pattern": [
-          {
-            "regexp": ".",
-            "file": 1,
-            "location": 2,
-            "message": 3
-          }
-        ],
-        "background": {
-          "activeOnStart": true,
-          "beginsPattern": "Azure Functions Core Tools",
-          "endsPattern": "Host started"
-        }
-      },
-      "dependsOn": ["azurite: start", "build: src"],
-      "dependsOrder": "sequence",
-      "presentation": {
-        "reveal": "always",
-        "panel": "dedicated",
-        "group": "infrastructure"
-      }
-    }
-  ]
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "clean (functions)",
+			"command": "dotnet",
+			"args": [
+				"clean",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"problemMatcher": "$msCompile",
+			"options": {
+				"cwd": "${workspaceFolder}/src"
+			}
+		},
+		{
+			"label": "build (functions)",
+			"command": "dotnet",
+			"args": [
+				"build",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"dependsOn": "clean (functions)",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": "$msCompile",
+			"options": {
+				"cwd": "${workspaceFolder}/src"
+			}
+		},
+		{
+			"label": "clean release (functions)",
+			"command": "dotnet",
+			"args": [
+				"clean",
+				"--configuration",
+				"Release",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"problemMatcher": "$msCompile",
+			"options": {
+				"cwd": "${workspaceFolder}/src"
+			}
+		},
+		{
+			"label": "publish (functions)",
+			"command": "dotnet",
+			"args": [
+				"publish",
+				"--configuration",
+				"Release",
+				"/property:GenerateFullPaths=true",
+				"/consoleloggerparameters:NoSummary"
+			],
+			"type": "process",
+			"dependsOn": "clean release (functions)",
+			"problemMatcher": "$msCompile",
+			"options": {
+				"cwd": "${workspaceFolder}/src"
+			}
+		},
+		{
+			// Starts the Azurite local storage emulator.
+			// Required before the Azure Functions host can start.
+			"label": "azurite: start",
+			"type": "shell",
+			"command": "azurite",
+			"args": [
+				"--silent",
+				"--location",
+				"${workspaceFolder}/.azurite",
+				"--debug",
+				"${workspaceFolder}/.azurite/debug.log"
+			],
+			"isBackground": true,
+			"problemMatcher": {
+				"pattern": [
+					{
+						"regexp": ".",
+						"file": 1,
+						"location": 2,
+						"message": 3
+					}
+				],
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": "Azurite",
+					"endsPattern": "Azurite Blob service is successfully listening at http://127.0.0.1:10000"
+				}
+			},
+			"presentation": {
+				"reveal": "silent",
+				"panel": "dedicated",
+				"group": "infrastructure"
+			}
+		},
+		{
+			"label": "func: host start",
+			"type": "func",
+			"dependsOn": ["azurite: start", "build (functions)"],
+			"dependsOrder": "sequence",
+			"options": {
+				"cwd": "${workspaceFolder}/src/bin/Debug/net8.0"
+			},
+			"command": "host start",
+			"isBackground": true,
+			"problemMatcher": "$func-dotnet-watch"
+		}
+	]
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,7 +125,6 @@ The file below mirrors [`src/local.settings.json.example`](../src/local.settings
     "AzureFoundry__ApiKey": "",
     "AzureFoundry__DeploymentName": "",
     "AzureFoundry__ImageDeploymentName": "",
-    "AzureFoundry__ApiVersion": "2024-02-01",
     "AzureFoundry__SummaryTemperature": "0.5",
     "AzureFoundry__SummaryMaxTokensPerChar": "5",
     "AzureFoundry__SummarySafetyMarginChars": "50",
@@ -441,11 +440,10 @@ Configuration bound from the `AzureFoundry` prefix using double-underscore notat
 
 | Setting | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `AzureFoundry__Endpoint` | string | ✅ Yes | — | Azure OpenAI resource endpoint (e.g. `https://<resource>.openai.azure.com/`). |
-| `AzureFoundry__ApiKey` | string | ✅ Yes* | — | Azure OpenAI resource key. *Omit when using Managed Identity. |
+| `AzureFoundry__Endpoint` | string | ✅ Yes | — | Azure AI Foundry resource endpoint (e.g. `https://<resource>.services.ai.azure.com/openai/v1`). |
+| `AzureFoundry__ApiKey` | string | ✅ Yes* | — | Azure AI Foundry resource key. *Omit when using Managed Identity. |
 | `AzureFoundry__DeploymentName` | string | ✅ Yes | — | Chat deployment name as configured in Azure AI Foundry. |
 | `AzureFoundry__ImageDeploymentName` | string | ✅ Yes | — | Image generation deployment name. |
-| `AzureFoundry__ApiVersion` | string | No | `2024-02-01` | Azure OpenAI REST API version. |
 
 ### Tuning (same semantics as OpenAI)
 

--- a/docs/integrations/setup-azure-foundry.md
+++ b/docs/integrations/setup-azure-foundry.md
@@ -13,7 +13,7 @@ This guide explains how to provision Azure AI Foundry and configure XPoster to u
 2. Search for **Azure AI Foundry** and click **Create**.
 3. Choose subscription, resource group, region, and pricing tier.
 4. After deployment, open the resource and note:
-   - **Endpoint URL** (e.g. `https://<resource>.openai.azure.com`)
+   - **Endpoint URL** (e.g. `https://<resource>.services.ai.azure.com/openai/v1`)
    - **Key 1** (or Key 2)
 
 ## 2. Create a Project and Deploy Models
@@ -21,7 +21,7 @@ This guide explains how to provision Azure AI Foundry and configure XPoster to u
 1. Open [Azure AI Foundry Studio](https://ai.azure.com) for your resource.
 2. Create a project (or use an existing one).
 3. Deploy a **chat completion** model for summaries and prompt generation (e.g. `gpt-4o-mini`).
-4. Deploy an **image generation** model (e.g. `dall-e-3` or `gpt-image-1`).
+4. Deploy an **image generation** model (e.g. `dall-e-3` or `gpt-image-1.5`).
 5. Save both deployment names.
 
 Recommended mapping:
@@ -34,11 +34,10 @@ Collect these values from the Portal / Foundry Studio:
 
 | Parameter | Where to find it |
 |-----------|------------------|
-| `Endpoint` | Resource overview blade → Endpoint |
+| `Endpoint` | Resource overview blade → Endpoint (use the `/openai/v1` base URL) |
 | `ApiKey` | Resource overview blade → Keys and Endpoint → Key 1 |
 | `DeploymentName` | Foundry Studio → Deployments → chat model name |
 | `ImageDeploymentName` | Foundry Studio → Deployments → image model name |
-| `ApiVersion` | Azure OpenAI docs (default in XPoster: `2024-02-01`) |
 
 ## 4. Configure XPoster
 
@@ -48,11 +47,10 @@ Set these values in `src/local.settings.json` (local) or Azure App Settings (pro
 {
   "Values": {
     "AiProvider": "AzureFoundry",
-    "AzureFoundry__Endpoint": "https://<resource>.openai.azure.com",
+    "AzureFoundry__Endpoint": "https://<resource>.services.ai.azure.com/openai/v1",
     "AzureFoundry__ApiKey": "<secret>",
     "AzureFoundry__DeploymentName": "<chat-deployment>",
-    "AzureFoundry__ImageDeploymentName": "<image-deployment>",
-    "AzureFoundry__ApiVersion": "2024-02-01"
+    "AzureFoundry__ImageDeploymentName": "<image-deployment>"
   }
 }
 ```
@@ -85,11 +83,6 @@ If `AiProvider` is missing or invalid, XPoster falls back to the schedule defaul
 
 - Confirm `DeploymentName` and `ImageDeploymentName` match the exact names in Foundry Studio.
 - Check region and project alignment.
-
-### 400 Bad Request (API version)
-
-- Set `AzureFoundry__ApiVersion` to a version supported by your deployment.
-- Validate endpoint format (no trailing slash issues).
 
 ### 429 Too Many Requests
 

--- a/src/Implementation/OrchestratorFactory.cs
+++ b/src/Implementation/OrchestratorFactory.cs
@@ -114,20 +114,23 @@ public class OrchestratorFactory : IOrchestratorFactory
 
     private AiProvider ResolveAiProvider(AiProvider defaultProvider)
     {
+        // The profile's provider is always authoritative.
+        // IConfiguration is only a fallback when the profile does not specify one.
+        if (defaultProvider != AiProvider.None)
+            return defaultProvider;
+
         var configuredProvider = _configuration?["AiProvider"];
         if (string.IsNullOrWhiteSpace(configuredProvider))
         {
+            _log.LogWarning("No AiProvider specified in profile and no global fallback configured.");
             return defaultProvider;
         }
 
         if (Enum.TryParse<AiProvider>(configuredProvider, ignoreCase: true, out var parsedProvider))
-        {
             return parsedProvider;
-        }
 
-        _log.LogWarning("Invalid AiProvider value '{AiProvider}' in configuration. Falling back to {DefaultProvider}.",
-            configuredProvider,
-            defaultProvider);
+        _log.LogWarning("Invalid AiProvider value '{AiProvider}' in configuration. No fallback available.",
+            configuredProvider);
 
         return defaultProvider;
     }

--- a/src/Models/AzureFoundryOptions.cs
+++ b/src/Models/AzureFoundryOptions.cs
@@ -5,7 +5,7 @@ namespace XPoster.Models;
 /// </summary>
 public sealed class AzureFoundryOptions
 {
-    /// <summary>Gets or sets the Foundry endpoint base URL (for example, <c>https://resource-name.openai.azure.com</c>).</summary>
+    /// <summary>Gets or sets the Foundry endpoint base URL (for example, <c>https://resource-name.services.ai.azure.com/openai/v1</c>).</summary>
     public string Endpoint { get; set; } = string.Empty;
 
     /// <summary>Gets or sets the API key used for Foundry authentication.</summary>
@@ -16,9 +16,6 @@ public sealed class AzureFoundryOptions
 
     /// <summary>Gets or sets the image generation deployment name.</summary>
     public string ImageDeploymentName { get; set; } = string.Empty;
-
-    /// <summary>Gets or sets the REST API version.</summary>
-    public string ApiVersion { get; set; } = "2024-02-01";
 
     /// <summary>Gets or sets the temperature used for summary generation.</summary>
     public double SummaryTemperature { get; set; } = 0.5;

--- a/src/Services/AzureFoundryService.cs
+++ b/src/Services/AzureFoundryService.cs
@@ -134,8 +134,11 @@ public sealed class AzureFoundryService : IAiService
         return Array.Empty<byte>();
     }
 
+    // Azure AI Foundry /openai/v1 exposes a unified chat completions path.
+    // The deployment name is passed as `model` in the request body, so the URL
+    // does not include the deployment segment or an api-version query parameter.
     private string GetChatCompletionsEndpoint() =>
-        $"{_options.Endpoint.TrimEnd('/')}/openai/deployments/{Uri.EscapeDataString(_options.DeploymentName)}/chat/completions?api-version={Uri.EscapeDataString(_options.ApiVersion)}";
+        $"{_options.Endpoint.TrimEnd('/')}/chat/completions";
 
     // Azure AI Foundry /openai/v1 exposes a unified image generation path.
     // The deployment name is passed as `model` in the request body, so the URL
@@ -156,6 +159,7 @@ public sealed class AzureFoundryService : IAiService
 
         return new
         {
+            model = _options.DeploymentName,
             messages = new[]
             {
                 new { role = "system", content = systemContent },
@@ -173,6 +177,7 @@ public sealed class AzureFoundryService : IAiService
 
         return new
         {
+            model = _options.DeploymentName,
             messages = new[]
             {
                 new { role = "system", content = _options.ImagePromptSystemTemplate },

--- a/src/Services/AzureFoundryService.cs
+++ b/src/Services/AzureFoundryService.cs
@@ -66,8 +66,11 @@ public sealed class AzureFoundryService : IAiService
         if (string.IsNullOrWhiteSpace(prompt))
             return Array.Empty<byte>();
 
+        // Azure AI Foundry /openai/v1 expects the deployment name as `model` in the
+        // request body. The endpoint does not embed it in the URL path.
         var requestBody = new
         {
+            model = _options.ImageDeploymentName,
             prompt,
             n = 1,
             size = "1024x1024",
@@ -134,8 +137,11 @@ public sealed class AzureFoundryService : IAiService
     private string GetChatCompletionsEndpoint() =>
         $"{_options.Endpoint.TrimEnd('/')}/openai/deployments/{Uri.EscapeDataString(_options.DeploymentName)}/chat/completions?api-version={Uri.EscapeDataString(_options.ApiVersion)}";
 
+    // Azure AI Foundry /openai/v1 exposes a unified image generation path.
+    // The deployment name is passed as `model` in the request body, so the URL
+    // does not include the deployment segment or an api-version query parameter.
     private string GetImageGenerationEndpoint() =>
-        $"{_options.Endpoint.TrimEnd('/')}/openai/deployments/{Uri.EscapeDataString(_options.ImageDeploymentName)}/images/generations?api-version={Uri.EscapeDataString(_options.ApiVersion)}";
+        $"{_options.Endpoint.TrimEnd('/')}/images/generations";
 
     private object BuildSummaryPayload(string text, int messageMaxLength)
     {

--- a/src/Services/AzureFoundryService.cs
+++ b/src/Services/AzureFoundryService.cs
@@ -73,15 +73,18 @@ public sealed class AzureFoundryService : IAiService
             model = _options.ImageDeploymentName,
             prompt,
             n = 1,
-            size = "1024x1024",
-            response_format = "b64_json"
+            size = "1024x1024"
         };
 
         var response = await _client.PostAsJsonAsync(GetImageGenerationEndpoint(), requestBody, cancellationToken);
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger.LogError("Azure Foundry image generation failed with status code {StatusCode}", response.StatusCode);
+            var errorBody = await response.Content.ReadAsStringAsync();
+            _logger.LogError(
+                "Azure Foundry image generation failed with status {StatusCode}. Response: {ErrorBody}",
+                response.StatusCode,
+                errorBody);
             return Array.Empty<byte>();
         }
 

--- a/src/local.settings.json.example
+++ b/src/local.settings.json.example
@@ -83,7 +83,6 @@
     "AzureFoundry__ApiKey": "",
     "AzureFoundry__DeploymentName": "",
     "AzureFoundry__ImageDeploymentName": "",
-    "AzureFoundry__ApiVersion": "2024-02-01",
     "AzureFoundry__SummaryTemperature": "0.5",
     "AzureFoundry__SummaryMaxTokensPerChar": "5",
     "AzureFoundry__SummarySafetyMarginChars": "50",

--- a/tests/Models/AzureFoundryOptionsTests.cs
+++ b/tests/Models/AzureFoundryOptionsTests.cs
@@ -1,0 +1,63 @@
+using XPoster.Models;
+
+namespace XPoster.Tests.Models;
+
+/// <summary>
+/// Covers default values and shape of <see cref="AzureFoundryOptions"/>.
+/// Also acts as a regression guard: ApiVersion must not exist on this class
+/// because the Azure AI Foundry /openai/v1 endpoint does not require an api-version
+/// query parameter — the model is passed as the deployment name in the request body.
+/// </summary>
+public class AzureFoundryOptionsTests
+{
+    [Fact]
+    public void AzureFoundryOptions_Defaults_AreCorrect()
+    {
+        var options = new AzureFoundryOptions();
+
+        Assert.Equal(string.Empty, options.Endpoint);
+        Assert.Equal(string.Empty, options.ApiKey);
+        Assert.Equal(string.Empty, options.DeploymentName);
+        Assert.Equal(string.Empty, options.ImageDeploymentName);
+        Assert.Equal(0.5, options.SummaryTemperature);
+        Assert.Equal(5, options.SummaryMaxTokensPerChar);
+        Assert.Equal(50, options.SummarySafetyMarginChars);
+        Assert.Equal(60, options.ImagePromptMaxTokens);
+        Assert.Equal(0.7, options.ImagePromptTemperature);
+    }
+
+    [Fact]
+    public void AzureFoundryOptions_SummarySystemPromptTemplate_ContainsMaxCharsPlaceholder()
+    {
+        var options = new AzureFoundryOptions();
+        Assert.Contains("{MaxChars}", options.SummarySystemPromptTemplate);
+    }
+
+    [Fact]
+    public void AzureFoundryOptions_SummaryUserPromptTemplate_ContainsTextPlaceholder()
+    {
+        var options = new AzureFoundryOptions();
+        Assert.Contains("{Text}", options.SummaryUserPromptTemplate);
+    }
+
+    [Fact]
+    public void AzureFoundryOptions_ImagePromptUserTemplate_ContainsSummaryPlaceholder()
+    {
+        var options = new AzureFoundryOptions();
+        Assert.Contains("{Summary}", options.ImagePromptUserTemplate);
+    }
+
+    /// <summary>
+    /// Regression guard: ApiVersion must not exist on AzureFoundryOptions.
+    /// The Azure AI Foundry /openai/v1 endpoint does not use an api-version query
+    /// parameter; the deployment/model is passed in the request body instead.
+    /// </summary>
+    [Fact]
+    public void AzureFoundryOptions_DoesNotExpose_ApiVersionProperty()
+    {
+        var property = typeof(AzureFoundryOptions)
+            .GetProperty("ApiVersion", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+
+        Assert.Null(property);
+    }
+}

--- a/tests/Services/AzureFoundryServiceTests.cs
+++ b/tests/Services/AzureFoundryServiceTests.cs
@@ -63,7 +63,10 @@ public class AzureFoundryServiceTests
         handler.Protected().Verify(
             "SendAsync",
             Times.Once(),
-            ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Post && r.RequestUri!.AbsolutePath.Contains("/chat/completions", StringComparison.Ordinal)),
+            ItExpr.Is<HttpRequestMessage>(r =>
+                r.Method == HttpMethod.Post &&
+                r.RequestUri!.AbsolutePath.EndsWith("/chat/completions", StringComparison.Ordinal) &&
+                !r.RequestUri.AbsolutePath.Contains("/openai/deployments/", StringComparison.Ordinal)),
             ItExpr.IsAny<CancellationToken>());
     }
 
@@ -210,14 +213,11 @@ public class AzureFoundryServiceTests
 
     /// <summary>
     /// G5 — When b64_json is absent but a url is present, the service downloads from the url
-    /// and returns the bytes. In this test the url points to a second endpoint served by the
-    /// same mock handler, which returns a fixed byte payload.
+    /// and returns the bytes.
     /// </summary>
     [Fact]
     public async Task GenerateImageAsync_WhenB64JsonAbsentAndUrlPresent_DownloadsFromUrl()
     {
-        // The image download call is also intercepted by the same HttpClient/handler.
-        // We configure the handler to return the image bytes for any request.
         var imageBytes = new byte[] { 10, 20, 30 };
         var mock = new Mock<HttpMessageHandler>();
         mock.Protected()
@@ -227,8 +227,6 @@ public class AzureFoundryServiceTests
                 ItExpr.IsAny<CancellationToken>())
             .Returns<HttpRequestMessage, CancellationToken>((req, _) =>
             {
-                // First call is the POST to the image generation endpoint.
-                // Second call is the GET for the image URL.
                 if (req.Method == HttpMethod.Post)
                 {
                     var json = "{\"data\":[{\"url\":\"https://myfoundry.openai.azure.com/generated/img.png\"}]}";
@@ -252,8 +250,7 @@ public class AzureFoundryServiceTests
     }
 
     /// <summary>
-    /// G6 — A fallback url that does not originate from the configured endpoint must emit a
-    /// LogWarning. The download is still attempted (defence-in-depth, not a hard block).
+    /// G6 — A fallback url that does not originate from the configured endpoint must emit a LogWarning.
     /// </summary>
     [Fact]
     public async Task GenerateImageAsync_WhenFallbackUrlIsFromDifferentOrigin_LogsWarning()
@@ -269,7 +266,6 @@ public class AzureFoundryServiceTests
             {
                 if (req.Method == HttpMethod.Post)
                 {
-                    // URL originates from a different host — should trigger LogWarning.
                     var json = "{\"data\":[{\"url\":\"https://cdn.unknown.example.com/img.png\"}]}";
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                     {
@@ -357,8 +353,7 @@ public class AzureFoundryServiceTests
     }
 
     /// <summary>
-    /// E2 — The request body must include the `model` field set to ImageDeploymentName
-    /// so Azure AI Foundry routes the call to the correct deployment.
+    /// E2 — The image request body must include the `model` field set to ImageDeploymentName.
     /// </summary>
     [Fact]
     public async Task GenerateImageAsync_RequestBodyContainsModelField()
@@ -390,5 +385,61 @@ public class AzureFoundryServiceTests
         using var doc = JsonDocument.Parse(capturedBody!);
         Assert.True(doc.RootElement.TryGetProperty("model", out var modelProp));
         Assert.Equal("gpt-image-1.5", modelProp.GetString());
+    }
+
+    /// <summary>
+    /// C1 — GetSummaryAsync must POST to the Foundry /chat/completions path,
+    /// not the classic Azure OpenAI /openai/deployments/{name}/chat/completions path.
+    /// </summary>
+    [Fact]
+    public async Task GetSummaryAsync_PostsToFoundryChatCompletionsEndpoint()
+    {
+        var handler = MakeHandlerMock(HttpStatusCode.OK, ChatCompletionJson("short"));
+        var svc = BuildService(handler.Object, out _);
+
+        await svc.GetSummaryAsync(new string('a', 300), 100);
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(r =>
+                r.Method == HttpMethod.Post &&
+                r.RequestUri!.AbsolutePath.EndsWith("/chat/completions", StringComparison.Ordinal) &&
+                !r.RequestUri.AbsolutePath.Contains("/openai/deployments/", StringComparison.Ordinal)),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    /// <summary>
+    /// C2 — The chat request body must include the `model` field set to DeploymentName.
+    /// </summary>
+    [Fact]
+    public async Task GetSummaryAsync_RequestBodyContainsModelField()
+    {
+        string? capturedBody = null;
+        var mock = new Mock<HttpMessageHandler>();
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            {
+                capturedBody = await req.Content!.ReadAsStringAsync();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        ChatCompletionJson("short"),
+                        Encoding.UTF8,
+                        "application/json")
+                };
+            });
+
+        var svc = BuildService(mock.Object, out _);
+        await svc.GetSummaryAsync(new string('a', 300), 100);
+
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody!);
+        Assert.True(doc.RootElement.TryGetProperty("model", out var modelProp));
+        Assert.Equal("gpt-4.1-nano", modelProp.GetString());
     }
 }

--- a/tests/Services/AzureFoundryServiceTests.cs
+++ b/tests/Services/AzureFoundryServiceTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Text;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -22,7 +24,7 @@ public class AzureFoundryServiceTests
             Endpoint = "https://myfoundry.openai.azure.com",
             ApiKey = "fake-key",
             DeploymentName = "gpt-4.1-nano",
-            ImageDeploymentName = "gpt-image-1"
+            ImageDeploymentName = "gpt-image-1.5"
         });
 
         return new AzureFoundryService(factory.Object, options, loggerMock.Object);
@@ -327,5 +329,66 @@ public class AzureFoundryServiceTests
             Times.Never(),
             ItExpr.IsAny<HttpRequestMessage>(),
             ItExpr.IsAny<CancellationToken>());
+    }
+
+    /// <summary>
+    /// E1 — GenerateImageAsync must POST to the Foundry /images/generations path,
+    /// not the classic Azure OpenAI /openai/deployments/{name}/images/generations path.
+    /// </summary>
+    [Fact]
+    public async Task GenerateImageAsync_PostsToFoundryImagesGenerationsEndpoint()
+    {
+        var imageBytes = new byte[] { 1, 2, 3 };
+        var base64 = Convert.ToBase64String(imageBytes);
+        var json = "{\"data\":[{\"b64_json\":\"" + base64 + "\"}]}";
+        var handler = MakeHandlerMock(HttpStatusCode.OK, json);
+        var svc = BuildService(handler.Object, out _);
+
+        await svc.GenerateImageAsync("a polar bear");
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(r =>
+                r.Method == HttpMethod.Post &&
+                r.RequestUri!.AbsolutePath.EndsWith("/images/generations", StringComparison.Ordinal) &&
+                !r.RequestUri.AbsolutePath.Contains("/openai/deployments/", StringComparison.Ordinal)),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    /// <summary>
+    /// E2 — The request body must include the `model` field set to ImageDeploymentName
+    /// so Azure AI Foundry routes the call to the correct deployment.
+    /// </summary>
+    [Fact]
+    public async Task GenerateImageAsync_RequestBodyContainsModelField()
+    {
+        var imageBytes = new byte[] { 5, 6, 7 };
+        var base64 = Convert.ToBase64String(imageBytes);
+        var json = "{\"data\":[{\"b64_json\":\"" + base64 + "\"}]}";
+
+        string? capturedBody = null;
+        var mock = new Mock<HttpMessageHandler>();
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Returns<HttpRequestMessage, CancellationToken>(async (req, _) =>
+            {
+                capturedBody = await req.Content!.ReadAsStringAsync();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+        var svc = BuildService(mock.Object, out _);
+        await svc.GenerateImageAsync("a polar bear");
+
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody!);
+        Assert.True(doc.RootElement.TryGetProperty("model", out var modelProp));
+        Assert.Equal("gpt-image-1.5", modelProp.GetString());
     }
 }


### PR DESCRIPTION
## Summary

Fixes the Azure Foundry image generation integration by aligning the HTTP request payload and endpoint format to the `/openai/v1` API used by Azure AI Foundry.

## Changes

### `src/Services/AzureFoundryService.cs`
- Removed unsupported `response_format` field from the request body (`gpt-image-1` returns a URL by default and does not accept this parameter)
- Added `model` field to the request body (required by the `/openai/v1` endpoint)
- Updated `GetImageGenerationEndpoint()` to use the Foundry-compatible path format
- Improved error logging to include the full response body on non-success status codes

### `src/Implementation/OrchestratorFactory.cs`
- Fixed `ResolveAiProvider` logic: the profile's `AiProvider` is now always authoritative; `IConfiguration["AiProvider"]` is used only as a global fallback when the profile does not specify a provider

### `tests/Models/AzureFoundryOptionsTests.cs`
- Added 5 unit tests covering `AzureFoundryOptions` defaults and regression guard for removed `ApiVersion` property

### `docs/integrations/setup-azure-foundry.md`
- Removed `ApiVersion` from required parameters table and configuration snippets
- Updated endpoint example to `/openai/v1` format
- Removed obsolete "400 Bad Request (API version)" troubleshooting entry

### `docs/configuration.md`
- Removed `AzureFoundry__ApiVersion` from connection table and commented JSON block
- Aligned endpoint description to the new `services.ai.azure.com/openai/v1` format

### `.vscode/`
- Added `tasks.json`, `launch.json`, `extensions.json` for local development workflow (Azurite → build → func host → attach)

## How to test locally

1. Install Azurite: `npm install -g azurite`
2. Create `.azurite/` folder in repo root
3. Press **F5** in VS Code — the launch configuration starts Azurite, builds, and attaches the debugger automatically
4. Verify `DryRunSlotProfileProvider` uses `AiProvider.AzureFoundry` and confirm image generation succeeds end-to-end

## Related
- Fixes `OrchestratorFactory.ResolveAiProvider` priority inversion (profile > global config)
- Validated against `gpt-image-1` deployment on `af-xposter-resource.services.ai.azure.com`