### PR TITLE
ADR-005 · Point 2 — Separate Orchestrator identity from Sender identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Replaced `MessageSender` enum with `SenderPlatform` enum; platform and orchestrator identity are now independent (ADR-005)
+- `OrchestratorFactory` resolves `ISender` from `SenderPlatform`; adding a new orchestrator no longer requires enum changes
+- `ScheduledOrchestrationProfile` uses `SenderPlatform` instead of `MessageSender`
+
+### Removed
+- `MessageSender` enum
+
 ---
 
 ## [0.1.5] - 2026-06-22

--- a/README.md
+++ b/README.md
@@ -383,12 +383,12 @@ az functionapp config appsettings set \
 
 The production schedule is defined in `DefaultSlotProfileProvider`, which returns four fixed profiles:
 
-| UTC Hour | Sender | Orchestrator | AI Provider |
-|----------|--------|--------------|-------------|
-| 6 | `InSummaryFeed` | `FeedOrchestrator` | OpenAi |
-| 8 | `XSummaryFeed` | `FeedOrchestrator` | OpenAi |
-| 14 | `InPowerLaw` | `PowerLawOrchestrator` | *(default)* |
-| 16 | `XPowerLaw` | `PowerLawOrchestrator` | *(default)* |
+| UTC Hour | `SenderPlatform` | Orchestrator | AI Provider |
+|----------|------------------|--------------|-------------|
+| 6 | `LinkedIn` | `FeedOrchestrator` | OpenAi |
+| 8 | `X` | `FeedOrchestrator` | OpenAi |
+| 14 | `LinkedIn` | `PowerLawOrchestrator` | *(default)* |
+| 16 | `X` | `PowerLawOrchestrator` | *(default)* |
 
 `OrchestratorFactory` no longer owns a static list of profiles. It receives an `ISlotProfileProvider` via constructor injection and calls `GetProfiles()` at resolution time — making the schedule a swappable dependency rather than embedded logic.
 
@@ -408,7 +408,7 @@ To run the full pipeline locally without publishing to any social platform, acti
 
 | Key | Value | Effect |
 |-----|-------|--------|
-| `EnableDryRunSlot` | `true` | Registers `DryRunSlotProfileProvider` in DI, which decorates `DefaultSlotProfileProvider` and appends a `DryRunSend` entry at hour 9 |
+| `EnableDryRunSlot` | `true` | Registers `DryRunSlotProfileProvider` in DI, which decorates `DefaultSlotProfileProvider` and appends a `DryRun` entry at hour 9 |
 | `ForceHour` | `9` | Overrides the UTC clock so `OrchestratorFactory` selects the dry-run slot at startup |
 
 `DryRunSender` will probe Key Vault connectivity (reads the `XApiKey` secret), log the generated post content (character count + full text and image presence), and return `true` — without calling any social platform API.
@@ -432,8 +432,8 @@ XPoster is designed with explicit extension points that allow new capabilities t
 
 | Extension point | How to extend | Rationale |
 |---|---|---|
-| **Sender Plugins** (`ISender`) | Implement `ISender`, register in DI, add an enum value to `MessageSender`, configure a `ScheduledOrchestrationProfile` | Platform-specific code is fully isolated behind a single interface, so adding a new social network has zero impact on orchestrators or scheduling |
-| **Content Orchestrators** (`BaseOrchestrator`) | Subclass `BaseOrchestrator`, override `OrchestrateAsync()`, register in `OrchestratorFactory` | The Strategy pattern in `OrchestratorFactory` decouples content logic from scheduling, making it safe to introduce new content strategies independently |
+| **Sender Plugins** (`ISender`) | Implement `ISender`, register in DI, add a value to `SenderPlatform`, configure a `ScheduledOrchestrationProfile` | Platform-specific code is fully isolated behind a single interface, so adding a new social network has zero impact on orchestrators or scheduling |
+| **Content Orchestrators** (`BaseOrchestrator`) | Subclass `BaseOrchestrator`, override `OrchestrateAsync()` and `SupportedPlatforms`, add a `ScheduledOrchestrationProfile` entry | The Strategy pattern in `OrchestratorFactory` decouples content logic from scheduling, making it safe to introduce new content strategies independently |
 | **AI Providers** (`IAiService`) | Implement `IAiService`, register as a keyed service in DI, add an `AiProvider` enum value | All orchestrators depend only on `IAiService`, so swapping or adding a provider requires no changes outside the service layer and `Program.cs` |
 | **Scheduling profiles** (`ISlotProfileProvider`) | Implement `ISlotProfileProvider` (or subclass `DryRunSlotProfileProvider` as a decorator) and register it in `Program.cs` | The schedule is a swappable dependency injected into `OrchestratorFactory` — operators can alter or extend the slot list without touching factory or orchestrator code |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,11 +86,11 @@ XPoster is a **serverless, event-driven pipeline** that runs on a timer, selects
 | Field | Type | Purpose |
 |---|---|---|
 | `Hour` | `int` | Hour of day (0–23) when this slot is active |
-| `SenderType` | `MessageSender` | Identifies which `ISender` implementation to resolve |
+| `SenderPlatform` | `SenderPlatform` | Identifies which `ISender` implementation to resolve |
 | `OrchestratorType` | `Type` | The concrete `BaseOrchestrator` subclass to instantiate |
 | `AiProvider?` | `AiProvider?` | Optional AI provider for slots that require AI services |
 
-At runtime, the factory calls `Resolve()` to match the current hour to a profile returned by `ISlotProfileProvider.GetProfiles()`, independently resolves the **sender** (via the DI container) and the **AI service** (via `IAiServiceFactory.GetByProvider()`), then dynamically constructs the orchestrator using reflection (`CreateOrchestratorInstance`). The effective `AiProvider` can be overridden at deploy time via the `AiProvider` configuration key, without code changes.
+At runtime, the factory calls `Resolve()` to match the current hour to a profile returned by `ISlotProfileProvider.GetProfiles()`, independently resolves the **sender** (via the DI container, keyed by `SenderPlatform`) and the **AI service** (via `IAiServiceFactory.GetByProvider()`), then dynamically constructs the orchestrator using reflection (`CreateOrchestratorInstance`). The effective `AiProvider` can be overridden at deploy time via the `AiProvider` configuration key, without code changes.
 
 The **schedule itself is a dependency**, not a compile-time constant. In production, `DefaultSlotProfileProvider` supplies the four canonical slots (06:00, 08:00, 14:00, 16:00). For local dry-run testing, `DryRunSlotProfileProvider` decorates `DefaultSlotProfileProvider` and appends the dry-run slot at hour 9; it is activated by setting `EnableDryRunSlot = true` in app settings and registered in `Program.cs` via conditional DI. This means adding or switching the dry-run slot requires no changes to `OrchestratorFactory`.
 
