### PR TITLE
feat: unified image byte extraction via AiServiceHelper.ParseImageResponseAsync(AiProvider)

### DIFF
--- a/src/Abstraction/AiProvider.cs
+++ b/src/Abstraction/AiProvider.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace XPoster.Abstraction;
 
 /// <summary>
@@ -6,17 +8,22 @@ namespace XPoster.Abstraction;
 public enum AiProvider
 {
     /// <summary>No provider selected.</summary>
+    [Description("None")]
     None = 0,
 
     /// <summary>OpenAI provider.</summary>
+    [Description("OpenAI")]
     OpenAi = 1,
 
     /// <summary>Perplexity provider.</summary>
+    [Description("Perplexity")]
     Perplexity = 2,
 
     /// <summary>Azure AI Foundry provider.</summary>
+    [Description("Azure Foundry")]
     AzureFoundry = 3,
 
     /// <summary>DeepSeek provider with Fal.ai integration.</summary>
+    [Description("fal.ai")]
     DeepSeekWithFal = 4,
 }

--- a/src/Abstraction/AiProviderExtensions.cs
+++ b/src/Abstraction/AiProviderExtensions.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel;
+using System.Reflection;
+
+namespace XPoster.Abstraction;
+
+/// <summary>
+/// Extension methods for <see cref="AiProvider"/>.
+/// </summary>
+public static class AiProviderExtensions
+{
+    /// <summary>
+    /// Returns the human-readable label for the provider, sourced from
+    /// <see cref="DescriptionAttribute"/> when present; falls back to
+    /// <see cref="Enum.ToString()"/> otherwise.
+    /// </summary>
+    public static string GetLabel(this AiProvider provider)
+    {
+        var field = typeof(AiProvider).GetField(provider.ToString());
+        var attr = field?.GetCustomAttribute<DescriptionAttribute>();
+        return attr?.Description ?? provider.ToString();
+    }
+}

--- a/src/Services/AiServiceHelper.cs
+++ b/src/Services/AiServiceHelper.cs
@@ -116,18 +116,18 @@ internal static class AiServiceHelper
         string? allowedOrigin,
         CancellationToken cancellationToken)
     {
-        var providerName = GetProviderLabel(provider);
+        var label = provider.GetLabel();
 
         if (response.StatusCode == HttpStatusCode.TooManyRequests)
         {
-            logger.LogWarning("{Provider} returned 429 (TooManyRequests) during image generation.", providerName);
+            logger.LogWarning("{Provider} returned 429 (TooManyRequests) during image generation.", label);
             return Array.Empty<byte>();
         }
 
         if (!response.IsSuccessStatusCode)
         {
             logger.LogError("{Provider} image generation failed with status code {StatusCode}.",
-                providerName, response.StatusCode);
+                label, response.StatusCode);
             return Array.Empty<byte>();
         }
 
@@ -138,26 +138,28 @@ internal static class AiServiceHelper
         }
         catch (JsonException)
         {
-            logger.LogError("{Provider} image generation returned malformed JSON.", providerName);
+            logger.LogError("{Provider} image generation returned malformed JSON.", label);
             return Array.Empty<byte>();
         }
 
         return provider switch
         {
-            AiProvider.OpenAi => ExtractOpenAiBytes(root, providerName, logger),
-            AiProvider.AzureFoundry => await ExtractAzureFoundryBytesAsync(root, providerName, allowedOrigin, httpClient, logger, cancellationToken),
-            AiProvider.DeepSeekWithFal => await ExtractFalAiBytesAsync(root, providerName, httpClient, logger, cancellationToken),
-            _ => LogAndReturnEmpty(logger, providerName, "Image byte extraction is not supported for this provider.")
+            AiProvider.OpenAi        => ExtractOpenAiBytes(root, provider, logger),
+            AiProvider.AzureFoundry  => await ExtractAzureFoundryBytesAsync(root, provider, allowedOrigin, httpClient, logger, cancellationToken),
+            AiProvider.DeepSeekWithFal => await ExtractFalAiBytesAsync(root, provider, httpClient, logger, cancellationToken),
+            _                        => LogAndReturnEmpty(logger, provider, "Image byte extraction is not supported for this provider.")
         };
     }
 
     // --- provider-specific extractors ---
 
-    private static byte[] ExtractOpenAiBytes(JsonElement root, string providerName, ILogger logger)
+    private static byte[] ExtractOpenAiBytes(JsonElement root, AiProvider provider, ILogger logger)
     {
+        var label = provider.GetLabel();
+
         if (!root.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
         {
-            logger.LogError("{Provider} image generation response does not contain data entries.", providerName);
+            logger.LogError("{Provider} image generation response does not contain data entries.", label);
             return Array.Empty<byte>();
         }
 
@@ -165,14 +167,14 @@ internal static class AiServiceHelper
 
         if (!first.TryGetProperty("b64_json", out var b64Property))
         {
-            logger.LogError("{Provider} image data entry does not contain b64_json.", providerName);
+            logger.LogError("{Provider} image data entry does not contain b64_json.", label);
             return Array.Empty<byte>();
         }
 
         var base64 = b64Property.GetString();
         if (string.IsNullOrWhiteSpace(base64))
         {
-            logger.LogError("{Provider} image data entry contains an empty b64_json value.", providerName);
+            logger.LogError("{Provider} image data entry contains an empty b64_json value.", label);
             return Array.Empty<byte>();
         }
 
@@ -181,15 +183,17 @@ internal static class AiServiceHelper
 
     private static async Task<byte[]> ExtractAzureFoundryBytesAsync(
         JsonElement root,
-        string providerName,
+        AiProvider provider,
         string? allowedOrigin,
         HttpClient httpClient,
         ILogger logger,
         CancellationToken cancellationToken)
     {
+        var label = provider.GetLabel();
+
         if (!root.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
         {
-            logger.LogError("{Provider} image generation response does not contain data entries.", providerName);
+            logger.LogError("{Provider} image generation response does not contain data entries.", label);
             return Array.Empty<byte>();
         }
 
@@ -200,7 +204,7 @@ internal static class AiServiceHelper
             var base64 = b64Property.GetString();
             if (string.IsNullOrWhiteSpace(base64))
             {
-                logger.LogError("{Provider} image data entry contains an empty b64_json value.", providerName);
+                logger.LogError("{Provider} image data entry contains an empty b64_json value.", label);
                 return Array.Empty<byte>();
             }
 
@@ -220,27 +224,37 @@ internal static class AiServiceHelper
                 {
                     logger.LogWarning(
                         "{Provider} image generation returned a fallback URL from a different origin: {ImageUrl}. Expected origin: {ConfiguredOrigin}.",
-                        providerName, imageUrl, allowedOrigin);
+                        label, imageUrl, allowedOrigin);
                 }
             }
 
-            return await httpClient.GetByteArrayAsync(imageUrl, cancellationToken);
+            try
+            {
+                return await httpClient.GetByteArrayAsync(imageUrl, cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                logger.LogError(ex, "{Provider} failed to download image from fallback URL: {Url}", label, imageUrl);
+                return Array.Empty<byte>();
+            }
         }
 
-        logger.LogError("{Provider} image data entry does not contain b64_json or url.", providerName);
+        logger.LogError("{Provider} image data entry does not contain b64_json or url.", label);
         return Array.Empty<byte>();
     }
 
     private static async Task<byte[]> ExtractFalAiBytesAsync(
         JsonElement root,
-        string providerName,
+        AiProvider provider,
         HttpClient httpClient,
         ILogger logger,
         CancellationToken cancellationToken)
     {
+        var label = provider.GetLabel();
+
         if (!root.TryGetProperty("images", out var images) || images.GetArrayLength() == 0)
         {
-            logger.LogError("{Provider} response does not contain any images.", providerName);
+            logger.LogError("{Provider} response does not contain any images.", label);
             return Array.Empty<byte>();
         }
 
@@ -248,36 +262,35 @@ internal static class AiServiceHelper
 
         if (!firstImage.TryGetProperty("url", out var urlProperty))
         {
-            logger.LogError("{Provider} image entry does not contain a URL.", providerName);
+            logger.LogError("{Provider} image entry does not contain a URL.", label);
             return Array.Empty<byte>();
         }
 
         var imageUrl = urlProperty.GetString();
         if (string.IsNullOrWhiteSpace(imageUrl))
         {
-            logger.LogError("{Provider} returned an empty image URL.", providerName);
+            logger.LogError("{Provider} returned an empty image URL.", label);
             return Array.Empty<byte>();
         }
 
         logger.LogInformation("Downloading generated image from {ImageUrl}", imageUrl);
-        return await httpClient.GetByteArrayAsync(imageUrl, cancellationToken);
+
+        try
+        {
+            return await httpClient.GetByteArrayAsync(imageUrl, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            logger.LogError(ex, "{Provider} failed to download generated image from URL: {Url}", label, imageUrl);
+            return Array.Empty<byte>();
+        }
     }
 
     // --- utilities ---
 
-    internal static string GetProviderLabel(AiProvider provider) => provider switch
+    private static byte[] LogAndReturnEmpty(ILogger logger, AiProvider provider, string reason)
     {
-        AiProvider.OpenAi => "OpenAI",
-        AiProvider.AzureFoundry => "Azure Foundry",
-        AiProvider.DeepSeekWithFal => "fal.ai",
-        AiProvider.Perplexity => "Perplexity",
-        AiProvider.None => "None",
-        _ => provider.ToString()
-    };
-
-    private static byte[] LogAndReturnEmpty(ILogger logger, string providerName, string reason)
-    {
-        logger.LogError("{Provider} image byte extraction skipped: {Reason}", providerName, reason);
+        logger.LogError("{Provider} image byte extraction skipped: {Reason}", provider.GetLabel(), reason);
         return Array.Empty<byte>();
     }
 }

--- a/src/Services/AiServiceHelper.cs
+++ b/src/Services/AiServiceHelper.cs
@@ -7,9 +7,8 @@ using XPoster.Models;
 namespace XPoster.Services;
 
 /// <summary>
-/// Shared helper for parsing OpenAI-compatible chat completion HTTP responses.
-/// Centralises the five-step guard pipeline used by every <see cref="IAiService"/> text implementation:
-/// HTTP 429 intercept, non-2xx guard, JSON deserialisation, null/empty choices guard, content trim.
+/// Shared helper for parsing OpenAI-compatible HTTP responses.
+/// Centralises guard pipelines used by every <see cref="IAiService"/> implementation.
 /// </summary>
 internal static class AiServiceHelper
 {
@@ -63,5 +62,51 @@ internal static class AiServiceHelper
         }
 
         return (true, result.choices[0].message.content.Trim());
+    }
+
+    /// <summary>
+    /// Parses an image generation HTTP response, applying the HTTP-level guard pipeline
+    /// shared by all image provider implementations:
+    /// HTTP 429 intercept, non-2xx guard, and JSON deserialisation failure.
+    /// Schema-specific parsing (<c>data[0].b64_json</c>, <c>images[0].url</c>, etc.)
+    /// remains the responsibility of the calling service.
+    /// Returns <c>(true, JsonElement)</c> on success;
+    /// <c>(false, null)</c> on any failure path.
+    /// </summary>
+    /// <param name="response">The <see cref="HttpResponseMessage"/> returned by the upstream API.</param>
+    /// <param name="providerName">A human-readable provider label used in log messages (e.g. "OpenAI", "fal.ai").</param>
+    /// <param name="logger">The <see cref="ILogger"/> to write structured diagnostics to.</param>
+    /// <param name="cancellationToken">Propagates cancellation to the JSON deserialization step.</param>
+    internal static async Task<(bool Success, JsonElement? Content)> ParseImageResponseAsync(
+        HttpResponseMessage response,
+        string providerName,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            logger.LogWarning("{Provider} returned 429 (TooManyRequests) during image generation.", providerName);
+            return (false, null);
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogError("{Provider} image generation failed with status code {StatusCode}.",
+                providerName, response.StatusCode);
+            return (false, null);
+        }
+
+        JsonElement result;
+        try
+        {
+            result = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+        }
+        catch (JsonException)
+        {
+            logger.LogError("{Provider} image generation returned malformed JSON.", providerName);
+            return (false, null);
+        }
+
+        return (true, result);
     }
 }

