### PR TITLE
docs(changelog): populate [Unreleased] with Azure Foundry API fixes post-v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`AzureFoundryService.GenerateImageAsync` — image generation endpoint aligned to Azure AI Foundry `/openai/v1` format**: `GetImageGenerationEndpoint()` now builds `{Endpoint}/images/generations` without the `/openai/deployments/{name}/` path segment and without `api-version`; the `model = ImageDeploymentName` field is now included in the request body instead of being embedded in the URL.
+- **`AzureFoundryService` — chat completions endpoint aligned to Azure AI Foundry `/openai/v1` format**: `GetChatCompletionsEndpoint()` now builds `{Endpoint}/chat/completions` without the `/openai/deployments/{name}/` path segment and without `api-version`; `BuildSummaryPayload()` and `BuildImagePromptPayload()` now include `model = DeploymentName` in the request body.
+- **`AzureFoundryOptions` — removed `ApiVersion` property**: `ApiVersion` was not used by Foundry `/openai/v1` endpoints and was causing `400 Bad Request` errors; removed from `AzureFoundryOptions`, `local.settings.json.example`, and related documentation.
+- **`AzureFoundryService.GenerateImageAsync` — removed unsupported `response_format` parameter**: the `response_format` field is not accepted by the Foundry image generation endpoint; removed from the request body to prevent `400 Bad Request` responses.
+
+### Tests
+- **`AzureFoundryServiceTests` — endpoint and payload coverage for image generation and chat completions**:
+  - `E1`: verifies POST targets `/images/generations` without the `/openai/deployments/` path segment.
+  - `E2`: verifies `model` is serialised in the image generation request body.
+  - `C1`: verifies POST targets `/chat/completions` without the `/openai/deployments/` path segment.
+  - `C2`: verifies `model` is present in the chat completions request body.
+- **`AzureFoundryOptionsTests`** — added `DoesNotExpose_ApiVersionProperty` regression test to ensure `ApiVersion` is not reintroduced in the options model; follows the `DeepSeekOptions` test pattern.
+
 ---
 
 ## [0.1.3] - 2026-06-17


### PR DESCRIPTION
## Summary

Populates the `[Unreleased]` section of `CHANGELOG.md` with changes introduced after the `v0.1.3` release that were not yet documented.

## Changes

### Fixed
- `AzureFoundryService.GenerateImageAsync` — image generation endpoint aligned to Azure AI Foundry `/openai/v1` format
- `AzureFoundryService` — chat completions endpoint aligned to Azure AI Foundry `/openai/v1` format
- `AzureFoundryOptions` — removed `ApiVersion` property (not used by Foundry endpoints, was causing `400 Bad Request`)
- `AzureFoundryService.GenerateImageAsync` — removed unsupported `response_format` parameter

### Tests
- `AzureFoundryServiceTests` — endpoint and payload coverage (E1, E2, C1, C2)
- `AzureFoundryOptionsTests` — `DoesNotExpose_ApiVersionProperty` regression test

## Notes
- Documentation only — no production code changes.
- All entries follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
- Entries already present in `[0.1.3]` have not been duplicated in `[Unreleased]`.