@@ -143,12 +143,12 @@ Sender credentials (OAuth tokens, API keys) are loaded into `IConfiguration` at 
 
 **Current sender implementations:**
 
-| Sender | `MessageSender` value | Target | Notes |
+| Sender | `SenderPlatform` value | Target | Notes |
 |---|---|---|---|
-| `XSender` | `XSummaryFeed`, `XPowerLaw` | Twitter/X API | OAuth 1.0a via `LinqToTwitter`; credentials injected via `IOptions<XCredentials>` |
-| `InSender` | `InSummaryFeed`, `InPowerLaw` | LinkedIn API | Direct HTTP via `IHttpClientFactory`; credentials injected via `IOptions<LinkedInCredentials>` |
-| `IgSender` | *(in development)* | Instagram Graph API | Direct HTTP via `IHttpClientFactory`; credentials injected via `IOptions<IgCredentials>` |
-| `DryRunSender` | `DryRunSend` | **None** | **Local development and testing only.** Logs post content (character count, full text, image presence) but makes **no outbound social API calls**. Always returns `true` on a well-formed post. `MessageMaxLength` is `int.MaxValue`. Activated via `EnableDryRunSlot = true` in app settings; must never be used in a production environment. |
+| `XSender` | `X` | Twitter/X API | OAuth 1.0a via `LinqToTwitter`; credentials injected via `IOptions<XCredentials>` |
+| `InSender` | `LinkedIn` | LinkedIn API | Direct HTTP via `IHttpClientFactory`; credentials injected via `IOptions<LinkedInCredentials>` |
+| `IgSender` | `Instagram` | Instagram Graph API | Direct HTTP via `IHttpClientFactory`; credentials injected via `IOptions<IgCredentials>` |
+| `DryRunSender` | `DryRun` | **None** | **Local development and testing only.** Logs post content (character count, full text, image presence) but makes **no outbound social API calls**. Always returns `true` on a well-formed post. `MessageMaxLength` is `int.MaxValue`. Activated via `EnableDryRunSlot = true` in app settings; must never be used in a production environment. |
 
 ---
 
@@ -166,15 +166,15 @@ Sender credentials (OAuth tokens, API keys) are loaded into `IConfiguration` at 
 
 **What**: `OrchestratorFactory` centralises the construction and selection of `(IOrchestrator, ISender, IAiService)` triples. Its `Resolve()` method reads the current UTC hour, calls `ISlotProfileProvider.GetProfiles()` to obtain the active schedule, looks up the matching `ScheduledOrchestrationProfile`, and dynamically instantiates the orchestrator via `CreateOrchestratorInstance` (reflection-based constructor resolution), injecting the resolved sender and AI service.
 
-**Why**: Centralising selection logic in one class avoids scattering time-aware conditionals across the codebase. Moving from a flat `Dictionary<int, MessageSender>` to a typed `ScheduledOrchestrationProfile` list makes each slot self-documenting and allows per-slot AI provider assignment without additional lookup tables. The factory can be unit-tested in isolation using a mock `ISlotProfileProvider` with synthetic profiles, and the `ITimeProvider` abstraction makes schedule-based tests deterministic.
+**Why**: Centralising selection logic in one class avoids scattering time-aware conditionals across the codebase. Moving from a flat `Dictionary<int, SenderPlatform>` to a typed `ScheduledOrchestrationProfile` list makes each slot self-documenting and allows per-slot AI provider assignment without additional lookup tables. The factory can be unit-tested in isolation using a mock `ISlotProfileProvider` with synthetic profiles, and the `ITimeProvider` abstraction makes schedule-based tests deterministic.
 
 **Trade-off**: The schedule is now an injected dependency (`ISlotProfileProvider`), which means schedule changes — including adding or removing the dry-run slot — are controlled entirely via DI registration and app settings, with no changes required to `OrchestratorFactory` itself. Adding a fully externalised schedule (e.g. from Azure App Configuration) would only require a new `ISlotProfileProvider` implementation registered in `Program.cs`.
 
 ### Plugin Pattern — Sender Architecture
 
-**What**: Platform senders implement a common `ISender` interface and are registered in the DI container as concrete types. `OrchestratorFactory` resolves the appropriate sender from the DI container by matching the `MessageSender` enum value in the profile.
+**What**: Platform senders implement a common `ISender` interface and are registered in the DI container as concrete types. `OrchestratorFactory` resolves the appropriate sender from the DI container by matching the `SenderPlatform` enum value in the profile.
 
-**Why**: The plugin approach means **adding a new platform requires zero changes to existing code** — only a new class, a DI registration, a new enum value, and a profile entry. This directly supports the Roadmap's expansion goals (Threads, Mastodon, BlueSky, etc.).
+**Why**: The plugin approach means **adding a new platform requires zero changes to existing code** — only a new class, a DI registration, a new `SenderPlatform` enum value, and a profile entry. This directly supports the Roadmap's expansion goals (Threads, Mastodon, BlueSky, etc.).
 
 **Extensibility contract**: Any sender must:
 1. Implement `ISender`
@@ -215,13 +215,13 @@ XPoster exposes three well-defined extension points. Each maps to a distinct abs
 
 A sender encapsulates everything needed to publish a `Post` to a specific social platform: authentication, payload serialisation, and error handling. The `ISender` interface is intentionally minimal — it receives a fully-formed post and returns a boolean outcome — so platform-specific complexity is completely isolated from the rest of the pipeline.
 
-Adding a new platform has no impact on existing senders, orchestrators, or the factory. The only touch points are a new implementing class, a DI registration, a new `MessageSender` enum value, and one entry in the scheduling profile (either in `DefaultSlotProfileProvider` for production slots, or in a custom `ISlotProfileProvider` decorator for environment-specific slots). This directly supports the Roadmap goal of expanding to Threads, Mastodon, BlueSky, and other platforms.
+Adding a new platform has no impact on existing senders, orchestrators, or the factory. The only touch points are a new implementing class, a DI registration, a new `SenderPlatform` enum value, and one entry in the scheduling profile (either in `DefaultSlotProfileProvider` for production slots, or in a custom `ISlotProfileProvider` decorator for environment-specific slots). This directly supports the Roadmap goal of expanding to Threads, Mastodon, BlueSky, and other platforms.
 
 ### Content Orchestrators
 