--- a/src/Services/AiServiceHelper.cs
+++ b/src/Services/AiServiceHelper.cs
@@ -18,11 +18,6 @@ internal static class AiServiceHelper
     /// <c>(false, string.Empty)</c> on any failure path.
     /// Logs 429, non-2xx, and empty-choices cases via <paramref name="logger"/>.
     /// </summary>
-    /// <param name="response">The <see cref="HttpResponseMessage"/> returned by the upstream API.</param>
-    /// <param name="providerName">A human-readable provider label used in log messages (e.g. "OpenAI", "DeepSeek").</param>
-    /// <param name="operationName">A human-readable operation label used in log messages (e.g. "summary generation").</param>
-    /// <param name="logger">The <see cref="ILogger"/> to write structured diagnostics to.</param>
-    /// <param name="cancellationToken">Propagates cancellation to the JSON deserialization step.</param>
     internal static async Task<(bool Success, string Content)> ParseChatCompletionResponseAsync(
         HttpResponseMessage response,
         string providerName,
@@ -65,18 +60,10 @@ internal static class AiServiceHelper
     }
 
     /// <summary>
-    /// Parses an image generation HTTP response, applying the HTTP-level guard pipeline
-    /// shared by all image provider implementations:
-    /// HTTP 429 intercept, non-2xx guard, and JSON deserialisation failure.
-    /// Schema-specific parsing (<c>data[0].b64_json</c>, <c>images[0].url</c>, etc.)
-    /// remains the responsibility of the calling service.
-    /// Returns <c>(true, JsonElement)</c> on success;
-    /// <c>(false, null)</c> on any failure path.
+    /// Legacy overload: parses HTTP guards and JSON only, returning the raw <see cref="JsonElement"/>.
+    /// Schema-specific parsing remains the responsibility of the caller.
+    /// Kept for backward compatibility; prefer the <see cref="AiProvider"/>-based overload for new callers.
     /// </summary>
-    /// <param name="response">The <see cref="HttpResponseMessage"/> returned by the upstream API.</param>
-    /// <param name="providerName">A human-readable provider label used in log messages (e.g. "OpenAI", "fal.ai").</param>
-    /// <param name="logger">The <see cref="ILogger"/> to write structured diagnostics to.</param>
-    /// <param name="cancellationToken">Propagates cancellation to the JSON deserialization step.</param>
     internal static async Task<(bool Success, JsonElement? Content)> ParseImageResponseAsync(
         HttpResponseMessage response,
         string providerName,
@@ -108,5 +95,189 @@ internal static class AiServiceHelper
         }
 
         return (true, result);
+    }
+
+    /// <summary>
+    /// Parses an image generation HTTP response end-to-end, applying the HTTP-level guard pipeline
+    /// and provider-specific byte extraction determined by <paramref name="provider"/>.
+    /// </summary>
+    /// <param name="response">The <see cref="HttpResponseMessage"/> returned by the upstream API.</param>
+    /// <param name="provider">The <see cref="AiProvider"/> that issued the request; drives extraction strategy.</param>
+    /// <param name="httpClient">HTTP client used for downloading image bytes (fal.ai URL, AzureFoundry fallback URL).</param>
+    /// <param name="logger">The <see cref="ILogger"/> to write structured diagnostics to.</param>
+    /// <param name="allowedOrigin">Optional: expected origin for URL validation (used by AzureFoundry only).</param>
+    /// <param name="cancellationToken">Propagates cancellation.</param>
+    /// <returns>Decoded image bytes, or <see cref="Array.Empty{T}"/> on any failure.</returns>
+    internal static async Task<byte[]> ParseImageResponseAsync(
+        HttpResponseMessage response,
+        AiProvider provider,
+        HttpClient httpClient,
+        ILogger logger,
+        string? allowedOrigin,
+        CancellationToken cancellationToken)
+    {
+        var providerName = GetProviderLabel(provider);
+
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            logger.LogWarning("{Provider} returned 429 (TooManyRequests) during image generation.", providerName);
+            return Array.Empty<byte>();
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogError("{Provider} image generation failed with status code {StatusCode}.",
+                providerName, response.StatusCode);
+            return Array.Empty<byte>();
+        }
+
+        JsonElement root;
+        try
+        {
+            root = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+        }
+        catch (JsonException)
+        {
+            logger.LogError("{Provider} image generation returned malformed JSON.", providerName);
+            return Array.Empty<byte>();
+        }
+
+        return provider switch
+        {
+            AiProvider.OpenAi => ExtractOpenAiBytes(root, providerName, logger),
+            AiProvider.AzureFoundry => await ExtractAzureFoundryBytesAsync(root, providerName, allowedOrigin, httpClient, logger, cancellationToken),
+            AiProvider.DeepSeekWithFal => await ExtractFalAiBytesAsync(root, providerName, httpClient, logger, cancellationToken),
+            _ => LogAndReturnEmpty(logger, providerName, "Image byte extraction is not supported for this provider.")
+        };
+    }
+
+    // --- provider-specific extractors ---
+
+    private static byte[] ExtractOpenAiBytes(JsonElement root, string providerName, ILogger logger)
+    {
+        if (!root.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
+        {
+            logger.LogError("{Provider} image generation response does not contain data entries.", providerName);
+            return Array.Empty<byte>();
+        }
+
+        var first = data[0];
+
+        if (!first.TryGetProperty("b64_json", out var b64Property))
+        {
+            logger.LogError("{Provider} image data entry does not contain b64_json.", providerName);
+            return Array.Empty<byte>();
+        }
+
+        var base64 = b64Property.GetString();
+        if (string.IsNullOrWhiteSpace(base64))
+        {
+            logger.LogError("{Provider} image data entry contains an empty b64_json value.", providerName);
+            return Array.Empty<byte>();
+        }
+
+        return Convert.FromBase64String(base64);
+    }
+
+    private static async Task<byte[]> ExtractAzureFoundryBytesAsync(
+        JsonElement root,
+        string providerName,
+        string? allowedOrigin,
+        HttpClient httpClient,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (!root.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
+        {
+            logger.LogError("{Provider} image generation response does not contain data entries.", providerName);
+            return Array.Empty<byte>();
+        }
+
+        var first = data[0];
+
+        if (first.TryGetProperty("b64_json", out var b64Property))
+        {
+            var base64 = b64Property.GetString();
+            if (string.IsNullOrWhiteSpace(base64))
+            {
+                logger.LogError("{Provider} image data entry contains an empty b64_json value.", providerName);
+                return Array.Empty<byte>();
+            }
+
+            return Convert.FromBase64String(base64);
+        }
+
+        if (first.TryGetProperty("url", out var urlProperty))
+        {
+            var imageUrl = urlProperty.GetString();
+            if (string.IsNullOrWhiteSpace(imageUrl))
+                return Array.Empty<byte>();
+
+            if (!string.IsNullOrWhiteSpace(allowedOrigin))
+            {
+                var imageOrigin = new Uri(imageUrl).GetLeftPart(UriPartial.Authority);
+                if (!string.Equals(allowedOrigin, imageOrigin, StringComparison.OrdinalIgnoreCase))
+                {
+                    logger.LogWarning(
+                        "{Provider} image generation returned a fallback URL from a different origin: {ImageUrl}. Expected origin: {ConfiguredOrigin}.",
+                        providerName, imageUrl, allowedOrigin);
+                }
+            }
+
+            return await httpClient.GetByteArrayAsync(imageUrl, cancellationToken);
+        }
+
+        logger.LogError("{Provider} image data entry does not contain b64_json or url.", providerName);
+        return Array.Empty<byte>();
+    }
+
+    private static async Task<byte[]> ExtractFalAiBytesAsync(
+        JsonElement root,
+        string providerName,
+        HttpClient httpClient,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (!root.TryGetProperty("images", out var images) || images.GetArrayLength() == 0)
+        {
+            logger.LogError("{Provider} response does not contain any images.", providerName);
+            return Array.Empty<byte>();
+        }
+
+        var firstImage = images[0];
+
+        if (!firstImage.TryGetProperty("url", out var urlProperty))
+        {
+            logger.LogError("{Provider} image entry does not contain a URL.", providerName);
+            return Array.Empty<byte>();
+        }
+
+        var imageUrl = urlProperty.GetString();
+        if (string.IsNullOrWhiteSpace(imageUrl))
+        {
+            logger.LogError("{Provider} returned an empty image URL.", providerName);
+            return Array.Empty<byte>();
+        }
+
+        logger.LogInformation("Downloading generated image from {ImageUrl}", imageUrl);
+        return await httpClient.GetByteArrayAsync(imageUrl, cancellationToken);
+    }
+
+    // --- utilities ---
+
+    internal static string GetProviderLabel(AiProvider provider) => provider switch
+    {
+        AiProvider.OpenAi => "OpenAI",
+        AiProvider.AzureFoundry => "Azure Foundry",
+        AiProvider.DeepSeekWithFal => "fal.ai",
+        AiProvider.Perplexity => "Perplexity",
+        AiProvider.None => "None",
+        _ => provider.ToString()
+    };
+
+    private static byte[] LogAndReturnEmpty(ILogger logger, string providerName, string reason)
+    {
+        logger.LogError("{Provider} image byte extraction skipped: {Reason}", providerName, reason);
+        return Array.Empty<byte>();
     }
 }

--- a/src/Services/AzureFoundryService.cs
+++ b/src/Services/AzureFoundryService.cs
@@ -62,12 +62,11 @@ public sealed class AzureFoundryService : IAiService
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Delegates HTTP-level guards (429, non-2xx, JSON deserialisation failure) to
-    /// <see cref="AiServiceHelper.ParseImageResponseAsync"/>.
+    /// Delegates the full pipeline (HTTP guards, JSON deserialisation, b64_json extraction,
+    /// url fallback with origin validation) to
+    /// <see cref="AiServiceHelper.ParseImageResponseAsync(HttpResponseMessage,AiProvider,HttpClient,ILogger,string?,CancellationToken)"/>.
     /// <see cref="System.Net.Http.HttpRequestException"/> on the POST call is caught and logged as an error.
     /// An empty or whitespace prompt emits <c>LogWarning</c> and returns immediately without making any HTTP call.
-    /// Schema-specific parsing (<c>data[0].b64_json</c>, <c>data[0].url</c> fallback, origin validation)
-    /// remains inside this service.
     /// </remarks>
     public async Task<byte[]> GenerateImageAsync(string prompt, CancellationToken cancellationToken = default)
     {
@@ -77,8 +76,6 @@ public sealed class AzureFoundryService : IAiService
             return Array.Empty<byte>();
         }
 
-        // Azure AI Foundry /openai/v1 expects the deployment name as `model` in the
-        // request body. The endpoint does not embed it in the URL path.
         var requestBody = new
         {
             model = _options.ImageDeploymentName,
@@ -98,61 +95,15 @@ public sealed class AzureFoundryService : IAiService
             return Array.Empty<byte>();
         }
 
-        var (success, content) = await AiServiceHelper.ParseImageResponseAsync(
-            response, "Azure Foundry", _logger, cancellationToken);
+        var allowedOrigin = new Uri(_options.Endpoint.TrimEnd('/')).GetLeftPart(UriPartial.Authority);
 
-        if (!success || content is null)
-            return Array.Empty<byte>();
-
-        var result = content.Value;
-
-        if (!result.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
-        {
-            _logger.LogError("Azure Foundry image generation response does not contain data entries.");
-            return Array.Empty<byte>();
-        }
-
-        var first = data[0];
-
-        if (first.TryGetProperty("b64_json", out var b64Property))
-        {
-            var base64 = b64Property.GetString();
-            return string.IsNullOrWhiteSpace(base64)
-                ? Array.Empty<byte>()
-                : Convert.FromBase64String(base64);
-        }
-
-        if (first.TryGetProperty("url", out var urlProperty))
-        {
-            var imageUrl = urlProperty.GetString();
-            if (string.IsNullOrWhiteSpace(imageUrl))
-                return Array.Empty<byte>();
-
-            // Warn when the fallback URL origin differs from the configured endpoint.
-            var configuredOrigin = new Uri(_options.Endpoint.TrimEnd('/')).GetLeftPart(UriPartial.Authority);
-            var imageOrigin = new Uri(imageUrl).GetLeftPart(UriPartial.Authority);
-            if (!string.Equals(configuredOrigin, imageOrigin, StringComparison.OrdinalIgnoreCase))
-            {
-                _logger.LogWarning(
-                    "Azure Foundry image generation returned a fallback URL from a different origin: {ImageUrl}. Expected origin: {ConfiguredOrigin}.",
-                    imageUrl, configuredOrigin);
-            }
-
-            return await _client.GetByteArrayAsync(imageUrl, cancellationToken);
-        }
-
-        return Array.Empty<byte>();
+        return await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.AzureFoundry, _client, _logger, allowedOrigin, cancellationToken);
     }
 
