### PR TITLE
fix: replace Console.WriteLine with structured logger in FeedService

### DIFF
--- a/src/Services/FeedService.cs
+++ b/src/Services/FeedService.cs
@@ -73,7 +73,7 @@ public class FeedService : IFeedService
 
             if (channel == null)
             {
-                Console.WriteLine("No feeds found");
+                _logger.LogWarning("RSS feed channel element not found for URL {Url}. Possible invalid feed format.", url);
                 throw new Exception("Invalid RSS feed format");
             }
 


### PR DESCRIPTION
## Summary

Replaces the `Console.WriteLine` call in `FeedService.GetFeedsAsync` with a structured `_logger.LogWarning`, consistent with the rest of the service and with the project's observability approach.

Closes #199

## Change

```diff
- Console.WriteLine("No feeds found");
+ _logger.LogWarning("RSS feed channel element not found for URL {Url}. Possible invalid feed format.", url);
```

## Why

- `Console.WriteLine` output is **not forwarded to Application Insights** in an Azure Functions isolated worker — no correlation ID, no severity, no invocation context.
- `ILogger<FeedService>` is already injected and used in the same class; this change makes the diagnostic consistent.
- Code search confirms this was the **only** `Console.WriteLine` in the repository.

## Notes

The `catch` block at the end of the method still silently swallows all exceptions. That behaviour is intentional and untouched here; a follow-up issue can address structured error logging inside the catch if needed.