-An orchestrator encapsulates a complete content-production algorithm: what data to fetch, how to transform it, whether to invoke an AI service, and what shape the resulting `Post` takes. Each orchestrator extends `BaseOrchestrator` and is selected at runtime based on the current time slot via `OrchestratorFactory.Resolve()`, so different algorithms can run at different hours without any conditional logic in `XFunction`.
+An orchestrator encapsulates a complete content-production algorithm: what data to fetch, how to transform it, whether to invoke an AI service, and what shape the resulting `Post` takes. Each orchestrator extends `BaseOrchestrator` and implements the `SupportedPlatforms` property to declare which `SenderPlatform` values it is compatible with. The orchestrator is selected at runtime based on the current time slot via `OrchestratorFactory.Resolve()`, so different algorithms can run at different hours without any conditional logic in `XFunction`.
 
-Because orchestrators receive their dependencies (sender, AI service, data services) via constructor injection, a new orchestrator is a self-contained unit that can be developed and tested in isolation. The factory instantiates it dynamically; the only required change is adding a `ScheduledOrchestrationProfile` entry to the appropriate `ISlotProfileProvider` implementation — no changes to `OrchestratorFactory` itself.
+Because orchestrators receive their dependencies (sender, AI service, data services) via constructor injection, a new orchestrator is a self-contained unit that can be developed and tested in isolation. The factory instantiates it dynamically; the only required changes are implementing `SupportedPlatforms` on the new class and adding a `ScheduledOrchestrationProfile` entry to the appropriate `ISlotProfileProvider` implementation — no changes to `OrchestratorFactory` itself.
 
 ### AI Providers
 
@@ -264,7 +264,7 @@ sequenceDiagram
     Factory->>ProfileProvider: GetProfiles()
     ProfileProvider-->>Factory: List<ScheduledOrchestrationProfile>
     Factory->>Factory: Match currentHour → ScheduledOrchestrationProfile
-    Factory->>Factory: Resolve ISender from DI (by SenderType)
+    Factory->>Factory: Resolve ISender from DI (by SenderPlatform)
     Factory->>AiFactory: GetByProvider(profile.AiProvider)
     AiFactory-->>Factory: IAiService (concrete implementation)
     Factory->>Factory: CreateOrchestratorInstance(type, sender, aiService)

--- a/docs/extending-xposter.md
+++ b/docs/extending-xposter.md
@@ -136,47 +136,47 @@ For local development only, set them in `src/local.settings.json` using the doub
 
 > Do not add social-platform credentials to `src/local.settings.json.example`. Use Key Vault for all non-local environments.
 
-### Step 5 — Add Enum Value
+### Step 5 — Add SenderPlatform Enum Value
+
+Add a single value to `SenderPlatform` representing the new platform. Each value maps to exactly one sender class, independent of which orchestrator produces the content:
 
 ```csharp
 // src/Contracts/Enums.cs
-public enum MessageSender
+public enum SenderPlatform
 {
-    // existing values...
-    TikTokSummaryFeed,
-    TikTokPowerLaw,
+    // existing values ...
+    TikTok,
 }
 ```
 
+> `SenderPlatform` represents **where** to publish. It is orthogonal to the orchestrator type (what content strategy to use), so a single `TikTok` value covers all orchestrators that target TikTok. This is the key difference from the legacy `MessageSender` enum, which conflated platform identity with content strategy.
+
 ### Step 6 — Wire in OrchestratorFactory
 
-`OrchestratorFactory.Resolve()` resolves the concrete sender through a **switch expression** that maps each `MessageSender` enum value to a specific class retrieved from the DI container. The result is cast to `ISender` because `GetService` returns `object?`; the factory then passes the interface reference to `CreateOrchestratorInstance`, keeping orchestrators fully decoupled from sender implementations.
-
-Add two arms to the existing switch expression inside `Resolve()`:
+`OrchestratorFactory.Resolve()` resolves the concrete sender through a **switch expression** that maps each `SenderPlatform` value to the class retrieved from the DI container. Because `SenderPlatform` is platform-only, there is **one arm per platform** — independent of how many orchestrators target that platform. Add one arm to the existing switch expression inside `Resolve()`:
 
 ```csharp
 // src/Orchestrators/OrchestratorFactory.cs — sender switch expression
-ISender? sender = profile.SenderType switch
+ISender? sender = profile.SenderPlatform switch
 {
     // existing arms ...
-    MessageSender.TikTokSummaryFeed => _serviceProvider.GetService(typeof(TikTokSender)) as ISender,
-    MessageSender.TikTokPowerLaw    => _serviceProvider.GetService(typeof(TikTokSender)) as ISender,
+    SenderPlatform.TikTok => _serviceProvider.GetService(typeof(TikTokSender)) as ISender,
     _ => null
 };
 ```
 
-> Both `TikTokSummaryFeed` and `TikTokPowerLaw` resolve to the same `TikTokSender` class. The two enum values express *what is being posted* (content strategy + platform), not *how* — `TikTokSender` owns the how. This mirrors the existing pattern for `XSender` and `InSender`.
+> One enum value, one switch arm, one sender class. Adding a new orchestrator that posts to TikTok (e.g. `TrendingOrchestrator`) requires **no change** to this switch — only a new `ScheduledOrchestrationProfile` entry referencing `SenderPlatform.TikTok`.
 
 ### Step 7 — Add a ScheduledOrchestrationProfile entry
 
-The production schedule is owned by `DefaultSlotProfileProvider` (`src/Orchestrators/DefaultSlotProfileProvider.cs`), which implements `ISlotProfileProvider`. Add the new profile to its `GetProfiles()` return list, specifying the UTC hour, sender type, orchestrator type, and (optionally) the AI provider for that slot:
+The production schedule is owned by `DefaultSlotProfileProvider` (`src/Orchestrators/DefaultSlotProfileProvider.cs`). Add the new profile to its `GetProfiles()` return list, specifying the UTC hour, sender platform, orchestrator type, and (optionally) the AI provider for that slot:
 
 ```csharp
 // src/Orchestrators/DefaultSlotProfileProvider.cs
 public IReadOnlyList<ScheduledOrchestrationProfile> GetProfiles() =>
 [
     // existing profiles ...
-    new ScheduledOrchestrationProfile(20, MessageSender.TikTokSummaryFeed, typeof(FeedOrchestrator), AiProvider.OpenAi),
+    new ScheduledOrchestrationProfile(20, SenderPlatform.TikTok, typeof(FeedOrchestrator), AiProvider.OpenAi),
 ];
 ```
 
@@ -188,7 +188,7 @@ public IReadOnlyList<ScheduledOrchestrationProfile> GetProfiles() =>
 
 ## Adding a New Orchestrator (Content Strategy)
 