-    // Azure AI Foundry /openai/v1 exposes a unified chat completions path.
-    // The deployment name is passed as `model` in the request body, so the URL
-    // does not include the deployment segment or an api-version query parameter.
     private string GetChatCompletionsEndpoint() =>
         $"{_options.Endpoint.TrimEnd('/')}/chat/completions";
 
-    // Azure AI Foundry /openai/v1 exposes a unified image generation path.
-    // The deployment name is passed as `model` in the request body, so the URL
-    // does not include the deployment segment or an api-version query parameter.
     private string GetImageGenerationEndpoint() =>
         $"{_options.Endpoint.TrimEnd('/')}/images/generations";
 

--- a/src/Services/AzureFoundryService.cs
+++ b/src/Services/AzureFoundryService.cs
@@ -61,10 +61,21 @@ public sealed class AzureFoundryService : IAiService
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Delegates HTTP-level guards (429, non-2xx, JSON deserialisation failure) to
+    /// <see cref="AiServiceHelper.ParseImageResponseAsync"/>.
+    /// <see cref="System.Net.Http.HttpRequestException"/> on the POST call is caught and logged as an error.
+    /// An empty or whitespace prompt emits <c>LogWarning</c> and returns immediately without making any HTTP call.
+    /// Schema-specific parsing (<c>data[0].b64_json</c>, <c>data[0].url</c> fallback, origin validation)
+    /// remains inside this service.
+    /// </remarks>
     public async Task<byte[]> GenerateImageAsync(string prompt, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(prompt))
+        {
+            _logger.LogWarning("Azure Foundry GenerateImageAsync called with an empty or whitespace prompt.");
             return Array.Empty<byte>();
+        }
 
         // Azure AI Foundry /openai/v1 expects the deployment name as `model` in the
         // request body. The endpoint does not embed it in the URL path.
@@ -76,28 +87,24 @@ public sealed class AzureFoundryService : IAiService
             size = "1024x1024"
         };
 
-        var response = await _client.PostAsJsonAsync(GetImageGenerationEndpoint(), requestBody, cancellationToken);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var errorBody = await response.Content.ReadAsStringAsync();
-            _logger.LogError(
-                "Azure Foundry image generation failed with status {StatusCode}. Response: {ErrorBody}",
-                response.StatusCode,
-                errorBody);
-            return Array.Empty<byte>();
-        }
-
-        JsonElement result;
+        HttpResponseMessage response;
         try
         {
-            result = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+            response = await _client.PostAsJsonAsync(GetImageGenerationEndpoint(), requestBody, cancellationToken);
         }
-        catch (JsonException)
+        catch (HttpRequestException ex)
         {
-            _logger.LogError("Azure Foundry image generation returned malformed JSON.");
+            _logger.LogError(ex, "Azure Foundry image generation HTTP request failed.");
             return Array.Empty<byte>();
         }
+
+        var (success, content) = await AiServiceHelper.ParseImageResponseAsync(
+            response, "Azure Foundry", _logger, cancellationToken);
+
+        if (!success || content is null)
+            return Array.Empty<byte>();
+
+        var result = content.Value;
 
         if (!result.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
         {

--- a/src/Services/FalAiImageService.cs
+++ b/src/Services/FalAiImageService.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
@@ -39,7 +38,13 @@ public sealed class FalAiImageService
     /// </summary>
     /// <param name="prompt">The text prompt describing the desired image.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>A byte array containing the generated image data, or an empty array on failure.</returns>
+    /// <returns>
+    /// A byte array containing the generated image data, or an empty array on failure.
+    /// HTTP-level guards (429 <c>LogWarning</c>, non-2xx <c>LogError</c>, JSON deserialisation
+    /// <c>LogError</c>) are handled by <see cref="AiServiceHelper.ParseImageResponseAsync"/>.
+    /// <see cref="System.Net.Http.HttpRequestException"/> on both POST and image download are caught
+    /// and logged as errors inside this service.
+    /// </returns>
     public async Task<byte[]> GenerateImageAsync(string prompt, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(prompt))
@@ -80,30 +85,13 @@ public sealed class FalAiImageService
             return Array.Empty<byte>();
         }
 
-        if (response.StatusCode == HttpStatusCode.TooManyRequests)
-        {
-            _logger.LogWarning("fal.ai returned 429 Too Many Requests during image generation.");
-            return Array.Empty<byte>();
-        }
+        var (success, content) = await AiServiceHelper.ParseImageResponseAsync(
+            response, "fal.ai", _logger, cancellationToken);
 
-        if (!response.IsSuccessStatusCode)
-        {
-            _logger.LogError(
-                "fal.ai image generation failed. StatusCode: {StatusCode}",
-                response.StatusCode);
+        if (!success || content is null)
             return Array.Empty<byte>();
-        }
 
-        JsonElement result;
-        try
-        {
-            result = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
-        }
-        catch (JsonException ex)
-        {
-            _logger.LogError(ex, "Failed to deserialize fal.ai response.");
-            return Array.Empty<byte>();
-        }
+        var result = content.Value;
 
         // Response schema: { "images": [{ "url": "...", ... }] }
         if (!result.TryGetProperty("images", out var images) || images.GetArrayLength() == 0)

--- a/src/Services/FalAiImageService.cs
+++ b/src/Services/FalAiImageService.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
+using XPoster.Abstraction;
 using XPoster.Models;
 
 namespace XPoster.Services;
@@ -19,9 +20,6 @@ public sealed class FalAiImageService
     /// <summary>
     /// Initializes a new instance of <see cref="FalAiImageService"/>.
     /// </summary>
-    /// <param name="httpClientFactory">Factory used to create the HTTP client.</param>
-    /// <param name="options">Strongly-typed fal.ai configuration.</param>
-    /// <param name="logger">Logger instance.</param>
     public FalAiImageService(
         IHttpClientFactory httpClientFactory,
         IOptions<FalAiOptions> options,
@@ -36,15 +34,14 @@ public sealed class FalAiImageService
     /// <summary>
     /// Generates an image from the given prompt using FLUX.1 Turbo on fal.ai.
     /// </summary>
-    /// <param name="prompt">The text prompt describing the desired image.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>
-    /// A byte array containing the generated image data, or an empty array on failure.
-    /// HTTP-level guards (429 <c>LogWarning</c>, non-2xx <c>LogError</c>, JSON deserialisation
-    /// <c>LogError</c>) are handled by <see cref="AiServiceHelper.ParseImageResponseAsync"/>.
-    /// <see cref="System.Net.Http.HttpRequestException"/> on both POST and image download are caught
-    /// and logged as errors inside this service.
-    /// </returns>
+    /// <remarks>
+    /// Delegates the full pipeline (HTTP guards, JSON deserialisation, images[0].url extraction,
+    /// image download) to
+    /// <see cref="AiServiceHelper.ParseImageResponseAsync(HttpResponseMessage,AiProvider,HttpClient,ILogger,string?,CancellationToken)"/>.
+    /// <see cref="System.Net.Http.HttpRequestException"/> on the POST call is caught and logged as an error.
+    /// Download-level <see cref="System.Net.Http.HttpRequestException"/> is caught inside the helper
+    /// and bubbles up as an empty array with a structured error log.
+    /// </remarks>
     public async Task<byte[]> GenerateImageAsync(string prompt, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(prompt))
@@ -63,11 +60,6 @@ public sealed class FalAiImageService
             output_format = "png"
         };
 
-        // ModelId may contain path separators (e.g. "fal-ai/flux/schnell").
-        // Each segment is encoded individually so that slashes are preserved as
-        // path delimiters while any reserved or unsafe characters within a segment
-        // are percent-encoded. This is consistent with the AzureFoundryService
-        // pattern that calls Uri.EscapeDataString on DeploymentName.
         var encodedModelPath = string.Join(
             "/",
             _options.ModelId.Split('/').Select(Uri.EscapeDataString));
@@ -85,46 +77,7 @@ public sealed class FalAiImageService
             return Array.Empty<byte>();
         }
 
-        var (success, content) = await AiServiceHelper.ParseImageResponseAsync(
-            response, "fal.ai", _logger, cancellationToken);
-
-        if (!success || content is null)
-            return Array.Empty<byte>();
-
-        var result = content.Value;
-
-        // Response schema: { "images": [{ "url": "...", ... }] }
-        if (!result.TryGetProperty("images", out var images) || images.GetArrayLength() == 0)
-        {
-            _logger.LogError("fal.ai response does not contain any images.");
-            return Array.Empty<byte>();
-        }
-
-        var firstImage = images[0];
-
-        if (!firstImage.TryGetProperty("url", out var urlProperty))
-        {
-            _logger.LogError("fal.ai image entry does not contain a URL.");
-            return Array.Empty<byte>();
-        }
-
-        var imageUrl = urlProperty.GetString();
-        if (string.IsNullOrWhiteSpace(imageUrl))
-        {
-            _logger.LogError("fal.ai returned an empty image URL.");
-            return Array.Empty<byte>();
-        }
-
-        _logger.LogInformation("Downloading generated image from {ImageUrl}", imageUrl);
-
-        try
-        {
-            return await _client.GetByteArrayAsync(imageUrl, cancellationToken);
-        }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogError(ex, "Failed to download generated image from fal.ai URL: {Url}", imageUrl);
-            return Array.Empty<byte>();
-        }
+        return await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.DeepSeekWithFal, _client, _logger, allowedOrigin: null, cancellationToken);
     }
 }

--- a/src/Services/OpenAiService.cs
+++ b/src/Services/OpenAiService.cs
@@ -61,11 +61,10 @@ public class OpenAiService : IAiService
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Delegates HTTP-level guards (429, non-2xx, JSON deserialisation failure) to
-    /// <see cref="AiServiceHelper.ParseImageResponseAsync"/>.
+    /// Delegates the full pipeline (HTTP guards, JSON deserialisation, b64_json extraction)
+    /// to <see cref="AiServiceHelper.ParseImageResponseAsync(HttpResponseMessage,AiProvider,HttpClient,ILogger,string?,CancellationToken)"/>.
     /// <see cref="System.Net.Http.HttpRequestException"/> on the POST call is caught and logged as an error.
     /// An empty or whitespace prompt emits <c>LogWarning</c> and returns immediately without making any HTTP call.
-    /// Schema-specific parsing (<c>data[0].b64_json</c>) remains inside this service.
     /// </remarks>
     public async Task<byte[]> GenerateImageAsync(string prompt, CancellationToken cancellationToken = default)
     {
@@ -96,31 +95,8 @@ public class OpenAiService : IAiService
             return Array.Empty<byte>();
         }
 
-        var (success, content) = await AiServiceHelper.ParseImageResponseAsync(
-            response, "OpenAI", _logger, cancellationToken);
-
-        if (!success || content is null)
-            return Array.Empty<byte>();
-
-        var result = content.Value;
-
-        if (!result.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
-        {
-            _logger.LogError("OpenAI image generation response does not contain data entries.");
-            return Array.Empty<byte>();
-        }
-
-        var first = data[0];
-
-        if (first.TryGetProperty("b64_json", out var b64Property))
-        {
-            var base64 = b64Property.GetString();
-            return string.IsNullOrWhiteSpace(base64)
-                ? Array.Empty<byte>()
-                : Convert.FromBase64String(base64);
-        }
-
-        return Array.Empty<byte>();
+        return await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.OpenAi, _client, _logger, allowedOrigin: null, cancellationToken);
     }
 
     private object GetSummary(string text, int messageMaxLength)

--- a/src/Services/OpenAiService.cs
+++ b/src/Services/OpenAiService.cs
@@ -60,10 +60,20 @@ public class OpenAiService : IAiService
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Delegates HTTP-level guards (429, non-2xx, JSON deserialisation failure) to
+    /// <see cref="AiServiceHelper.ParseImageResponseAsync"/>.
+    /// <see cref="System.Net.Http.HttpRequestException"/> on the POST call is caught and logged as an error.
+    /// An empty or whitespace prompt emits <c>LogWarning</c> and returns immediately without making any HTTP call.
+    /// Schema-specific parsing (<c>data[0].b64_json</c>) remains inside this service.
+    /// </remarks>
     public async Task<byte[]> GenerateImageAsync(string prompt, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(prompt))
+        {
+            _logger.LogWarning("OpenAI GenerateImageAsync called with an empty or whitespace prompt.");
             return Array.Empty<byte>();
+        }
 
         _logger.LogInformation("Generating image with {ImageModel}, prompt: {Prompt}", _options.ImageModel, prompt);
 
@@ -75,24 +85,24 @@ public class OpenAiService : IAiService
             size = _options.ImageSize
         };
 
-        var response = await _client.PostAsJsonAsync(_options.ImageEndpoint, body, cancellationToken);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            _logger.LogError("Image generation failed with status code {StatusCode}", response.StatusCode);
-            return Array.Empty<byte>();
-        }
-
-        JsonElement result;
+        HttpResponseMessage response;
         try
         {
-            result = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+            response = await _client.PostAsJsonAsync(_options.ImageEndpoint, body, cancellationToken);
         }
-        catch (JsonException)
+        catch (HttpRequestException ex)
         {
-            _logger.LogError("OpenAI image generation returned malformed JSON.");
+            _logger.LogError(ex, "OpenAI image generation HTTP request failed.");
             return Array.Empty<byte>();
         }
+
+        var (success, content) = await AiServiceHelper.ParseImageResponseAsync(
+            response, "OpenAI", _logger, cancellationToken);
+
+        if (!success || content is null)
+            return Array.Empty<byte>();
+
+        var result = content.Value;
 
         if (!result.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
         {

--- a/tests/Abstraction/AiProviderExtensionsTests.cs
+++ b/tests/Abstraction/AiProviderExtensionsTests.cs
@@ -1,0 +1,36 @@
+using XPoster.Abstraction;
+
+namespace XPoster.Tests.Abstraction;
+
+public class AiProviderExtensionsTests
+{
+    [Theory]
+    [InlineData(AiProvider.None, "None")]
+    [InlineData(AiProvider.OpenAi, "OpenAI")]
+    [InlineData(AiProvider.Perplexity, "Perplexity")]
+    [InlineData(AiProvider.AzureFoundry, "Azure Foundry")]
+    [InlineData(AiProvider.DeepSeekWithFal, "fal.ai")]
+    public void GetLabel_KnownProvider_ReturnsDescriptionAttributeValue(AiProvider provider, string expected)
+    {
+        Assert.Equal(expected, provider.GetLabel());
+    }
+
+    [Fact]
+    public void GetLabel_UnknownProvider_ReturnsFallbackToString()
+    {
+        var unknown = (AiProvider)999;
+
+        Assert.Equal("999", unknown.GetLabel());
+    }
+
+    [Theory]
+    [InlineData(AiProvider.OpenAi, "OpenAI")]
+    [InlineData(AiProvider.AzureFoundry, "Azure Foundry")]
+    [InlineData(AiProvider.DeepSeekWithFal, "fal.ai")]
+    public void GetLabel_DescriptionDiffersFromEnumName(AiProvider provider, string label)
+    {
+        // Ensures Description attribute is read, not Enum.ToString()
+        Assert.NotEqual(provider.ToString(), label);
+        Assert.Equal(label, provider.GetLabel());
+    }
+}

--- a/tests/Services/AiServiceHelperImageTests.cs
+++ b/tests/Services/AiServiceHelperImageTests.cs
@@ -1,0 +1,484 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using XPoster.Abstraction;
+using XPoster.Services;
+
+namespace XPoster.Tests.Services;
+
+/// <summary>
+/// Tests for AiServiceHelper.ParseImageResponseAsync(response, AiProvider, httpClient, logger, allowedOrigin, ct).
+/// </summary>
+public class AiServiceHelperImageTests
+{
+    private static (HttpClient Client, Mock<HttpMessageHandler> Handler) MakeSingleResponseClient(
+        HttpStatusCode code, string body)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(code)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json")
+            });
+        return (new HttpClient(handler.Object), handler);
+    }
+
+    private static (HttpClient Client, Mock<HttpMessageHandler> Handler) MakeSequenceClient(
+        HttpResponseMessage first, HttpResponseMessage second)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .SetupSequence<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(first)
+            .ReturnsAsync(second);
+        return (new HttpClient(handler.Object), handler);
+    }
+
+    private static (HttpClient Client, Mock<HttpMessageHandler> Handler) MakeThrowingDownloadClient(
+        HttpResponseMessage first)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .SetupSequence<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(first)
+            .ThrowsAsync(new HttpRequestException("download failed"));
+        return (new HttpClient(handler.Object), handler);
+    }
+
+    private static HttpResponseMessage JsonResponse(string body) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        };
+
+    // ── HTTP guard pipeline ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(AiProvider.OpenAi)]
+    [InlineData(AiProvider.AzureFoundry)]
+    [InlineData(AiProvider.DeepSeekWithFal)]
+    public async Task Parse_Returns429_ReturnsEmpty(AiProvider provider)
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.TooManyRequests, "{}");
+        var logger = new Mock<ILogger>();
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, provider, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData(AiProvider.OpenAi)]
+    [InlineData(AiProvider.AzureFoundry)]
+    [InlineData(AiProvider.DeepSeekWithFal)]
+    public async Task Parse_Returns429_LogsWarning(AiProvider provider)
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.TooManyRequests, "{}");
+        var logger = new Mock<ILogger>();
+        var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
+
+        await AiServiceHelper.ParseImageResponseAsync(
+            response, provider, client, logger.Object, null, CancellationToken.None);
+
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("429") || v.ToString()!.Contains("TooManyRequests")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(AiProvider.OpenAi)]
+    [InlineData(AiProvider.AzureFoundry)]
+    [InlineData(AiProvider.DeepSeekWithFal)]
+    public async Task Parse_NonSuccessStatus_ReturnsEmpty(AiProvider provider)
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.InternalServerError, "{}");
+        var logger = new Mock<ILogger>();
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, provider, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData(AiProvider.OpenAi)]
+    [InlineData(AiProvider.AzureFoundry)]
+    [InlineData(AiProvider.DeepSeekWithFal)]
+    public async Task Parse_MalformedJson_ReturnsEmpty(AiProvider provider)
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("NOT-JSON", Encoding.UTF8, "application/json")
+        };
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, provider, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    // ── OpenAI extractor ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Parse_OpenAi_ValidB64_ReturnsBytes()
+    {
+        var expected = new byte[] { 1, 2, 3, 4 };
+        var b64 = Convert.ToBase64String(expected);
+        var json = $"{{\"data\":[{{\"b64_json\":\"{b64}\"}}]}}";
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse(json);
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.OpenAi, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task Parse_OpenAi_MissingDataProperty_ReturnsEmpty()
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse("{\"other\":\"value\"}");
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.OpenAi, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Parse_OpenAi_EmptyDataArray_ReturnsEmpty()
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse("{\"data\":[]}");
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.OpenAi, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Parse_OpenAi_EmptyB64Value_ReturnsEmpty()
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse("{\"data\":[{\"b64_json\":\"\"}]}");
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.OpenAi, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    // ── fal.ai extractor ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Parse_FalAi_ValidUrl_ReturnsBytes()
+    {
+        var expected = new byte[] { 10, 20, 30 };
+        var imageUrl = "https://cdn.fal.ai/img.png";
+        var json = $"{{\"images\":[{{\"url\":\"{imageUrl}\"}}]}}";
+
+        var (client, _) = MakeSequenceClient(
+            JsonResponse(json),
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(expected) });
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse(json);
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task Parse_FalAi_MissingImagesProperty_ReturnsEmpty()
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse("{\"other\":\"value\"}");
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Parse_FalAi_EmptyImagesArray_ReturnsEmpty()
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse("{\"images\":[]}");
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Parse_FalAi_MissingUrlProperty_ReturnsEmpty()
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse("{\"images\":[{\"width\":512}]}");
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Parse_FalAi_EmptyUrl_ReturnsEmpty()
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse("{\"images\":[{\"url\":\"\"}]}");
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Parse_FalAi_DownloadThrows_ReturnsEmpty()
+    {
+        var imageUrl = "https://cdn.fal.ai/img.png";
+        var json = $"{{\"images\":[{{\"url\":\"{imageUrl}\"}}]}}";
+        var (client, _) = MakeThrowingDownloadClient(JsonResponse(json));
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse(json);
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Parse_FalAi_DownloadThrows_LogsError()
+    {
+        var imageUrl = "https://cdn.fal.ai/img.png";
+        var json = $"{{\"images\":[{{\"url\":\"{imageUrl}\"}}]}}";
+        var (client, _) = MakeThrowingDownloadClient(JsonResponse(json));
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse(json);
+
+        await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("fal.ai") &&
+                    v.ToString()!.Contains("failed to download generated image from URL") &&
+                    v.ToString()!.Contains(imageUrl)),
+                It.IsAny<HttpRequestException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    // ── AzureFoundry extractor ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Parse_AzureFoundry_ValidB64_ReturnsBytes()
+    {
+        var expected = new byte[] { 5, 6, 7, 8 };
+        var b64 = Convert.ToBase64String(expected);
+        var json = $"{{\"data\":[{{\"b64_json\":\"{b64}\"}}]}}";
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse(json);
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.AzureFoundry, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task Parse_AzureFoundry_UrlFallback_ReturnsBytes()
+    {
+        var expected = new byte[] { 11, 22, 33 };
+        var imageUrl = "https://foundry.azure.com/img.png";
+        var json = $"{{\"data\":[{{\"url\":\"{imageUrl}\"}}]}}";
+
+        var (client, _) = MakeSequenceClient(
+            JsonResponse(json),
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(expected) });
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse(json);
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.AzureFoundry, client, logger.Object,
+            allowedOrigin: "https://foundry.azure.com", CancellationToken.None);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task Parse_AzureFoundry_UrlFallback_WrongOrigin_LogsWarning()
+    {
+        var imageUrl = "https://other-cdn.net/img.png";
+        var json = $"{{\"data\":[{{\"url\":\"{imageUrl}\"}}]}}";
+        var expected = new byte[] { 1, 2 };
+
+        var (client, _) = MakeSequenceClient(
+            JsonResponse(json),
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(expected) });
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse(json);
+
+        await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.AzureFoundry, client, logger.Object,
+            allowedOrigin: "https://foundry.azure.com", CancellationToken.None);
+
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("different origin") &&
+                    v.ToString()!.Contains(imageUrl)),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Parse_AzureFoundry_MissingDataProperty_ReturnsEmpty()
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse("{\"other\":\"value\"}");
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.AzureFoundry, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Parse_AzureFoundry_MissingBothB64AndUrl_ReturnsEmpty()
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse("{\"data\":[{\"width\":512}]}");
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.AzureFoundry, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Parse_AzureFoundry_UrlFallback_DownloadThrows_ReturnsEmpty()
+    {
+        var imageUrl = "https://foundry.azure.com/img.png";
+        var json = $"{{\"data\":[{{\"url\":\"{imageUrl}\"}}]}}";
+        var (client, _) = MakeThrowingDownloadClient(JsonResponse(json));
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse(json);
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.AzureFoundry, client, logger.Object,
+            allowedOrigin: "https://foundry.azure.com", CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Parse_AzureFoundry_UrlFallback_DownloadThrows_LogsError()
+    {
+        var imageUrl = "https://foundry.azure.com/img.png";
+        var json = $"{{\"data\":[{{\"url\":\"{imageUrl}\"}}]}}";
+        var (client, _) = MakeThrowingDownloadClient(JsonResponse(json));
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse(json);
+
+        await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.AzureFoundry, client, logger.Object,
+            allowedOrigin: "https://foundry.azure.com", CancellationToken.None);
+
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("Azure Foundry") &&
+                    v.ToString()!.Contains("failed to download image from fallback URL") &&
+                    v.ToString()!.Contains(imageUrl)),
+                It.IsAny<HttpRequestException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    // ── Unsupported provider ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Parse_UnsupportedProvider_ReturnsEmpty()
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse("{\"data\":[{\"b64_json\":\"dGVzdA==\"}]}");
+
+        var result = await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.Perplexity, client, logger.Object, null, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Parse_UnsupportedProvider_LogsError()
+    {
+        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
+        var logger = new Mock<ILogger>();
+        var response = JsonResponse("{\"data\":[{\"b64_json\":\"dGVzdA==\"}]}");
+
+        await AiServiceHelper.ParseImageResponseAsync(
+            response, AiProvider.Perplexity, client, logger.Object, null, CancellationToken.None);
+
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("Perplexity") &&
+                    v.ToString()!.Contains("not supported")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/tests/Services/AiServiceHelperImageTests.cs
+++ b/tests/Services/AiServiceHelperImageTests.cs
@@ -13,8 +13,17 @@ namespace XPoster.Tests.Services;
 /// </summary>
 public class AiServiceHelperImageTests
 {
-    private static (HttpClient Client, Mock<HttpMessageHandler> Handler) MakeSingleResponseClient(
-        HttpStatusCode code, string body)
+    private static HttpClient MakeNoOpClient()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        return new HttpClient(handler.Object);
+    }
+
+    /// <summary>
+    /// Returns an HttpClient whose handler returns <paramref name="downloadBytes"/> on the first SendAsync
+    /// (i.e. the image download request issued inside the extractor).
+    /// </summary>
+    private static HttpClient MakeDownloadClient(byte[] downloadBytes)
     {
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected()
@@ -22,39 +31,26 @@ public class AiServiceHelperImageTests
                 "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage(code)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
             {
-                Content = new StringContent(body, Encoding.UTF8, "application/json")
+                Content = new ByteArrayContent(downloadBytes)
             });
-        return (new HttpClient(handler.Object), handler);
+        return new HttpClient(handler.Object);
     }
 