-An orchestrator inherits from `BaseOrchestrator` and overrides `OrchestrateAsync()` to produce a `Post`. It receives its dependencies — sender, AI service, and any data services — via constructor injection; `OrchestratorFactory` resolves them automatically through reflection.
+An orchestrator inherits from `BaseOrchestrator` and overrides `OrchestrateAsync()` to produce a `Post`. It must also implement the `SupportedPlatforms` property to declare which `SenderPlatform` values it is compatible with. Dependencies — sender, AI service, and any data services — are received via constructor injection; `OrchestratorFactory` resolves them automatically through reflection.
 
 ### Step 1 — Extend BaseOrchestrator
 
@@ -198,6 +198,9 @@ public class QuoteOrchestrator : BaseOrchestrator
 {
     public QuoteOrchestrator(ISender sender, ILogger<QuoteOrchestrator> logger, IAiService aiService)
         : base(sender, logger, aiService) { }
+
+    public override IReadOnlyList<SenderPlatform> SupportedPlatforms { get; } =
+        [SenderPlatform.X, SenderPlatform.LinkedIn, SenderPlatform.DryRun];
 
     public override async Task<Post>? OrchestrateAsync()
     {
@@ -210,18 +213,20 @@ public class QuoteOrchestrator : BaseOrchestrator
 }
 ```
 
-> **Invariant**: `OrchestrateAsync()` must return `null` — not throw — when content cannot be produced. `XFunction` treats a `null` return as a graceful skip; an exception is treated as a pipeline failure.
+> **`SupportedPlatforms` invariant**: always include `SenderPlatform.DryRun` so the orchestrator can be exercised locally without live API calls. Declare only the platforms the orchestrator has been validated against — omitting a platform is a deliberate signal that the content format may not be compatible.
+
+> **`OrchestrateAsync` invariant**: must return `null` — not throw — when content cannot be produced. `XFunction` treats a `null` return as a graceful skip; an exception is treated as a pipeline failure.
 
 ### Step 2 — Add a ScheduledOrchestrationProfile entry
 
-Reference the new orchestrator type in `DefaultSlotProfileProvider.GetProfiles()`. `CreateOrchestratorInstance` in `OrchestratorFactory` resolves constructor parameters automatically via reflection:
+Reference the new orchestrator type and the target `SenderPlatform` in `DefaultSlotProfileProvider.GetProfiles()`. `CreateOrchestratorInstance` in `OrchestratorFactory` resolves constructor parameters automatically via reflection:
 
 ```csharp
 // src/Orchestrators/DefaultSlotProfileProvider.cs
 public IReadOnlyList<ScheduledOrchestrationProfile> GetProfiles() =>
 [
     // existing profiles ...
-    new ScheduledOrchestrationProfile(10, MessageSender.XSummaryFeed, typeof(QuoteOrchestrator), AiProvider.Perplexity),
+    new ScheduledOrchestrationProfile(10, SenderPlatform.X, typeof(QuoteOrchestrator), AiProvider.Perplexity),
 ];
 ```
 
@@ -357,6 +362,7 @@ All extensions must respect the following invariants to integrate correctly with
 - **`SendAsync` must return `false`, not throw, on non-fatal platform errors.** Throwing from a sender propagates the exception to `XFunction` and prevents App Insights from recording a clean skip.
 - **`MessageMaxLength` must be accurate.** Orchestrators rely on this value to truncate content before calling `SendAsync`. An incorrect value causes silent data loss at the platform layer.
 - **`OrchestrateAsync` must return `null`, not throw, when no content can be produced.** `XFunction` treats a `null` return as a graceful skip; an exception is treated as a pipeline failure.
+- **Orchestrators must implement `SupportedPlatforms`.** The property must include every `SenderPlatform` value the orchestrator has been validated against, and always include `SenderPlatform.DryRun`. `NoOrchestrator` is the only valid exception (empty list).
 - **Orchestrators must be idempotent where possible.** Avoid side effects beyond returning a `Post`. In particular, do not call `ISender.SendAsync` from inside an orchestrator — that responsibility belongs to `XFunction`.
 - **All external HTTP calls must go through `IHttpClientFactory`.** This ensures connection pooling, Polly resilience pipelines (retry, circuit breaker, attempt timeout), and consistent timeout configuration across the entire codebase. All services — including `FeedService` (named client `"Feed"`, registered in `HttpClientExtensions`) — conform to this constraint. Creating `new HttpClient()` inline is prohibited.
 - **Every new sender must include a `*CredentialsExtensions.cs` file** in `src/Credentials/`, declaring `SectionName` on the credentials DTO and the `Add*Credentials(IServiceCollection, IConfiguration)` extension method. `Program.cs` must use only the extension method — never raw `Configure<T>` + `GetSection("...")` literals for sender credentials.

--- a/src/Abstraction/BaseOrchestrator.cs
+++ b/src/Abstraction/BaseOrchestrator.cs
@@ -19,6 +19,9 @@ public abstract class BaseOrchestrator(ISender? sender, ILogger logger) : IOrche
     /// <inheritdoc/>
     public abstract bool ProduceImage { get; set; }
 
+    /// <inheritdoc/>
+    public abstract IReadOnlyList<SenderPlatform> SupportedPlatforms { get; }
+
     /// <summary>The sender used to publish posts to the target social-media platform. May be <c>null</c> for no-op orchestrators.</summary>
     protected ISender? _sender { get; } = sender;
 

--- a/src/Abstraction/ScheduledOrchestrationProfile.cs
+++ b/src/Abstraction/ScheduledOrchestrationProfile.cs
@@ -10,8 +10,8 @@ public sealed class ScheduledOrchestrationProfile
     /// <summary>Hour of day (0-23) when this slot is active.</summary>
     public int Hour { get; init; }
 
-    /// <summary>Sender strategy used for this slot.</summary>
-    public MessageSender SenderType { get; init; }
+    /// <summary>Target platform for this slot. Drives sender resolution in <see cref="XPoster.Orchestrators.OrchestratorFactory"/>.</summary>
+    public SenderPlatform SenderPlatform { get; init; }
 
     /// <summary>Orchestrator type to instantiate for this slot.</summary>
     public Type OrchestratorType { get; init; }
@@ -23,13 +23,13 @@ public sealed class ScheduledOrchestrationProfile
     /// Initialises a new instance of <see cref="ScheduledOrchestrationProfile"/>.
     /// </summary>
     /// <param name="hour">Hour of day (0-23) when this slot is active.</param>
-    /// <param name="senderType">Sender strategy used for this slot.</param>
+    /// <param name="senderPlatform">Target platform for this slot.</param>
     /// <param name="orchestratorType">Orchestrator type to instantiate for this slot.</param>
     /// <param name="aiProvider">Optional AI provider for orchestrators that require AI services.</param>
-    public ScheduledOrchestrationProfile(int hour, MessageSender senderType, Type orchestratorType, AiProvider? aiProvider = null)
+    public ScheduledOrchestrationProfile(int hour, SenderPlatform senderPlatform, Type orchestratorType, AiProvider? aiProvider = null)
     {
         Hour = hour;
-        SenderType = senderType;
+        SenderPlatform = senderPlatform;
         OrchestratorType = orchestratorType;
         AiProvider = aiProvider;
     }

--- a/src/Contracts/Enums.cs
+++ b/src/Contracts/Enums.cs
@@ -1,8 +1,26 @@
 namespace XPoster.Contracts;
 
 /// <summary>
-/// Identifies the target social platform and content strategy for a scheduled posting slot.
+/// Identifies the target social platform for a scheduled posting slot.
+/// Replaces <see cref="MessageSender"/> which coupled platform identity to orchestrator identity.
 /// </summary>
+public enum SenderPlatform
+{
+    /// <summary>Posts to X (Twitter).</summary>
+    X,
+    /// <summary>Posts to LinkedIn.</summary>
+    LinkedIn,
+    /// <summary>Posts to Instagram.</summary>
+    Instagram,
+    /// <summary>Dry-run sender for local integration testing. Logs post output without publishing.</summary>
+    DryRun,
+}
+
+/// <summary>
+/// Legacy enum kept temporarily for migration safety.
+/// All production code must use <see cref="SenderPlatform"/> instead.
+/// </summary>
+[Obsolete("Use SenderPlatform instead. MessageSender will be removed once all references are migrated.")]
 public enum MessageSender
 {
     /// <summary>No message will be sent during this time slot.</summary>

--- a/src/Contracts/IOrchestrator.cs
+++ b/src/Contracts/IOrchestrator.cs
@@ -18,6 +18,12 @@ public interface IOrchestrator
     bool ProduceImage { get; set; }
 
     /// <summary>
+    /// Gets the list of target platforms this orchestrator supports.
+    /// Used for optional validation — confirms the resolved sender platform is compatible with this orchestrator.
+    /// </summary>
+    IReadOnlyList<SenderPlatform> SupportedPlatforms { get; }
+
+    /// <summary>
     /// Asynchronously orchestrates the production of a <see cref="Post"/> ready for publishing.
     /// </summary>
     /// <returns>

--- a/src/Orchestrators/DefaultSlotProfileProvider.cs
+++ b/src/Orchestrators/DefaultSlotProfileProvider.cs
@@ -12,12 +12,12 @@ public sealed class DefaultSlotProfileProvider : ISlotProfileProvider
 {
     private static readonly IReadOnlyList<ScheduledOrchestrationProfile> _profiles = new List<ScheduledOrchestrationProfile>
     {
-        new ScheduledOrchestrationProfile(6,  MessageSender.InSummaryFeed, typeof(FeedOrchestrator),      AiProvider.OpenAi),
-        new ScheduledOrchestrationProfile(8,  MessageSender.XSummaryFeed,  typeof(FeedOrchestrator),      AiProvider.AzureFoundry),
-        //new ScheduledOrchestrationProfile(10, MessageSender.IgSummaryFeed, typeof(FeedOrchestrator),  AiProvider.OpenAi),
-        new ScheduledOrchestrationProfile(14, MessageSender.InPowerLaw,    typeof(PowerLawOrchestrator)),
-        new ScheduledOrchestrationProfile(16, MessageSender.XPowerLaw,     typeof(PowerLawOrchestrator)),
-        //new ScheduledOrchestrationProfile(18, MessageSender.IgPowerLaw,    typeof(PowerLawOrchestrator)),
+        new ScheduledOrchestrationProfile(6,  SenderPlatform.LinkedIn,  typeof(FeedOrchestrator),      AiProvider.OpenAi),
+        new ScheduledOrchestrationProfile(8,  SenderPlatform.X,         typeof(FeedOrchestrator),      AiProvider.AzureFoundry),
+        //new ScheduledOrchestrationProfile(10, SenderPlatform.Instagram,  typeof(FeedOrchestrator),  AiProvider.OpenAi),
+        new ScheduledOrchestrationProfile(14, SenderPlatform.LinkedIn,  typeof(PowerLawOrchestrator)),
+        new ScheduledOrchestrationProfile(16, SenderPlatform.X,         typeof(PowerLawOrchestrator)),
+        //new ScheduledOrchestrationProfile(18, SenderPlatform.Instagram,  typeof(PowerLawOrchestrator)),
     }.AsReadOnly();
 
     /// <inheritdoc />

--- a/src/Orchestrators/DryRunSlotProfileProvider.cs
+++ b/src/Orchestrators/DryRunSlotProfileProvider.cs
@@ -28,14 +28,14 @@ public sealed class DryRunSlotProfileProvider : ISlotProfileProvider
 
     /// <inheritdoc />
     /// <remarks>
-    /// Appends <see cref="MessageSender.DryRunSend"/> at hour 9 to the profiles
+    /// Appends <see cref="SenderPlatform.DryRun"/> at hour 9 to the profiles
     /// returned by the inner provider.
     /// </remarks>
     public IReadOnlyList<ScheduledOrchestrationProfile> GetProfiles()
     {
         var profiles = new List<ScheduledOrchestrationProfile>(_inner.GetProfiles())
         {
-            new ScheduledOrchestrationProfile(9, MessageSender.DryRunSend, typeof(FeedOrchestrator), AiProvider.OpenAi)
+            new ScheduledOrchestrationProfile(9, SenderPlatform.DryRun, typeof(FeedOrchestrator), AiProvider.OpenAi)
         };
         return profiles.AsReadOnly();
     }

--- a/src/Orchestrators/FeedOrchestrator.cs
+++ b/src/Orchestrators/FeedOrchestrator.cs
@@ -29,6 +29,11 @@ public class FeedOrchestrator : BaseOrchestrator
     /// <summary>Always <c>true</c>; this orchestrator always attempts to attach an AI-generated image.</summary>
     public override bool ProduceImage { get => true; set => throw new NotImplementedException(); }
 
+    /// <inheritdoc/>
+    /// <remarks>FeedOrchestrator supports X, LinkedIn, and Instagram. DryRun is also supported for testing.</remarks>
+    public override IReadOnlyList<SenderPlatform> SupportedPlatforms { get; } =
+        new List<SenderPlatform> { SenderPlatform.X, SenderPlatform.LinkedIn, SenderPlatform.Instagram, SenderPlatform.DryRun }.AsReadOnly();
+
     /// <summary>
     /// Initialises a new instance of <see cref="FeedOrchestrator"/>.
     /// </summary>

--- a/src/Orchestrators/NoOrchestrator.cs
+++ b/src/Orchestrators/NoOrchestrator.cs
@@ -1,4 +1,5 @@
 using XPoster.Abstraction;
+using XPoster.Contracts;
 using XPoster.Models;
 
 namespace XPoster.Orchestrators
@@ -17,6 +18,11 @@ namespace XPoster.Orchestrators
 
         /// <summary>Always <c>false</c>; this orchestrator never produces images.</summary>
         public override bool ProduceImage { get => false; set => throw new System.NotImplementedException(); }
+
+        /// <inheritdoc/>
+        /// <remarks>NoOrchestrator supports no platforms — it is a no-op slot.</remarks>
+        public override IReadOnlyList<SenderPlatform> SupportedPlatforms { get; } =
+            new List<SenderPlatform>().AsReadOnly();
 
         /// <summary>
         /// Returns <c>null</c> unconditionally — no content is orchestrated in a no-send slot.

--- a/src/Orchestrators/OrchestratorFactory.cs
+++ b/src/Orchestrators/OrchestratorFactory.cs
@@ -9,6 +9,7 @@ namespace XPoster.Orchestrators;
 /// <summary>
 /// Resolves and instantiates the correct <see cref="BaseOrchestrator"/> for the current hour of the day
 /// by consulting the <see cref="ISlotProfileProvider"/> schedule, including AI provider orchestration.
+/// Sender resolution is O(senders) via <see cref="SenderPlatform"/> switch — independent of orchestrator type.
 /// </summary>
 public class OrchestratorFactory : IOrchestratorFactory
 {
@@ -60,18 +61,16 @@ public class OrchestratorFactory : IOrchestratorFactory
             return CreateOrchestratorInstance(typeof(NoOrchestrator), null, null);
         }
 
-        _log.LogInformation("Creating orchestrator {OrchestratorType} for sender {SenderType} at hour {Hour} with AI provider {AiProvider}",
-            profile.OrchestratorType.Name, profile.SenderType, profile.Hour, profile.AiProvider);
+        _log.LogInformation("Creating orchestrator {OrchestratorType} for platform {SenderPlatform} at hour {Hour} with AI provider {AiProvider}",
+            profile.OrchestratorType.Name, profile.SenderPlatform, profile.Hour, profile.AiProvider);
 
-        ISender? sender = profile.SenderType switch
+        // O(senders) switch — never changes when new orchestrators are added
+        ISender? sender = profile.SenderPlatform switch
         {
-            MessageSender.XPowerLaw     => _serviceProvider.GetService(typeof(XSender))     as ISender,
-            MessageSender.XSummaryFeed  => _serviceProvider.GetService(typeof(XSender))     as ISender,
-            MessageSender.InSummaryFeed => _serviceProvider.GetService(typeof(InSender))    as ISender,
-            MessageSender.InPowerLaw    => _serviceProvider.GetService(typeof(InSender))    as ISender,
-            MessageSender.IgSummaryFeed => _serviceProvider.GetService(typeof(IgSender))    as ISender,
-            MessageSender.IgPowerLaw    => _serviceProvider.GetService(typeof(IgSender))    as ISender,
-            MessageSender.DryRunSend    => _serviceProvider.GetService(typeof(DryRunSender)) as ISender,
+            SenderPlatform.X         => _serviceProvider.GetService(typeof(XSender))     as ISender,
+            SenderPlatform.LinkedIn  => _serviceProvider.GetService(typeof(InSender))    as ISender,
+            SenderPlatform.Instagram => _serviceProvider.GetService(typeof(IgSender))    as ISender,
+            SenderPlatform.DryRun    => _serviceProvider.GetService(typeof(DryRunSender)) as ISender,
             _ => null
         };
 

--- a/src/Orchestrators/PowerLawOrchestrator.cs
+++ b/src/Orchestrators/PowerLawOrchestrator.cs
@@ -28,6 +28,11 @@ namespace XPoster.Orchestrators
         /// <summary>Always <c>false</c>; this orchestrator does not attach images to its posts.</summary>
         public override bool ProduceImage { get => false; set => throw new NotImplementedException(); }
 
+        /// <inheritdoc/>
+        /// <remarks>PowerLawOrchestrator supports X and LinkedIn. DryRun is also supported for testing.</remarks>
+        public override IReadOnlyList<SenderPlatform> SupportedPlatforms { get; } =
+            new List<SenderPlatform> { SenderPlatform.X, SenderPlatform.LinkedIn, SenderPlatform.DryRun }.AsReadOnly();
+
         /// <summary>
         /// Initialises a new instance of <see cref="PowerLawOrchestrator"/>.
         /// </summary>

--- a/tests/Contracts/BaseOrchestratorTests.cs
+++ b/tests/Contracts/BaseOrchestratorTests.cs
@@ -20,6 +20,8 @@ public class BaseOrchestratorTests
         public override string Name => "TestOrchestrator";
         public override bool SendIt { get => _sendIt; set => _sendIt = value; }
         public override bool ProduceImage { get; set; } = produceImage;
+        public override IReadOnlyList<SenderPlatform> SupportedPlatforms { get; } =
+            new List<SenderPlatform>().AsReadOnly();
         public override Task<Post?> OrchestrateAsync() => Task.FromResult<Post?>(null);
     }
 

--- a/tests/Orchestrators/OrchestratorFactoryTests.cs
+++ b/tests/Orchestrators/OrchestratorFactoryTests.cs
@@ -37,21 +37,21 @@ public class OrchestratorFactoryTests
     }
 
     // ---------------------------------------------------------------------------
-    // Orchestrator type resolution — sender-driven, not hour-driven
+    // Orchestrator type resolution — platform-driven, not sender-enum-driven
     // ---------------------------------------------------------------------------
 
     [Theory]
-    [InlineData(typeof(FeedOrchestrator),     MessageSender.InSummaryFeed)]
-    [InlineData(typeof(FeedOrchestrator),     MessageSender.XSummaryFeed)]
-    [InlineData(typeof(FeedOrchestrator),     MessageSender.DryRunSend)]
-    [InlineData(typeof(PowerLawOrchestrator), MessageSender.InPowerLaw)]
-    [InlineData(typeof(PowerLawOrchestrator), MessageSender.XPowerLaw)]
+    [InlineData(typeof(FeedOrchestrator),     SenderPlatform.LinkedIn)]
+    [InlineData(typeof(FeedOrchestrator),     SenderPlatform.X)]
+    [InlineData(typeof(FeedOrchestrator),     SenderPlatform.DryRun)]
+    [InlineData(typeof(PowerLawOrchestrator), SenderPlatform.LinkedIn)]
+    [InlineData(typeof(PowerLawOrchestrator), SenderPlatform.X)]
     public void Resolve_Should_ReturnCorrectOrchestratorType_ForGivenSenderProfile(
-        Type expectedType, MessageSender sender)
+        Type expectedType, SenderPlatform platform)
     {
-        // ARRANGE — synthetic profile at an arbitrary hour; no coupling to slotProfiles
+        // ARRANGE — synthetic profile at an arbitrary hour; no coupling to production schedule
         const int arbitraryHour = 10;
-        var profile = new ScheduledOrchestrationProfile(arbitraryHour, sender, expectedType, AiProvider.OpenAi);
+        var profile = new ScheduledOrchestrationProfile(arbitraryHour, platform, expectedType, AiProvider.OpenAi);
         var factory = CreateFactoryWithProfiles(arbitraryHour, profile);
 
         // ACT
@@ -84,16 +84,16 @@ public class OrchestratorFactoryTests
     }
 
     // ---------------------------------------------------------------------------
-    // Sender wiring verification
+    // Sender wiring — O(senders) switch, independent of orchestrator type
     // ---------------------------------------------------------------------------
 
     [Fact]
-    public void Resolve_Should_ResolveInSender_WhenProfileUsesInSummaryFeed()
+    public void Resolve_Should_ResolveInSender_WhenProfileUsesLinkedIn()
     {
         // ARRANGE
         const int arbitraryHour = 10;
         var profile = new ScheduledOrchestrationProfile(
-            arbitraryHour, MessageSender.InSummaryFeed, typeof(FeedOrchestrator), AiProvider.OpenAi);
+            arbitraryHour, SenderPlatform.LinkedIn, typeof(FeedOrchestrator), AiProvider.OpenAi);
         var factory = CreateFactoryWithProfiles(arbitraryHour, profile);
 
         // ACT
@@ -105,12 +105,12 @@ public class OrchestratorFactoryTests
     }
 
     [Fact]
-    public void Resolve_Should_ResolveXSender_WhenProfileUsesXSummaryFeed()
+    public void Resolve_Should_ResolveXSender_WhenProfileUsesX()
     {
         // ARRANGE
         const int arbitraryHour = 11;
         var profile = new ScheduledOrchestrationProfile(
-            arbitraryHour, MessageSender.XSummaryFeed, typeof(FeedOrchestrator), AiProvider.OpenAi);
+            arbitraryHour, SenderPlatform.X, typeof(FeedOrchestrator), AiProvider.OpenAi);
         var factory = CreateFactoryWithProfiles(arbitraryHour, profile);
 
         // ACT
@@ -122,12 +122,29 @@ public class OrchestratorFactoryTests
     }
 
     [Fact]
-    public void Resolve_Should_ResolveDryRunSender_WhenProfileUsesDryRunSend()
+    public void Resolve_Should_ResolveIgSender_WhenProfileUsesInstagram()
+    {
+        // ARRANGE
+        const int arbitraryHour = 12;
+        var profile = new ScheduledOrchestrationProfile(
+            arbitraryHour, SenderPlatform.Instagram, typeof(FeedOrchestrator), AiProvider.OpenAi);
+        var factory = CreateFactoryWithProfiles(arbitraryHour, profile);
+
+        // ACT
+        var orchestrator = factory.Resolve();
+
+        // ASSERT
+        Assert.IsType<FeedOrchestrator>(orchestrator);
+        _mockServiceProvider.Verify(sp => sp.GetService(typeof(IgSender)), Times.Once);
+    }
+
+    [Fact]
+    public void Resolve_Should_ResolveDryRunSender_WhenProfileUsesDryRun()
     {
         // ARRANGE — DryRun profile injected synthetically; no dependency on production schedule
         const int arbitraryHour = 10;
         var profile = new ScheduledOrchestrationProfile(
-            arbitraryHour, MessageSender.DryRunSend, typeof(FeedOrchestrator), AiProvider.OpenAi);
+            arbitraryHour, SenderPlatform.DryRun, typeof(FeedOrchestrator), AiProvider.OpenAi);
         var factory = CreateFactoryWithProfiles(arbitraryHour, profile);
 
         // ACT
@@ -136,6 +153,40 @@ public class OrchestratorFactoryTests
         // ASSERT
         Assert.IsType<FeedOrchestrator>(orchestrator);
         _mockServiceProvider.Verify(sp => sp.GetService(typeof(DryRunSender)), Times.Once);
+    }
+
+    [Fact]
+    public void Resolve_Should_ResolveLinkedInSender_ForPowerLawOrchestrator()
+    {
+        // ARRANGE — same platform (LinkedIn), different orchestrator type: switch must be O(senders)
+        const int arbitraryHour = 14;
+        var profile = new ScheduledOrchestrationProfile(
+            arbitraryHour, SenderPlatform.LinkedIn, typeof(PowerLawOrchestrator));
+        var factory = CreateFactoryWithProfiles(arbitraryHour, profile);
+
+        // ACT
+        var orchestrator = factory.Resolve();
+
+        // ASSERT
+        Assert.IsType<PowerLawOrchestrator>(orchestrator);
+        _mockServiceProvider.Verify(sp => sp.GetService(typeof(InSender)), Times.Once);
+    }
+
+    [Fact]
+    public void Resolve_Should_ResolveXSender_ForPowerLawOrchestrator()
+    {
+        // ARRANGE — same platform (X), different orchestrator type: switch must be O(senders)
+        const int arbitraryHour = 16;
+        var profile = new ScheduledOrchestrationProfile(
+            arbitraryHour, SenderPlatform.X, typeof(PowerLawOrchestrator));
+        var factory = CreateFactoryWithProfiles(arbitraryHour, profile);
+
+        // ACT
+        var orchestrator = factory.Resolve();
+
+        // ASSERT
+        Assert.IsType<PowerLawOrchestrator>(orchestrator);
+        _mockServiceProvider.Verify(sp => sp.GetService(typeof(XSender)), Times.Once);
     }
 
     // ---------------------------------------------------------------------------
@@ -148,7 +199,7 @@ public class OrchestratorFactoryTests
         // ARRANGE
         const int arbitraryHour = 10;
         var profile = new ScheduledOrchestrationProfile(
-            arbitraryHour, MessageSender.XSummaryFeed, typeof(FeedOrchestrator), AiProvider.OpenAi);
+            arbitraryHour, SenderPlatform.X, typeof(FeedOrchestrator), AiProvider.OpenAi);
         var factory = CreateFactoryWithProfiles(arbitraryHour, profile);
 
         // ACT
@@ -164,7 +215,7 @@ public class OrchestratorFactoryTests
         // ARRANGE
         const int arbitraryHour = 10;
         var profile = new ScheduledOrchestrationProfile(
-            arbitraryHour, MessageSender.InPowerLaw, typeof(PowerLawOrchestrator));
+            arbitraryHour, SenderPlatform.LinkedIn, typeof(PowerLawOrchestrator));
         var factory = CreateFactoryWithProfiles(arbitraryHour, profile);
 
         // ACT
@@ -183,7 +234,7 @@ public class OrchestratorFactoryTests
     {
         // ARRANGE
         var innerProfile = new ScheduledOrchestrationProfile(
-            6, MessageSender.InSummaryFeed, typeof(FeedOrchestrator), AiProvider.OpenAi);
+            6, SenderPlatform.LinkedIn, typeof(FeedOrchestrator), AiProvider.OpenAi);
 
         var mockInner = new Mock<ISlotProfileProvider>();
         mockInner.Setup(p => p.GetProfiles())
@@ -196,7 +247,7 @@ public class OrchestratorFactoryTests
 
         // ASSERT
         Assert.Equal(2, profiles.Count);
-        Assert.Contains(profiles, p => p.SenderType == MessageSender.DryRunSend);
+        Assert.Contains(profiles, p => p.SenderPlatform == SenderPlatform.DryRun);
     }
 
     [Fact]
@@ -209,7 +260,73 @@ public class OrchestratorFactoryTests
         var profiles = provider.GetProfiles();
 
         // ASSERT
-        Assert.DoesNotContain(profiles, p => p.SenderType == MessageSender.DryRunSend);
+        Assert.DoesNotContain(profiles, p => p.SenderPlatform == SenderPlatform.DryRun);
+    }
+
+    // ---------------------------------------------------------------------------
+    // SupportedPlatforms contract
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public void FeedOrchestrator_SupportedPlatforms_ContainsAllExpectedPlatforms()
+    {
+        // ARRANGE
+        const int arbitraryHour = 10;
+        var profile = new ScheduledOrchestrationProfile(
+            arbitraryHour, SenderPlatform.X, typeof(FeedOrchestrator), AiProvider.OpenAi);
+        var factory = CreateFactoryWithProfiles(arbitraryHour, profile);
+
+        // ACT
+        var orchestrator = factory.Resolve();
+
+        // ASSERT
+        var feedOrchestrator = Assert.IsType<FeedOrchestrator>(orchestrator);
+        Assert.Contains(SenderPlatform.X,         feedOrchestrator.SupportedPlatforms);
+        Assert.Contains(SenderPlatform.LinkedIn,  feedOrchestrator.SupportedPlatforms);
+        Assert.Contains(SenderPlatform.Instagram, feedOrchestrator.SupportedPlatforms);
+        Assert.Contains(SenderPlatform.DryRun,    feedOrchestrator.SupportedPlatforms);
+    }
+
+    [Fact]
+    public void PowerLawOrchestrator_SupportedPlatforms_ContainsXAndLinkedIn()
+    {
+        // ARRANGE
+        const int arbitraryHour = 14;
+        var profile = new ScheduledOrchestrationProfile(
+            arbitraryHour, SenderPlatform.LinkedIn, typeof(PowerLawOrchestrator));
+        var factory = CreateFactoryWithProfiles(arbitraryHour, profile);
+
+        // ACT
+        var orchestrator = factory.Resolve();
+
+        // ASSERT
+        var powerLawOrchestrator = Assert.IsType<PowerLawOrchestrator>(orchestrator);
+        Assert.Contains(SenderPlatform.X,        powerLawOrchestrator.SupportedPlatforms);
+        Assert.Contains(SenderPlatform.LinkedIn, powerLawOrchestrator.SupportedPlatforms);
+        Assert.Contains(SenderPlatform.DryRun,   powerLawOrchestrator.SupportedPlatforms);
+        Assert.DoesNotContain(SenderPlatform.Instagram, powerLawOrchestrator.SupportedPlatforms);
+    }
+
+    [Fact]
+    public void NoOrchestrator_SupportedPlatforms_IsEmpty()
+    {
+        // ARRANGE — empty schedule forces NoOrchestrator
+        var mockProfileProvider = new Mock<ISlotProfileProvider>();
+        mockProfileProvider.Setup(p => p.GetProfiles())
+            .Returns(new List<ScheduledOrchestrationProfile>());
+
+        _mockTimeProvider.Setup(tp => tp.GetCurrentTime())
+            .Returns(new DateTime(2025, 1, 1, 3, 0, 0));
+
+        SetupMocksForOrchestratorFactory();
+        var factory = CreateFactory(mockProfileProvider.Object);
+
+        // ACT
+        var orchestrator = factory.Resolve();
+
+        // ASSERT
+        var noOrchestrator = Assert.IsType<NoOrchestrator>(orchestrator);
+        Assert.Empty(noOrchestrator.SupportedPlatforms);
     }
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implementation of **ADR-005 § Decision 1** — removes the coupling between Orchestrator identity and Sender identity encoded in the `MessageSender` enum.

Introduces `SenderPlatform` to represent only the target platform, and makes `OrchestratorFactory` resolve the correct `ISender` from it.

Closes #210

---

## Changes

- Replaced `MessageSender` enum with `SenderPlatform { X, LinkedIn, Instagram, DryRun }` in `src/Contracts/Enums.cs`
- `ScheduledOrchestrationProfile` now uses `SenderPlatform` instead of `MessageSender`
- `OrchestratorFactory` sender switch is now O(senders) — independent of orchestrator count
- `DefaultSlotProfileProvider` and `DryRunSlotProfileProvider` updated to use `SenderPlatform`
- `IOrchestrator` exposes `SupportedPlatforms` property; implemented in `FeedOrchestrator`, `PowerLawOrchestrator`, `NoOrchestrator`
- All related tests updated/added
- Docs updated: `docs/architecture.md`, `docs/extending-xposter.md`, `README.md`
- `CHANGELOG.md` updated under `## [Unreleased]`

## References

- ADR-005 § Decision 1
- Issue #210
- Issue #134 Part 1