-    private static (HttpClient Client, Mock<HttpMessageHandler> Handler) MakeSequenceClient(
-        HttpResponseMessage first, HttpResponseMessage second)
+    /// <summary>
+    /// Returns an HttpClient whose handler throws <see cref="HttpRequestException"/> on the first SendAsync.
+    /// </summary>
+    private static (HttpClient Client, Mock<ILogger> Logger) MakeThrowingDownloadClient()
     {
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected()
-            .SetupSequence<Task<HttpResponseMessage>>(
+            .Setup<Task<HttpResponseMessage>>(
                 "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(first)
-            .ReturnsAsync(second);
-        return (new HttpClient(handler.Object), handler);
-    }
-
-    private static (HttpClient Client, Mock<HttpMessageHandler> Handler) MakeThrowingDownloadClient(
-        HttpResponseMessage first)
-    {
-        var handler = new Mock<HttpMessageHandler>();
-        handler.Protected()
-            .SetupSequence<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(first)
             .ThrowsAsync(new HttpRequestException("download failed"));
-        return (new HttpClient(handler.Object), handler);
+        return (new HttpClient(handler.Object), new Mock<ILogger>());
     }
 
     private static HttpResponseMessage JsonResponse(string body) =>
@@ -71,12 +67,11 @@ public class AiServiceHelperImageTests
     [InlineData(AiProvider.DeepSeekWithFal)]
     public async Task Parse_Returns429_ReturnsEmpty(AiProvider provider)
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.TooManyRequests, "{}");
         var logger = new Mock<ILogger>();
         var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, provider, client, logger.Object, null, CancellationToken.None);
+            response, provider, MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -87,12 +82,11 @@ public class AiServiceHelperImageTests
     [InlineData(AiProvider.DeepSeekWithFal)]
     public async Task Parse_Returns429_LogsWarning(AiProvider provider)
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.TooManyRequests, "{}");
         var logger = new Mock<ILogger>();
         var response = new HttpResponseMessage(HttpStatusCode.TooManyRequests);
 
         await AiServiceHelper.ParseImageResponseAsync(
-            response, provider, client, logger.Object, null, CancellationToken.None);
+            response, provider, MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         logger.Verify(
             x => x.Log(
@@ -111,12 +105,11 @@ public class AiServiceHelperImageTests
     [InlineData(AiProvider.DeepSeekWithFal)]
     public async Task Parse_NonSuccessStatus_ReturnsEmpty(AiProvider provider)
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.InternalServerError, "{}");
         var logger = new Mock<ILogger>();
         var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, provider, client, logger.Object, null, CancellationToken.None);
+            response, provider, MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -127,7 +120,6 @@ public class AiServiceHelperImageTests
     [InlineData(AiProvider.DeepSeekWithFal)]
     public async Task Parse_MalformedJson_ReturnsEmpty(AiProvider provider)
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
         var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
@@ -135,7 +127,7 @@ public class AiServiceHelperImageTests
         };
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, provider, client, logger.Object, null, CancellationToken.None);
+            response, provider, MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -148,12 +140,10 @@ public class AiServiceHelperImageTests
         var expected = new byte[] { 1, 2, 3, 4 };
         var b64 = Convert.ToBase64String(expected);
         var json = $"{{\"data\":[{{\"b64_json\":\"{b64}\"}}]}}";
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse(json);
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.OpenAi, client, logger.Object, null, CancellationToken.None);
+            JsonResponse(json), AiProvider.OpenAi, MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Equal(expected, result);
     }
@@ -161,12 +151,10 @@ public class AiServiceHelperImageTests
     [Fact]
     public async Task Parse_OpenAi_MissingDataProperty_ReturnsEmpty()
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse("{\"other\":\"value\"}");
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.OpenAi, client, logger.Object, null, CancellationToken.None);
+            JsonResponse("{\"other\":\"value\"}"), AiProvider.OpenAi, MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -174,12 +162,10 @@ public class AiServiceHelperImageTests
     [Fact]
     public async Task Parse_OpenAi_EmptyDataArray_ReturnsEmpty()
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse("{\"data\":[]}");
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.OpenAi, client, logger.Object, null, CancellationToken.None);
+            JsonResponse("{\"data\":[]}"), AiProvider.OpenAi, MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -187,12 +173,10 @@ public class AiServiceHelperImageTests
     [Fact]
     public async Task Parse_OpenAi_EmptyB64Value_ReturnsEmpty()
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse("{\"data\":[{\"b64_json\":\"\"}]}");
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.OpenAi, client, logger.Object, null, CancellationToken.None);
+            JsonResponse("{\"data\":[{\"b64_json\":\"\"}]}"), AiProvider.OpenAi, MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -205,15 +189,11 @@ public class AiServiceHelperImageTests
         var expected = new byte[] { 10, 20, 30 };
         var imageUrl = "https://cdn.fal.ai/img.png";
         var json = $"{{\"images\":[{{\"url\":\"{imageUrl}\"}}]}}";
-
-        var (client, _) = MakeSequenceClient(
-            JsonResponse(json),
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(expected) });
         var logger = new Mock<ILogger>();
-        var response = JsonResponse(json);
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+            JsonResponse(json), AiProvider.DeepSeekWithFal,
+            MakeDownloadClient(expected), logger.Object, null, CancellationToken.None);
 
         Assert.Equal(expected, result);
     }
@@ -221,12 +201,11 @@ public class AiServiceHelperImageTests
     [Fact]
     public async Task Parse_FalAi_MissingImagesProperty_ReturnsEmpty()
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse("{\"other\":\"value\"}");
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+            JsonResponse("{\"other\":\"value\"}"), AiProvider.DeepSeekWithFal,
+            MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -234,12 +213,11 @@ public class AiServiceHelperImageTests
     [Fact]
     public async Task Parse_FalAi_EmptyImagesArray_ReturnsEmpty()
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse("{\"images\":[]}");
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+            JsonResponse("{\"images\":[]}"), AiProvider.DeepSeekWithFal,
+            MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -247,12 +225,11 @@ public class AiServiceHelperImageTests
     [Fact]
     public async Task Parse_FalAi_MissingUrlProperty_ReturnsEmpty()
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse("{\"images\":[{\"width\":512}]}");
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+            JsonResponse("{\"images\":[{\"width\":512}]}"), AiProvider.DeepSeekWithFal,
+            MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -260,12 +237,11 @@ public class AiServiceHelperImageTests
     [Fact]
     public async Task Parse_FalAi_EmptyUrl_ReturnsEmpty()
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse("{\"images\":[{\"url\":\"\"}]}");
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+            JsonResponse("{\"images\":[{\"url\":\"\"}]}"), AiProvider.DeepSeekWithFal,
+            MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -275,12 +251,12 @@ public class AiServiceHelperImageTests
     {
         var imageUrl = "https://cdn.fal.ai/img.png";
         var json = $"{{\"images\":[{{\"url\":\"{imageUrl}\"}}]}}";
-        var (client, _) = MakeThrowingDownloadClient(JsonResponse(json));
+        var (client, _) = MakeThrowingDownloadClient();
         var logger = new Mock<ILogger>();
-        var response = JsonResponse(json);
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+            JsonResponse(json), AiProvider.DeepSeekWithFal,
+            client, logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -290,12 +266,12 @@ public class AiServiceHelperImageTests
     {
         var imageUrl = "https://cdn.fal.ai/img.png";
         var json = $"{{\"images\":[{{\"url\":\"{imageUrl}\"}}]}}";
-        var (client, _) = MakeThrowingDownloadClient(JsonResponse(json));
+        var (client, _) = MakeThrowingDownloadClient();
         var logger = new Mock<ILogger>();
-        var response = JsonResponse(json);
 
         await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.DeepSeekWithFal, client, logger.Object, null, CancellationToken.None);
+            JsonResponse(json), AiProvider.DeepSeekWithFal,
+            client, logger.Object, null, CancellationToken.None);
 
         logger.Verify(
             x => x.Log(
@@ -318,12 +294,11 @@ public class AiServiceHelperImageTests
         var expected = new byte[] { 5, 6, 7, 8 };
         var b64 = Convert.ToBase64String(expected);
         var json = $"{{\"data\":[{{\"b64_json\":\"{b64}\"}}]}}";
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse(json);
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.AzureFoundry, client, logger.Object, null, CancellationToken.None);
+            JsonResponse(json), AiProvider.AzureFoundry,
+            MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Equal(expected, result);
     }
@@ -334,15 +309,11 @@ public class AiServiceHelperImageTests
         var expected = new byte[] { 11, 22, 33 };
         var imageUrl = "https://foundry.azure.com/img.png";
         var json = $"{{\"data\":[{{\"url\":\"{imageUrl}\"}}]}}";
-
-        var (client, _) = MakeSequenceClient(
-            JsonResponse(json),
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(expected) });
         var logger = new Mock<ILogger>();
-        var response = JsonResponse(json);
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.AzureFoundry, client, logger.Object,
+            JsonResponse(json), AiProvider.AzureFoundry,
+            MakeDownloadClient(expected), logger.Object,
             allowedOrigin: "https://foundry.azure.com", CancellationToken.None);
 
         Assert.Equal(expected, result);
@@ -354,15 +325,11 @@ public class AiServiceHelperImageTests
         var imageUrl = "https://other-cdn.net/img.png";
         var json = $"{{\"data\":[{{\"url\":\"{imageUrl}\"}}]}}";
         var expected = new byte[] { 1, 2 };
-
-        var (client, _) = MakeSequenceClient(
-            JsonResponse(json),
-            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(expected) });
         var logger = new Mock<ILogger>();
-        var response = JsonResponse(json);
 
         await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.AzureFoundry, client, logger.Object,
+            JsonResponse(json), AiProvider.AzureFoundry,
+            MakeDownloadClient(expected), logger.Object,
             allowedOrigin: "https://foundry.azure.com", CancellationToken.None);
 
         logger.Verify(
@@ -380,12 +347,11 @@ public class AiServiceHelperImageTests
     [Fact]
     public async Task Parse_AzureFoundry_MissingDataProperty_ReturnsEmpty()
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse("{\"other\":\"value\"}");
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.AzureFoundry, client, logger.Object, null, CancellationToken.None);
+            JsonResponse("{\"other\":\"value\"}"), AiProvider.AzureFoundry,
+            MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -393,12 +359,11 @@ public class AiServiceHelperImageTests
     [Fact]
     public async Task Parse_AzureFoundry_MissingBothB64AndUrl_ReturnsEmpty()
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse("{\"data\":[{\"width\":512}]}");
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.AzureFoundry, client, logger.Object, null, CancellationToken.None);
+            JsonResponse("{\"data\":[{\"width\":512}]}"), AiProvider.AzureFoundry,
+            MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -408,12 +373,12 @@ public class AiServiceHelperImageTests
     {
         var imageUrl = "https://foundry.azure.com/img.png";
         var json = $"{{\"data\":[{{\"url\":\"{imageUrl}\"}}]}}";
-        var (client, _) = MakeThrowingDownloadClient(JsonResponse(json));
+        var (client, _) = MakeThrowingDownloadClient();
         var logger = new Mock<ILogger>();
-        var response = JsonResponse(json);
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.AzureFoundry, client, logger.Object,
+            JsonResponse(json), AiProvider.AzureFoundry,
+            client, logger.Object,
             allowedOrigin: "https://foundry.azure.com", CancellationToken.None);
 
         Assert.Empty(result);
@@ -424,12 +389,12 @@ public class AiServiceHelperImageTests
     {
         var imageUrl = "https://foundry.azure.com/img.png";
         var json = $"{{\"data\":[{{\"url\":\"{imageUrl}\"}}]}}";
-        var (client, _) = MakeThrowingDownloadClient(JsonResponse(json));
+        var (client, _) = MakeThrowingDownloadClient();
         var logger = new Mock<ILogger>();
-        var response = JsonResponse(json);
 
         await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.AzureFoundry, client, logger.Object,
+            JsonResponse(json), AiProvider.AzureFoundry,
+            client, logger.Object,
             allowedOrigin: "https://foundry.azure.com", CancellationToken.None);
 
         logger.Verify(
@@ -450,12 +415,11 @@ public class AiServiceHelperImageTests
     [Fact]
     public async Task Parse_UnsupportedProvider_ReturnsEmpty()
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse("{\"data\":[{\"b64_json\":\"dGVzdA==\"}]}");
 
         var result = await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.Perplexity, client, logger.Object, null, CancellationToken.None);
+            JsonResponse("{\"data\":[{\"b64_json\":\"dGVzdA==\"}]}"), AiProvider.Perplexity,
+            MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         Assert.Empty(result);
     }
@@ -463,12 +427,11 @@ public class AiServiceHelperImageTests
     [Fact]
     public async Task Parse_UnsupportedProvider_LogsError()
     {
-        var (client, _) = MakeSingleResponseClient(HttpStatusCode.OK, "{}");
         var logger = new Mock<ILogger>();
-        var response = JsonResponse("{\"data\":[{\"b64_json\":\"dGVzdA==\"}]}");
 
         await AiServiceHelper.ParseImageResponseAsync(
-            response, AiProvider.Perplexity, client, logger.Object, null, CancellationToken.None);
+            JsonResponse("{\"data\":[{\"b64_json\":\"dGVzdA==\"}]}"), AiProvider.Perplexity,
+            MakeNoOpClient(), logger.Object, null, CancellationToken.None);
 
         logger.Verify(
             x => x.Log(

--- a/tests/Services/AiServiceHelperTests.cs
+++ b/tests/Services/AiServiceHelperTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Moq;
 using XPoster.Services;
@@ -7,8 +8,9 @@ using XPoster.Services;
 namespace XPoster.Tests.Services;
 
 /// <summary>
-/// Unit tests for <see cref="AiServiceHelper.ParseChatCompletionResponseAsync"/>.
-/// Verifies the five-step guard pipeline in isolation.
+/// Unit tests for <see cref="AiServiceHelper.ParseChatCompletionResponseAsync"/> and
+/// <see cref="AiServiceHelper.ParseImageResponseAsync"/>.
+/// Verifies shared guard pipelines in isolation.
 /// </summary>
 public class AiServiceHelperTests
 {
@@ -23,7 +25,10 @@ public class AiServiceHelperTests
     private static string ChatJson(string content) =>
         $"{{\"choices\":[{{\"message\":{{\"content\":\"{content}\"}}}}]}}";
 
-    // --- 429 guard ---
+    private static string ImageJson(string propertyName, string propertyValue) =>
+        $"{{\"data\":[{{\"{propertyName}\":\"{propertyValue}\"}}]}}";
+
+    // --- chat completion helper ---
 
     [Fact]
     public async Task ParseChatCompletionResponseAsync_WhenStatusIs429_ReturnsFalseAndEmpty()
@@ -58,8 +63,6 @@ public class AiServiceHelperTests
             Times.Once);
     }
 
-    // --- non-2xx guard ---
-
     [Theory]
     [InlineData(HttpStatusCode.BadRequest)]
     [InlineData(HttpStatusCode.InternalServerError)]
@@ -75,8 +78,6 @@ public class AiServiceHelperTests
         Assert.False(success);
         Assert.Equal(string.Empty, content);
     }
-
-    // --- null/empty choices guard ---
 
     [Fact]
     public async Task ParseChatCompletionResponseAsync_WhenChoicesIsNull_ReturnsFalseAndEmpty()
@@ -114,8 +115,6 @@ public class AiServiceHelperTests
         Assert.Equal(string.Empty, content);
     }
 
-    // --- happy path ---
-
     [Fact]
     public async Task ParseChatCompletionResponseAsync_WhenValidResponse_ReturnsTrueAndTrimmedContent()
     {
@@ -139,8 +138,6 @@ public class AiServiceHelperTests
         Assert.True(success);
         Assert.Equal(string.Empty, content);
     }
-
-    // --- provider name appears in log messages ---
 
     [Fact]
     public async Task ParseChatCompletionResponseAsync_WhenNonSuccess_LogsProviderNameAndStatusCode()
@@ -180,5 +177,144 @@ public class AiServiceHelperTests
                 null,
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
+    }
+
+    // --- image helper ---
+
+    [Fact]
+    public async Task ParseImageResponseAsync_WhenStatusIs429_ReturnsFalseAndNull()
+    {
+        var response = MakeResponse(HttpStatusCode.TooManyRequests, "{}");
+
+        var (success, content) = await AiServiceHelper.ParseImageResponseAsync(
+            response, "TestProvider", _logger.Object, CancellationToken.None);
+
+        Assert.False(success);
+        Assert.Null(content);
+    }
+
+    [Fact]
+    public async Task ParseImageResponseAsync_WhenStatusIs429_LogsWarning()
+    {
+        var loggerMock = new Mock<ILogger>();
+        var response = MakeResponse(HttpStatusCode.TooManyRequests, "{}");
+
+        await AiServiceHelper.ParseImageResponseAsync(
+            response, "MyProvider", loggerMock.Object, CancellationToken.None);
+
+        loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("MyProvider") &&
+                    (v.ToString()!.Contains("429") || v.ToString()!.Contains("TooManyRequests"))),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public async Task ParseImageResponseAsync_WhenStatusIsNonSuccess_ReturnsFalseAndNull(HttpStatusCode code)
+    {
+        var response = MakeResponse(code, "{}");
+
+        var (success, content) = await AiServiceHelper.ParseImageResponseAsync(
+            response, "TestProvider", _logger.Object, CancellationToken.None);
+
+        Assert.False(success);
+        Assert.Null(content);
+    }
+
+    [Fact]
+    public async Task ParseImageResponseAsync_WhenStatusIsNonSuccess_LogsError()
+    {
+        var loggerMock = new Mock<ILogger>();
+        var response = MakeResponse(HttpStatusCode.InternalServerError, "{}");
+
+        await AiServiceHelper.ParseImageResponseAsync(
+            response, "OpenAI", loggerMock.Object, CancellationToken.None);
+
+        loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("OpenAI") &&
+                    v.ToString()!.Contains("InternalServerError")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ParseImageResponseAsync_WhenResponseBodyIsMalformedJson_ReturnsFalseAndNull()
+    {
+        var response = MakeResponse(HttpStatusCode.OK, "NOT_JSON");
+
+        var (success, content) = await AiServiceHelper.ParseImageResponseAsync(
+            response, "TestProvider", _logger.Object, CancellationToken.None);
+
+        Assert.False(success);
+        Assert.Null(content);
+    }
+
+    [Fact]
+    public async Task ParseImageResponseAsync_WhenResponseBodyIsMalformedJson_LogsError()
+    {
+        var loggerMock = new Mock<ILogger>();
+        var response = MakeResponse(HttpStatusCode.OK, "NOT_JSON");
+
+        await AiServiceHelper.ParseImageResponseAsync(
+            response, "Azure Foundry", loggerMock.Object, CancellationToken.None);
+
+        loggerMock.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Azure Foundry")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ParseImageResponseAsync_WhenResponseIs200WithValidJson_ReturnsTrueAndContent()
+    {
+        var response = MakeResponse(HttpStatusCode.OK, ImageJson("b64_json", "YWJj"));
+
+        var (success, content) = await AiServiceHelper.ParseImageResponseAsync(
+            response, "OpenAI", _logger.Object, CancellationToken.None);
+
+        Assert.True(success);
+        Assert.NotNull(content);
+        Assert.True(content.Value.TryGetProperty("data", out var data));
+        Assert.Equal(JsonValueKind.Array, data.ValueKind);
+    }
+
+    [Fact]
+    public async Task ParseImageResponseAsync_WhenProviderNameAppearsInAllLogs()
+    {
+        var loggerMock = new Mock<ILogger>();
+
+        await AiServiceHelper.ParseImageResponseAsync(
+            MakeResponse(HttpStatusCode.TooManyRequests, "{}"), "fal.ai", loggerMock.Object, CancellationToken.None);
+        await AiServiceHelper.ParseImageResponseAsync(
+            MakeResponse(HttpStatusCode.InternalServerError, "{}"), "fal.ai", loggerMock.Object, CancellationToken.None);
+        await AiServiceHelper.ParseImageResponseAsync(
+            MakeResponse(HttpStatusCode.OK, "NOT_JSON"), "fal.ai", loggerMock.Object, CancellationToken.None);
+
+        loggerMock.Verify(
+            l => l.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("fal.ai")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Exactly(3));
     }
 }

--- a/tests/Services/AzureFoundryServiceTests.cs
+++ b/tests/Services/AzureFoundryServiceTests.cs
@@ -49,8 +49,6 @@ public class AzureFoundryServiceTests
     private static string ChatCompletionJson(string content) =>
         "{\"choices\":[{\"message\":{\"content\":\"" + content + "\"}}]}";
 
-    // ── GetSummaryAsync ──────────────────────────────────────────────────────
-
     [Fact]
     public async Task GetSummaryAsync_WhenTextExceedsLimit_CallsApiAndReturnsTrimmedContent()
     {
@@ -110,8 +108,6 @@ public class AzureFoundryServiceTests
         Assert.Equal(string.Empty, result);
     }
 
-    // ── GetImagePromptAsync ─────────────────────────────────────────────────
-
     [Fact]
     public async Task GetImagePromptAsync_WhenApiReturnsValidResponse_ReturnsPrompt()
     {
@@ -142,8 +138,6 @@ public class AzureFoundryServiceTests
         Assert.Equal(string.Empty, result);
     }
 
-    // ── GenerateImageAsync ──────────────────────────────────────────────────
-
     [Fact]
     public async Task GenerateImageAsync_WhenApiReturnsValidResponse_ReturnsByteArray()
     {
@@ -167,7 +161,6 @@ public class AzureFoundryServiceTests
         Assert.Empty(result);
     }
 
-    /// <summary>G1 — 429 on image generation must return empty, not fall through to success path.</summary>
     [Fact]
     public async Task GenerateImageAsync_WhenApiReturnsTooManyRequests_ReturnsEmptyByteArray()
     {
@@ -178,7 +171,25 @@ public class AzureFoundryServiceTests
         Assert.Empty(result);
     }
 
-    /// <summary>G2 — Malformed JSON on 200 must not throw; must return empty array.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenApiReturnsTooManyRequests_LogsWarning()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.TooManyRequests, "{}").Object, out var loggerMock);
+
+        await svc.GenerateImageAsync("image prompt");
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("Azure Foundry") &&
+                    (v.ToString()!.Contains("429") || v.ToString()!.Contains("TooManyRequests"))),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
     [Fact]
     public async Task GenerateImageAsync_WhenResponseBodyIsMalformedJson_ReturnsEmptyByteArray()
     {
@@ -189,7 +200,6 @@ public class AzureFoundryServiceTests
         Assert.Empty(result);
     }
 
-    /// <summary>G3 — Empty data array on 200 must return empty array without throwing IndexOutOfRangeException.</summary>
     [Fact]
     public async Task GenerateImageAsync_WhenDataArrayIsEmpty_ReturnsEmptyByteArray()
     {
@@ -200,7 +210,6 @@ public class AzureFoundryServiceTests
         Assert.Empty(result);
     }
 
-    /// <summary>G4 — b64_json null must return empty array, not throw FormatException.</summary>
     [Fact]
     public async Task GenerateImageAsync_WhenB64JsonIsNull_ReturnsEmptyByteArray()
     {
@@ -211,10 +220,6 @@ public class AzureFoundryServiceTests
         Assert.Empty(result);
     }
 
-    /// <summary>
-    /// G5 — When b64_json is absent but a url is present, the service downloads from the url
-    /// and returns the bytes.
-    /// </summary>
     [Fact]
     public async Task GenerateImageAsync_WhenB64JsonAbsentAndUrlPresent_DownloadsFromUrl()
     {
@@ -249,9 +254,6 @@ public class AzureFoundryServiceTests
         Assert.Equal(imageBytes, result);
     }
 
-    /// <summary>
-    /// G6 — A fallback url that does not originate from the configured endpoint must emit a LogWarning.
-    /// </summary>
     [Fact]
     public async Task GenerateImageAsync_WhenFallbackUrlIsFromDifferentOrigin_LogsWarning()
     {
@@ -293,7 +295,49 @@ public class AzureFoundryServiceTests
             Times.Once);
     }
 
-    /// <summary>G7 — Empty prompt must return empty array immediately, without making any HTTP call.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenHttpRequestExceptionOnPost_ReturnsEmptyByteArray()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("network failure"));
+
+        var svc = BuildService(handler.Object, out _);
+
+        var result = await svc.GenerateImageAsync("image prompt");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GenerateImageAsync_WhenHttpRequestExceptionOnPost_LogsError()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("network failure"));
+
+        var svc = BuildService(handler.Object, out var loggerMock);
+
+        await svc.GenerateImageAsync("image prompt");
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Azure Foundry image generation HTTP request failed")),
+                It.IsAny<HttpRequestException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
     [Fact]
     public async Task GenerateImageAsync_WhenPromptIsEmpty_ReturnsEmptyByteArrayWithoutCallingApi()
     {
@@ -310,7 +354,24 @@ public class AzureFoundryServiceTests
             ItExpr.IsAny<CancellationToken>());
     }
 
-    /// <summary>G8 — Whitespace-only prompt must also be rejected before any HTTP call.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenPromptIsEmpty_LogsWarning()
+    {
+        var handler = MakeHandlerMock(HttpStatusCode.OK, "{}");
+        var svc = BuildService(handler.Object, out var loggerMock);
+
+        await svc.GenerateImageAsync(string.Empty);
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("empty or whitespace prompt")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
     [Fact]
     public async Task GenerateImageAsync_WhenPromptIsWhitespace_ReturnsEmptyByteArrayWithoutCallingApi()
     {
@@ -327,10 +388,6 @@ public class AzureFoundryServiceTests
             ItExpr.IsAny<CancellationToken>());
     }
 
-    /// <summary>
-    /// E1 — GenerateImageAsync must POST to the Foundry /images/generations path,
-    /// not the classic Azure OpenAI /openai/deployments/{name}/images/generations path.
-    /// </summary>
     [Fact]
     public async Task GenerateImageAsync_PostsToFoundryImagesGenerationsEndpoint()
     {
@@ -352,9 +409,6 @@ public class AzureFoundryServiceTests
             ItExpr.IsAny<CancellationToken>());
     }
 
-    /// <summary>
-    /// E2 — The image request body must include the `model` field set to ImageDeploymentName.
-    /// </summary>
     [Fact]
     public async Task GenerateImageAsync_RequestBodyContainsModelField()
     {
@@ -387,10 +441,6 @@ public class AzureFoundryServiceTests
         Assert.Equal("gpt-image-1.5", modelProp.GetString());
     }
 
-    /// <summary>
-    /// C1 — GetSummaryAsync must POST to the Foundry /chat/completions path,
-    /// not the classic Azure OpenAI /openai/deployments/{name}/chat/completions path.
-    /// </summary>
     [Fact]
     public async Task GetSummaryAsync_PostsToFoundryChatCompletionsEndpoint()
     {
@@ -409,9 +459,6 @@ public class AzureFoundryServiceTests
             ItExpr.IsAny<CancellationToken>());
     }
 
-    /// <summary>
-    /// C2 — The chat request body must include the `model` field set to DeploymentName.
-    /// </summary>
     [Fact]
     public async Task GetSummaryAsync_RequestBodyContainsModelField()
     {

--- a/tests/Services/FalAiImageServiceTests.cs
+++ b/tests/Services/FalAiImageServiceTests.cs
@@ -11,9 +11,6 @@ namespace XPoster.Tests.Services;
 
 public class FalAiImageServiceTests
 {
-    // Builds a FalAiImageService with a controllable HttpMessageHandler.
-    // The same handler is reused for both the POST (image generation) and the
-    // GET (image download) calls, or a dedicated download handler can be provided.
     private static FalAiImageService BuildService(
         HttpMessageHandler handler,
         out Mock<ILogger<FalAiImageService>> loggerMock,
@@ -33,7 +30,6 @@ public class FalAiImageServiceTests
         return new FalAiImageService(factory.Object, options, loggerMock.Object);
     }
 
-    // Creates a handler mock that returns the same response for every request.
     private static Mock<HttpMessageHandler> MakeHandlerMock(HttpStatusCode code, string body)
     {
         var mock = new Mock<HttpMessageHandler>();
@@ -49,13 +45,8 @@ public class FalAiImageServiceTests
         return mock;
     }
 
-    // Builds the fal.ai image generation response JSON with a single image URL entry.
     private static string FalImageJson(string imageUrl) =>
         $"{{\"images\":[{{\"url\":\"{imageUrl}\"}}]}}";
-
-    // -------------------------------------------------------------------------
-    // Prompt guard
-    // -------------------------------------------------------------------------
 
     [Fact]
     public async Task GenerateImageAsync_EmptyPrompt_ReturnsEmptyArray()
@@ -77,10 +68,6 @@ public class FalAiImageServiceTests
         Assert.Empty(result);
     }
 
-    // -------------------------------------------------------------------------
-    // HTTP error codes
-    // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GenerateImageAsync_Returns429_ReturnsEmptyArray()
     {
@@ -92,6 +79,25 @@ public class FalAiImageServiceTests
     }
 
     [Fact]
+    public async Task GenerateImageAsync_Returns429_LogsWarning()
+    {
+        var svc = BuildService(MakeHandlerMock(HttpStatusCode.TooManyRequests, "{}").Object, out var loggerMock);
+
+        await svc.GenerateImageAsync("a prompt");
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("fal.ai") &&
+                    (v.ToString()!.Contains("429") || v.ToString()!.Contains("TooManyRequests"))),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task GenerateImageAsync_ReturnsNonSuccess_ReturnsEmptyArray()
     {
         var svc = BuildService(MakeHandlerMock(HttpStatusCode.InternalServerError, "{}").Object, out _);
@@ -100,10 +106,6 @@ public class FalAiImageServiceTests
 
         Assert.Empty(result);
     }
-
-    // -------------------------------------------------------------------------
-    // JSON parsing
-    // -------------------------------------------------------------------------
 
     [Fact]
     public async Task GenerateImageAsync_MalformedJson_ReturnsEmptyArray()
@@ -157,18 +159,10 @@ public class FalAiImageServiceTests
         Assert.Empty(result);
     }
 
-    // -------------------------------------------------------------------------
-    // Happy path — successful image download
-    // -------------------------------------------------------------------------
-
     [Fact]
     public async Task GenerateImageAsync_ValidResponse_ReturnsImageBytes()
     {
-        var expectedBytes = new byte[] { 137, 80, 78, 71 }; // PNG magic bytes
-
-        // First call: POST to fal.run/{model} — returns JSON with image URL
-        // Second call: GET the image URL — returns raw bytes
-        // We use a sequential setup on the same mock handler.
+        var expectedBytes = new byte[] { 137, 80, 78, 71 };
         var handlerMock = new Mock<HttpMessageHandler>();
         var imageUrl = "https://cdn.fal.ai/output/image.png";
 
@@ -177,12 +171,10 @@ public class FalAiImageServiceTests
                 "SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
-            // First call: the POST to generate the image
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(FalImageJson(imageUrl), Encoding.UTF8, "application/json")
             })
-            // Second call: the GET to download the image
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new ByteArrayContent(expectedBytes)
@@ -195,16 +187,66 @@ public class FalAiImageServiceTests
         Assert.Equal(expectedBytes, result);
     }
 
-    // -------------------------------------------------------------------------
-    // Endpoint URL encoding — ModelId percent-encoding (Point 1, issue #139)
-    // -------------------------------------------------------------------------
+    [Fact]
+    public async Task GenerateImageAsync_WhenImageDownloadFails_HttpRequestException_ReturnsEmptyArray()
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var imageUrl = "https://cdn.fal.ai/output/image.png";
+
+        handlerMock.Protected()
+            .SetupSequence<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(FalImageJson(imageUrl), Encoding.UTF8, "application/json")
+            })
+            .ThrowsAsync(new HttpRequestException("download failed"));
+
+        var svc = BuildService(handlerMock.Object, out _);
+
+        var result = await svc.GenerateImageAsync("a prompt");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GenerateImageAsync_WhenImageDownloadFails_HttpRequestException_LogsError()
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var imageUrl = "https://cdn.fal.ai/output/image.png";
+
+        handlerMock.Protected()
+            .SetupSequence<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(FalImageJson(imageUrl), Encoding.UTF8, "application/json")
+            })
+            .ThrowsAsync(new HttpRequestException("download failed"));
+
+        var svc = BuildService(handlerMock.Object, out var loggerMock);
+
+        await svc.GenerateImageAsync("a prompt");
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("Failed to download generated image from fal.ai URL") &&
+                    v.ToString()!.Contains(imageUrl)),
+                It.IsAny<HttpRequestException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
 
     [Fact]
     public async Task GenerateImageAsync_ModelIdWithUnsafeChars_PercentEncodesInRequestUri()
     {
-        // ModelId containing a space — should be encoded as %20 in the request URI.
-        // The validator would normally block this at startup; this test verifies that
-        // even if an unsafe value reaches the service, the URL construction is safe.
         var opts = new FalAiOptions { ApiKey = "key", ModelId = "fal-ai/model with space" };
 
         HttpRequestMessage? capturedRequest = null;
@@ -222,7 +264,6 @@ public class FalAiImageServiceTests
         await svc.GenerateImageAsync("a prompt");
 
         Assert.NotNull(capturedRequest);
-        // The path must not contain a raw space; it must be percent-encoded.
         var path = capturedRequest!.RequestUri!.AbsolutePath;
         Assert.DoesNotContain(" ", path);
         Assert.Contains("%20", path, StringComparison.OrdinalIgnoreCase);
@@ -231,7 +272,6 @@ public class FalAiImageServiceTests
     [Fact]
     public async Task GenerateImageAsync_ModelIdWithMultipleSegments_PreservesSlashesInUri()
     {
-        // Default ModelId "fal-ai/flux/schnell" — slashes must remain as path separators.
         HttpRequestMessage? capturedRequest = null;
         var handlerMock = new Mock<HttpMessageHandler>();
         handlerMock.Protected()
@@ -248,7 +288,6 @@ public class FalAiImageServiceTests
 
         Assert.NotNull(capturedRequest);
         var path = capturedRequest!.RequestUri!.AbsolutePath;
-        // fal-ai, flux, schnell must all appear as distinct path segments.
         Assert.Contains("/fal-ai/flux/schnell", path, StringComparison.Ordinal);
     }
 }

--- a/tests/Services/FalAiImageServiceTests.cs
+++ b/tests/Services/FalAiImageServiceTests.cs
@@ -232,12 +232,14 @@ public class FalAiImageServiceTests
 
         await svc.GenerateImageAsync("a prompt");
 
+        // Message is now emitted by AiServiceHelper.ExtractFalAiBytesAsync
         loggerMock.Verify(
             x => x.Log(
                 LogLevel.Error,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, _) =>
-                    v.ToString()!.Contains("Failed to download generated image from fal.ai URL") &&
+                    v.ToString()!.Contains("fal.ai") &&
+                    v.ToString()!.Contains("failed to download generated image from URL") &&
                     v.ToString()!.Contains(imageUrl)),
                 It.IsAny<HttpRequestException>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),

--- a/tests/Services/OpenAiServiceTests.cs
+++ b/tests/Services/OpenAiServiceTests.cs
@@ -24,9 +24,6 @@ public class OpenAiServiceTests
         return new OpenAiService(factory.Object, options, loggerMock.Object);
     }
 
-    /// <summary>
-    /// Single-use handler: returns one fixed response. Safe for single-call tests.
-    /// </summary>
     private static HttpMessageHandler MakeHandler(HttpStatusCode code, string json)
     {
         var mock = new Mock<HttpMessageHandler>();
@@ -42,10 +39,6 @@ public class OpenAiServiceTests
         return mock.Object;
     }
 
-    /// <summary>
-    /// Multi-use handler: creates a fresh HttpResponseMessage on every SendAsync call.
-    /// Required for tests that exercise the retry loop (stream cannot be read twice).
-    /// </summary>
     private static Mock<HttpMessageHandler> MakeHandlerMock(HttpStatusCode code, string json)
     {
         var mock = new Mock<HttpMessageHandler>();
@@ -63,8 +56,6 @@ public class OpenAiServiceTests
 
     private static string ChatCompletionJson(string content) =>
         "{\"choices\":[{\"message\":{\"content\":\"" + content + "\"}}]}";
-
-    // ── GetSummaryAsync ──────────────────────────────────────────────────────
 
     [Fact]
     public async Task GetSummaryAsync_WhenTextAlreadyShort_ReturnsTextUnchanged()
@@ -115,11 +106,6 @@ public class OpenAiServiceTests
         Assert.Equal(string.Empty, result);
     }
 
-    /// <summary>
-    /// G5 — The retry loop must stop after at most 3 HTTP calls (tries 1,2,3; guard: tries &lt;= 2
-    /// checked before increment means the loop runs while tries is 0, 1, 2 — exactly 3 iterations).
-    /// Uses MakeHandlerMock so each call receives a fresh HttpResponseMessage with a readable stream.
-    /// </summary>
     [Fact]
     public async Task GetSummaryAsync_WhenSummaryAlwaysTooLong_StopsAfterThreeAttempts()
     {
@@ -137,8 +123,6 @@ public class OpenAiServiceTests
         Assert.Equal(longResponse, result);
     }
 
-    // ── GetImagePromptAsync ──────────────────────────────────────────────────
-
     [Fact]
     public async Task GetImagePromptAsync_WhenApiReturns200_ReturnsTrimmedContent()
     {
@@ -155,7 +139,6 @@ public class OpenAiServiceTests
         Assert.Equal(string.Empty, result);
     }
 
-    /// <summary>G6 — 429 must emit a log entry, not only return empty.</summary>
     [Fact]
     public async Task GetImagePromptAsync_WhenApiReturnsTooManyRequests_LogsInformation()
     {
@@ -196,8 +179,6 @@ public class OpenAiServiceTests
         Assert.Equal(string.Empty, result);
     }
 
-    // ── GenerateImageAsync ───────────────────────────────────────────────────
-
     [Fact]
     public async Task GenerateImageAsync_WhenApiReturns200_ReturnsDecodedBytes()
     {
@@ -217,7 +198,6 @@ public class OpenAiServiceTests
         Assert.Empty(result);
     }
 
-    /// <summary>G1 — 429 on image generation must return empty, not fall through to success path.</summary>
     [Fact]
     public async Task GenerateImageAsync_WhenApiReturnsTooManyRequests_ReturnsEmptyArray()
     {
@@ -226,7 +206,25 @@ public class OpenAiServiceTests
         Assert.Empty(result);
     }
 
-    /// <summary>G2 — Malformed JSON on 200 must not throw; must return empty array.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenApiReturnsTooManyRequests_LogsWarning()
+    {
+        var svc = BuildService(MakeHandler(HttpStatusCode.TooManyRequests, "{}"), out var loggerMock);
+
+        await svc.GenerateImageAsync("a prompt");
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) =>
+                    v.ToString()!.Contains("OpenAI") &&
+                    (v.ToString()!.Contains("429") || v.ToString()!.Contains("TooManyRequests"))),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
     [Fact]
     public async Task GenerateImageAsync_WhenResponseBodyIsMalformedJson_ReturnsEmptyArray()
     {
@@ -235,7 +233,6 @@ public class OpenAiServiceTests
         Assert.Empty(result);
     }
 
-    /// <summary>G3 — Empty data array on 200 must return empty array, not throw IndexOutOfRangeException.</summary>
     [Fact]
     public async Task GenerateImageAsync_WhenDataArrayIsEmpty_ReturnsEmptyArray()
     {
@@ -244,7 +241,6 @@ public class OpenAiServiceTests
         Assert.Empty(result);
     }
 
-    /// <summary>G4 — b64_json null in response must return empty array, not throw FormatException.</summary>
     [Fact]
     public async Task GenerateImageAsync_WhenB64JsonIsNull_ReturnsEmptyArray()
     {
@@ -253,7 +249,49 @@ public class OpenAiServiceTests
         Assert.Empty(result);
     }
 
-    /// <summary>G7 — Empty prompt must return empty array immediately, without making any HTTP call.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenHttpRequestExceptionThrown_ReturnsEmptyArray()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("network failure"));
+
+        var svc = BuildService(handler.Object, out _);
+
+        var result = await svc.GenerateImageAsync("a prompt");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GenerateImageAsync_WhenHttpRequestExceptionThrown_LogsError()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("network failure"));
+
+        var svc = BuildService(handler.Object, out var loggerMock);
+
+        await svc.GenerateImageAsync("a prompt");
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("OpenAI image generation HTTP request failed")),
+                It.IsAny<HttpRequestException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
     [Fact]
     public async Task GenerateImageAsync_WhenPromptIsEmpty_ReturnsEmptyArrayWithoutCallingApi()
     {
@@ -270,7 +308,24 @@ public class OpenAiServiceTests
             ItExpr.IsAny<CancellationToken>());
     }
 
-    /// <summary>G8 — Whitespace-only prompt must also be rejected before any HTTP call.</summary>
+    [Fact]
+    public async Task GenerateImageAsync_WhenPromptIsEmpty_LogsWarning()
+    {
+        var handler = MakeHandlerMock(HttpStatusCode.OK, "{}");
+        var svc = BuildService(handler.Object, out var loggerMock);
+
+        await svc.GenerateImageAsync(string.Empty);
+
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("empty or whitespace prompt")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
     [Fact]
     public async Task GenerateImageAsync_WhenPromptIsWhitespace_ReturnsEmptyArrayWithoutCallingApi()
     {


### PR DESCRIPTION
## Summary

Extracts the post-parse byte extraction logic shared across the three image generation services (`OpenAiService`, `AzureFoundryService`, `FalAiImageService`) into a single pipeline inside `AiServiceHelper`, conditioned on `AiProvider`.

Closes #168

---

## Motivation

Before this PR, each service duplicated ~20-30 lines of schema-specific JSON parsing after calling `ParseImageResponseAsync`. The logic was structurally identical but varied only in property names (`data` vs `images`, `b64_json` vs `url`) and byte extraction strategy (Base64 decode vs HTTP download). This was a copy-paste pattern with three independent failure surfaces.

---

## Changes

### `src/Abstraction/AiProvider.cs`
- Added `[Description("...")]` attribute to every enum case with the human-readable provider label.

### `src/Abstraction/AiProviderExtensions.cs` *(new)*
- `GetLabel(this AiProvider)` extension method reads `DescriptionAttribute` via reflection; falls back to `Enum.ToString()` for unknown values.

### `src/Services/AiServiceHelper.cs`
- New overload `ParseImageResponseAsync(response, AiProvider, HttpClient, ILogger, string? allowedOrigin, CancellationToken) → Task<byte[]>` with a four-phase pipeline:
  1. HTTP guard (429 → `LogWarning`, non-2xx → `LogError`)
  2. JSON deserialisation (malformed → `LogError`)
  3. Provider-specific extraction via `switch` on `AiProvider`
  4. Structured log messages using `provider.GetLabel()`
- Private extractors: `ExtractOpenAiBytes`, `ExtractAzureFoundryBytesAsync`, `ExtractFalAiBytesAsync`.
- `GetByteArrayAsync` wrapped in `try/catch (HttpRequestException)` in both download-path extractors (regression fix tracked in #183).
- Legacy `(bool, JsonElement?)` overload retained for backward compatibility.

### `src/Services/OpenAiService.cs` · `AzureFoundryService.cs` · `FalAiImageService.cs`
- `GenerateImageAsync` in each service: post-parse block (~20-30 lines) replaced by a single call to the new overload.
- `AzureFoundryService` passes `allowedOrigin` derived from `Endpoint` for URL origin validation.

---

## Tests

| File | Cases | What is covered |
|---|---|---|
| `AiProviderExtensionsTests` | 9 | `GetLabel()` for all enum values, unknown fallback, Description ≠ ToString |
| `AiServiceHelperImageTests` | 28 | HTTP guards × 3 providers; OpenAI b64 paths; fal.ai URL paths incl. download throw; AzureFoundry b64 + url fallback + wrong origin + download throw; unsupported provider |
| `FalAiImageServiceTests` | updated | `_LogsError` predicate aligned to new helper message |

---

## Notes

- The `try/catch` regression on `GetByteArrayAsync` (previously handled per-service, dropped during refactor) is fixed here and tracked in #183 for visibility.
- `AiProvider.Perplexity` and `AiProvider.None` hit the `_` branch and return `Array.Empty<byte>()` with a structured `LogError` — no silent failures.
