### PR TITLE
feat(#216): FeedOrchestrator tag replacement externalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AddXPosterAiProviders()` DI extension method; registers capability interfaces as keyed services by `AiProvider` ([#211](https://github.com/artcava/XPoster/issues/211))
 - `ITextToImageProvider` interface: capability contract for image generation ([#211](https://github.com/artcava/XPoster/issues/211))
 - `ITextToTextProvider` interface: capability contract for text summarisation and image prompt generation ([#211](https://github.com/artcava/XPoster/issues/211))
+- `ITagReplacementProvider` abstraction: config-backed keyword replacement contract for orchestrators, decoupling hashtag/tag mapping from code and enabling operator-managed replacements via configuration ([#216](https://github.com/artcava/XPoster/issues/216))
+- `ConfigurationTagReplacementProvider`: `ITagReplacementProvider` implementation bound from `TagReplacementOptions`, returning the configured replacement dictionary with empty-map fallback when the section is absent ([#216](https://github.com/artcava/XPoster/issues/216))
 
 ### Changed
 - `DefaultSlotProfileProvider`: any slot previously referencing `AiProvider.DeepSeekWithFal` updated to `AiProvider.DeepSeek` or `AiProvider.FalAi` ([#211](https://github.com/artcava/XPoster/issues/211))
@@ -21,12 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FalAiImageService` implements `ITextToImageProvider` only ([#211](https://github.com/artcava/XPoster/issues/211))
 - `DeepSeekService` and `PerplexityService` implement `ITextToTextProvider` only ([#211](https://github.com/artcava/XPoster/issues/211))
 - `OpenAiService` and `AzureFoundryService` implement both capability interfaces ([#211](https://github.com/artcava/XPoster/issues/211))
-- Per-slot AI provider selection preserved: `profile.AiProvider` still drives which implementation is active for each time slot ([#211](https://github.com/artcava/XPoster/issues/211))
+- Per-slot AI provider selection preserved: `ScheduledOrchestrationProfile` now carries independent `TextProvider` and `ImageProvider` fields, each resolved separately at runtime ([#211](https://github.com/artcava/XPoster/issues/211))
 - `OrchestratorFactory` resolves two keyed capability services via `GetKeyedService` (nullable); `IAiServiceFactory` dependency removed ([#211](https://github.com/artcava/XPoster/issues/211))
 - `FeedOrchestrator` depends on `ITextToTextProvider?` + `ITextToImageProvider?` instead of `IAiService` ([#211](https://github.com/artcava/XPoster/issues/211))
 - Replaced `MessageSender` enum with `SenderPlatform` enum; platform and orchestrator identity are now independent (ADR-005)
 - `OrchestratorFactory` resolves `ISender` from `SenderPlatform`; adding a new orchestrator no longer requires enum changes
 - `ScheduledOrchestrationProfile` uses `SenderPlatform` instead of `MessageSender`
+- `FeedOrchestrator` refactored to an explicit staged pipeline (`GetFeedUrls` → `GetFeedsAsync` → `GetSummaryAsync` → tag replacement → `GetImagePromptAsync` → `GenerateImageAsync` → `BuildPost`) with structured logging at each decision point; hashtag replacement is now externalised through `ITagReplacementProvider` instead of inline logic ([#216](https://github.com/artcava/XPoster/issues/216))
 
 ### Removed
 - `PerplexityService.GenerateImageAsync`: method removed; Perplexity is a text-only provider ([#211](https://github.com/artcava/XPoster/issues/211))
@@ -41,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ScheduledOrchestrationProfileTests`** ([#211](https://github.com/artcava/XPoster/issues/211)): new test class (`tests/Abstraction/`) covering all constructor combinations — both providers set, text-only, image-only, neither (PowerLaw pattern), canonical split-provider (DeepSeek+FalAi), and hour boundary values `[0, 6, 23]`.
 - **`DefaultSlotProfileProviderTests`** ([#211](https://github.com/artcava/XPoster/issues/211)): new test class verifying slot count (4), hour uniqueness, that FeedOrchestrator slots at hours 6 and 8 have both `TextProvider` and `ImageProvider` configured and non-`None`, that PowerLaw slots at hours 14 and 16 have both `null`, that no DryRun slot exists in the production schedule, and that `DryRunSlotProfileProvider` appends a slot with both providers configured.
 - **`FeedOrchestratorTests`** ([#211](https://github.com/artcava/XPoster/issues/211)): two new tests covering the `GetImagePromptAsync` empty-string and whitespace fallback branch — verifies that when `GetImagePromptAsync` returns an empty or whitespace result, `GenerateImageAsync` is called with the summary as the fallback prompt, and the post is published with the image.
+- **`ConfigurationTagReplacementProviderTests`** ([#216](https://github.com/artcava/XPoster/issues/216)): new test class covering configured replacement-map return, empty-map fallback when the `TagReplacementOptions` section is absent, and `ArgumentNullException` on null options.
+- **`FeedOrchestratorTests`** ([#216](https://github.com/artcava/XPoster/issues/216)): added staged-pipeline coverage for `GetFeedUrls()` invocation, early return when the configured URL list is empty, forwarding provider URLs into `IFeedService`, tag replacement execution before image prompt generation, single retrieval of replacement map, and graceful continuation when no replacements are configured.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `ITagReplacementProvider` abstraction: config-backed keyword replacement contract for orchestrators, decoupling hashtag/tag mapping from code and enabling operator-managed replacements via configuration ([#216](https://github.com/artcava/XPoster/issues/216))
+- `ConfigurationTagReplacementProvider`: `ITagReplacementProvider` implementation bound from `TagReplacementOptions`, returning the configured replacement dictionary with empty-map fallback when the section is absent ([#216](https://github.com/artcava/XPoster/issues/216))
+- `ConfigurationTagReplacementProviderTests`: new test class covering configured replacement-map return, empty-map fallback when the `TagReplacementOptions` section is absent, and `ArgumentNullException` on null options ([#216](https://github.com/artcava/XPoster/issues/216))
+- `FeedOrchestratorTests` — staged-pipeline coverage: `GetFeedUrls()` invocation, early return when the configured URL list is empty, forwarding provider URLs into `IFeedService`, tag replacement execution before image prompt generation, single retrieval of replacement map, and graceful continuation when no replacements are configured ([#216](https://github.com/artcava/XPoster/issues/216))
 - `DiWiringTests`: integration tests verifying correct capability resolution per `AiProvider` key, including null-resolution for text-only and image-only providers ([#211](https://github.com/artcava/XPoster/issues/211))
 - `AddXPosterAiProviders()` DI extension method; registers capability interfaces as keyed services by `AiProvider` ([#211](https://github.com/artcava/XPoster/issues/211))
 - `ITextToImageProvider` interface: capability contract for image generation ([#211](https://github.com/artcava/XPoster/issues/211))
 - `ITextToTextProvider` interface: capability contract for text summarisation and image prompt generation ([#211](https://github.com/artcava/XPoster/issues/211))
-- `ITagReplacementProvider` abstraction: config-backed keyword replacement contract for orchestrators, decoupling hashtag/tag mapping from code and enabling operator-managed replacements via configuration ([#216](https://github.com/artcava/XPoster/issues/216))
-- `ConfigurationTagReplacementProvider`: `ITagReplacementProvider` implementation bound from `TagReplacementOptions`, returning the configured replacement dictionary with empty-map fallback when the section is absent ([#216](https://github.com/artcava/XPoster/issues/216))
+- `OrchestratorFactoryTests` ([#211](https://github.com/artcava/XPoster/issues/211)): all `ScheduledOrchestrationProfile` usages updated to the new two-field constructor signature. Four new tests added: `Resolve_Should_RequestTextProviderKey_WhenProfileSpecifiesTextProvider`, `Resolve_Should_RequestImageProviderKey_WhenProfileSpecifiesImageProvider`, `Resolve_Should_RequestDifferentKeys_WhenTextAndImageProvidersAreDifferent` (verifies DeepSeek+FalAi split scenario with no cross-contamination), `Resolve_Should_NotRequestImageProvider_WhenProfileHasNoImageProvider` (text-only slot).
+- `ScheduledOrchestrationProfileTests` ([#211](https://github.com/artcava/XPoster/issues/211)): new test class (`tests/Abstraction/`) covering all constructor combinations — both providers set, text-only, image-only, neither (PowerLaw pattern), canonical split-provider (DeepSeek+FalAi), and hour boundary values `[0, 6, 23]`.
+- `DefaultSlotProfileProviderTests` ([#211](https://github.com/artcava/XPoster/issues/211)): new test class verifying slot count (4), hour uniqueness, that FeedOrchestrator slots at hours 6 and 8 have both `TextProvider` and `ImageProvider` configured and non-`None`, that PowerLaw slots at hours 14 and 16 have both `null`, that no DryRun slot exists in the production schedule, and that `DryRunSlotProfileProvider` appends a slot with both providers configured.
+- `FeedOrchestratorTests` ([#211](https://github.com/artcava/XPoster/issues/211)): two new tests covering the `GetImagePromptAsync` empty-string and whitespace fallback branch — verifies that when `GetImagePromptAsync` returns an empty or whitespace result, `GenerateImageAsync` is called with the summary as the fallback prompt, and the post is published with the image.
 
 ### Changed
+- `FeedOrchestrator` refactored to an explicit staged pipeline (`GetFeedUrls` → `GetFeedsAsync` → `GetSummaryAsync` → tag replacement → `GetImagePromptAsync` → `GenerateImageAsync` → `BuildPost`) with structured logging at each decision point; hashtag replacement is now externalised through `ITagReplacementProvider` instead of inline logic ([#216](https://github.com/artcava/XPoster/issues/216))
 - `DefaultSlotProfileProvider`: any slot previously referencing `AiProvider.DeepSeekWithFal` updated to `AiProvider.DeepSeek` or `AiProvider.FalAi` ([#211](https://github.com/artcava/XPoster/issues/211))
 - `PerplexityService.GenerateImageAsync` previously returned `byte[0]` silently; this silent failure is eliminated — the method is removed; misconfiguration surfaces explicitly at point of use ([#211](https://github.com/artcava/XPoster/issues/211))
 - `FalAiImageService` implements `ITextToImageProvider` only ([#211](https://github.com/artcava/XPoster/issues/211))
@@ -29,7 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `MessageSender` enum with `SenderPlatform` enum; platform and orchestrator identity are now independent (ADR-005)
 - `OrchestratorFactory` resolves `ISender` from `SenderPlatform`; adding a new orchestrator no longer requires enum changes
 - `ScheduledOrchestrationProfile` uses `SenderPlatform` instead of `MessageSender`
-- `FeedOrchestrator` refactored to an explicit staged pipeline (`GetFeedUrls` → `GetFeedsAsync` → `GetSummaryAsync` → tag replacement → `GetImagePromptAsync` → `GenerateImageAsync` → `BuildPost`) with structured logging at each decision point; hashtag replacement is now externalised through `ITagReplacementProvider` instead of inline logic ([#216](https://github.com/artcava/XPoster/issues/216))
 
 ### Removed
 - `PerplexityService.GenerateImageAsync`: method removed; Perplexity is a text-only provider ([#211](https://github.com/artcava/XPoster/issues/211))
@@ -38,14 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AiProvider.DeepSeekWithFal`: enum value removed; replaced by independent `AiProvider.DeepSeek` and `AiProvider.FalAi` keys ([#211](https://github.com/artcava/XPoster/issues/211))
 - `HybridAiService`: no longer needed; `DeepSeek` and `FalAi` are now independent `AiProvider` keys ([#211](https://github.com/artcava/XPoster/issues/211))
 - `MessageSender` enum
-
-### Tests
-- **`OrchestratorFactoryTests`** ([#211](https://github.com/artcava/XPoster/issues/211)): all `ScheduledOrchestrationProfile` usages updated to the new two-field constructor signature. Four new tests added: `Resolve_Should_RequestTextProviderKey_WhenProfileSpecifiesTextProvider`, `Resolve_Should_RequestImageProviderKey_WhenProfileSpecifiesImageProvider`, `Resolve_Should_RequestDifferentKeys_WhenTextAndImageProvidersAreDifferent` (verifies DeepSeek+FalAi split scenario with no cross-contamination), `Resolve_Should_NotRequestImageProvider_WhenProfileHasNoImageProvider` (text-only slot).
-- **`ScheduledOrchestrationProfileTests`** ([#211](https://github.com/artcava/XPoster/issues/211)): new test class (`tests/Abstraction/`) covering all constructor combinations — both providers set, text-only, image-only, neither (PowerLaw pattern), canonical split-provider (DeepSeek+FalAi), and hour boundary values `[0, 6, 23]`.
-- **`DefaultSlotProfileProviderTests`** ([#211](https://github.com/artcava/XPoster/issues/211)): new test class verifying slot count (4), hour uniqueness, that FeedOrchestrator slots at hours 6 and 8 have both `TextProvider` and `ImageProvider` configured and non-`None`, that PowerLaw slots at hours 14 and 16 have both `null`, that no DryRun slot exists in the production schedule, and that `DryRunSlotProfileProvider` appends a slot with both providers configured.
-- **`FeedOrchestratorTests`** ([#211](https://github.com/artcava/XPoster/issues/211)): two new tests covering the `GetImagePromptAsync` empty-string and whitespace fallback branch — verifies that when `GetImagePromptAsync` returns an empty or whitespace result, `GenerateImageAsync` is called with the summary as the fallback prompt, and the post is published with the image.
-- **`ConfigurationTagReplacementProviderTests`** ([#216](https://github.com/artcava/XPoster/issues/216)): new test class covering configured replacement-map return, empty-map fallback when the `TagReplacementOptions` section is absent, and `ArgumentNullException` on null options.
-- **`FeedOrchestratorTests`** ([#216](https://github.com/artcava/XPoster/issues/216)): added staged-pipeline coverage for `GetFeedUrls()` invocation, early return when the configured URL list is empty, forwarding provider URLs into `IFeedService`, tag replacement execution before image prompt generation, single retrieval of replacement map, and graceful continuation when no replacements are configured.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,11 +226,11 @@ When adding new files, place them in the folder that matches their responsibilit
 |---|---|---|
 | `src/Contracts/` | `XPoster.Contracts` | Interfaces (`I*.cs`), enums, extension methods |
 | `src/Abstraction/` | `XPoster.Abstraction` | Abstract base classes, shared profile records (`BaseOrchestrator`, `ScheduledOrchestrationProfile`) |
-| `src/Orchestrators/` | `XPoster.Orchestrators` | Concrete orchestrators, `OrchestratorFactory`, `AiServiceFactory`, slot profile providers |
+| `src/Orchestrators/` | `XPoster.Orchestrators` | Concrete orchestrators, `OrchestratorFactory`, slot profile providers (`DefaultSlotProfileProvider`, `DryRunSlotProfileProvider`), config-backed providers (`ConfigurationFeedUrlProvider`, `ConfigurationTagReplacementProvider`) |
 | `src/Models/` | `XPoster.Models` | Domain models, provider options and validators (use provider subfolders: `AzureFoundry/`, `DeepSeek/`, `FalAi/`, `OpenAi/`) |
 | `src/Credentials/` | `XPoster.Credentials` | Sender credentials DTOs, validators, and extension methods (`XCredentials`, `LinkedInCredentials`, `IgCredentials`…) |
 | `src/Services/` | `XPoster.Services` | Infrastructure services (`FeedService`, `CryptoService`, `TimeProvider`…) |
-| `src/Services/Ai/` | `XPoster.Services` | AI model integration services (`OpenAiService`, `AzureFoundryService`, `HybridAiService`…) |
+| `src/Services/Ai/` | `XPoster.Services` | AI model integration services (`OpenAiService`, `AzureFoundryService`, `DeepSeekService`, `PerplexityService`, `FalAiImageService`…) |
 | `src/SenderPlugins/` | `XPoster.SenderPlugins` | Platform-specific sender implementations (`ISender`) |
 | `src/Extensions/` | `XPoster.Extensions` | Cross-cutting extension methods (e.g. `HttpClientExtensions`) |
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ XPoster is a **serverless, event-driven pipeline** built on four structural pill
 - **Orchestrators** (`FeedOrchestrator`, `PowerLawOrchestrator`, `NoOrchestrator`) — each encapsulates a self-contained content-production algorithm; orchestrators depend exclusively on injected abstractions and are unaware of target platforms
 - **Sender Plugins** (`XSender`, `InSender`, `IgSender`, `DryRunSender`) — implement `ISender` to isolate all platform-specific API communication; adding a new platform requires zero changes to existing components
 
-The AI layer uses two capability interfaces — `ITextToTextProvider` and `ITextToImageProvider` — registered as **keyed services** in the DI container, keyed by `AiProvider` enum value. `OrchestratorFactory` resolves both capabilities independently via `IServiceProvider.GetKeyedService<T>(profile.AiProvider)`. A `null` result means the capability is not available for that provider; orchestrators degrade gracefully (text-only post or skip).
+The AI layer uses two capability interfaces — `ITextToTextProvider` and `ITextToImageProvider` — registered as **keyed services** in the DI container. Each `ScheduledOrchestrationProfile` declares `TextProvider` and `ImageProvider` independently as nullable `AiProvider?` values; `OrchestratorFactory` resolves each capability separately via `GetKeyedService<T>(profile.TextProvider)` and `GetKeyedService<T>(profile.ImageProvider)`. A `null` value means the capability is not assigned for that slot; orchestrators degrade gracefully (text-only post or skip).
 
 Sender OAuth credentials are loaded from **Azure Key Vault** at application startup via the Key Vault Configuration Provider registered in `Program.cs`. Secrets are merged into `IConfiguration` and injected into senders through `IOptions<TCredentials>` — no runtime Key Vault calls occur during post publishing.
 
@@ -141,7 +141,7 @@ Sender OAuth credentials are loaded from **Azure Key Vault** at application star
 
 ### AI & ML
 
-The AI layer uses two capability interfaces — `ITextToTextProvider` (text summarisation + image prompt generation) and `ITextToImageProvider` (image generation) — registered as **keyed services** in the DI container, keyed by `AiProvider` enum value. `OrchestratorFactory` resolves both independently; a `null` result signals that the capability is unavailable for that provider and the orchestrator degrades gracefully.
+The AI layer uses two capability interfaces — `ITextToTextProvider` (text summarisation + image prompt generation) and `ITextToImageProvider` (image generation) — registered as **keyed services** in the DI container, keyed by `AiProvider` enum value. Each `ScheduledOrchestrationProfile` carries independent `TextProvider` and `ImageProvider` fields, allowing different providers per capability within the same slot. `OrchestratorFactory` resolves each independently; a `null` field means the capability is not assigned for that slot and the orchestrator degrades gracefully.
 
 | Package | Version | Role |
 |---------|---------|------|
@@ -160,7 +160,7 @@ The AI layer uses two capability interfaces — `ITextToTextProvider` (text summ
 | `Perplexity` | ✅ `PerplexityService` | ❌ | Text only — posts published without image |
 | `FalAi` | ❌ | ✅ `FalAiImageService` | Image only — only valid for orchestrators that handle null `textProvider` |
 
-> ℹ️ `DeepSeekWithFal` / `HybridAiService` have been removed. Assign `AiProvider.DeepSeek` to text slots and `AiProvider.FalAi` to image slots independently in `DefaultSlotProfileProvider`.
+> ℹ️ `DeepSeekWithFal` / `HybridAiService` have been removed. Assign `AiProvider.DeepSeek` to `TextProvider` and `AiProvider.FalAi` to `ImageProvider` independently in `DefaultSlotProfileProvider`.
 
 ### Social Media APIs
 
@@ -379,14 +379,16 @@ az functionapp config appsettings set \
 
 ### Time-based Strategy (ISlotProfileProvider)
 
-The production schedule is defined in `DefaultSlotProfileProvider`, which returns four fixed profiles:
+The production schedule is defined in `DefaultSlotProfileProvider`, which returns four fixed profiles. Each slot declares `TextProvider` and `ImageProvider` independently as nullable `AiProvider?` — `null` means the capability is not assigned for that slot.
 
-| UTC Hour | `SenderPlatform` | Orchestrator | AI Provider |
-|----------|------------------|--------------|-------------|
-| 6 | `LinkedIn` | `FeedOrchestrator` | `OpenAi` |
-| 8 | `X` | `FeedOrchestrator` | `OpenAi` |
-| 14 | `LinkedIn` | `PowerLawOrchestrator` | *(default)* |
-| 16 | `X` | `PowerLawOrchestrator` | *(default)* |
+| UTC Hour | `SenderPlatform` | Orchestrator | `TextProvider` | `ImageProvider` |
+|----------|------------------|--------------|----------------|-----------------|
+| 6 | `LinkedIn` | `FeedOrchestrator` | `OpenAi` | `OpenAi` |
+| 8 | `X` | `FeedOrchestrator` | `AzureFoundry` | `AzureFoundry` |
+| 14 | `LinkedIn` | `PowerLawOrchestrator` | `null` | `null` |
+| 16 | `X` | `PowerLawOrchestrator` | `null` | `null` |
+
+> ℹ️ `PowerLawOrchestrator` slots at 14 and 16 do not require AI providers — they compute a deterministic post from crypto price data and do not call `ITextToTextProvider` or `ITextToImageProvider`.
 
 `OrchestratorFactory` no longer owns a static list of profiles. It receives an `ISlotProfileProvider` via constructor injection and calls `GetProfiles()` at resolution time — making the schedule a swappable dependency rather than embedded logic.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 ### 🤖 Content Generation
 - **AI-Powered Summarization**: Intelligent RSS feed summaries via a configurable AI model of your choice
 - **Image Generation**: Automatic contextual image creation using any supported image generation model
-- **Smart Hashtags**: Automatic keyword conversion to optimized hashtags
+- **Smart Hashtags**: Automatic keyword-to-hashtag conversion driven by a configurable replacement map (`TagReplacementOptions`) — no redeployment required to change the hashtag set
 - **Multi-Strategy**: Support for different content orchestration algorithms
 - **Provider Agnostic**: The AI provider (e.g. OpenAI, Azure AI Foundry) and the specific model are selected by the operator through configuration — no code change required to swap models
 
@@ -71,9 +71,9 @@ XPoster is a **serverless, event-driven pipeline** built on four structural pill
 - **Orchestrators** (`FeedOrchestrator`, `PowerLawOrchestrator`, `NoOrchestrator`) — each encapsulates a self-contained content-production algorithm; orchestrators depend exclusively on injected abstractions and are unaware of target platforms
 - **Sender Plugins** (`XSender`, `InSender`, `IgSender`, `DryRunSender`) — implement `ISender` to isolate all platform-specific API communication; adding a new platform requires zero changes to existing components
 
-The AI layer is abstracted behind `IAiService` and resolved at runtime by `AiServiceFactory`, enabling per-slot provider assignment and global override via configuration without touching orchestrator code.
+The AI layer uses two capability interfaces — `ITextToTextProvider` and `ITextToImageProvider` — registered as **keyed services** in the DI container, keyed by `AiProvider` enum value. `OrchestratorFactory` resolves both capabilities independently via `IServiceProvider.GetKeyedService<T>(profile.AiProvider)`. A `null` result means the capability is not available for that provider; orchestrators degrade gracefully (text-only post or skip).
 
-Secret resolution for platform tokens is handled by **`KeyVaultService`** (`IKeyVaultService`), which wraps `Azure.Security.KeyVault.Secrets` and is consumed by sender plugins at runtime to retrieve OAuth credentials from Azure Key Vault.
+Sender OAuth credentials are loaded from **Azure Key Vault** at application startup via the Key Vault Configuration Provider registered in `Program.cs`. Secrets are merged into `IConfiguration` and injected into senders through `IOptions<TCredentials>` — no runtime Key Vault calls occur during post publishing.
 
 ```
 ┌────────────────────────────┐
@@ -97,15 +97,16 @@ Secret resolution for platform tokens is handled by **`KeyVaultService`** (`IKey
       └──────┬───────────┘
              │
              ▼
-    ┌────────────────────┐
-    │   Services         │
-    ├────────────────────┤
-    │ • AiServiceFactory │ ◄─── Resolves IAiService by AiProvider
-    │ • AiServiceHelper  │ ◄─── HTTP response parsing / 429 handling
-    │ • Feed Service     │ ◄─── RSS Parser
-    │ • Crypto Service   │ ◄─── CryptoPrices HTTP client
-    │ • KeyVaultService  │ ◄─── Azure Key Vault secret resolution
-    └────────┬───────────┘
+    ┌────────────────────────────┐
+    │   Services                 │
+    ├────────────────────────────┤
+    │ • ITextToTextProvider      │ ◄─── Keyed by AiProvider (text capability)
+    │ • ITextToImageProvider     │ ◄─── Keyed by AiProvider (image capability)
+    │ • IFeedUrlProvider         │ ◄─── RSS feed URL list (config-backed)
+    │ • ITagReplacementProvider  │ ◄─── Hashtag map resolution (config-backed)
+    │ • FeedService              │ ◄─── RSS/Atom parser + resilient HTTP client
+    │ • CryptoService            │ ◄─── CryptoPrices HTTP client
+    └────────┬───────────────────┘
              │
              ▼
     ┌────────────────────┐
@@ -118,7 +119,7 @@ Secret resolution for platform tokens is handled by **`KeyVaultService`** (`IKey
     └────────────────────┘
 ```
 
-> 📐 For the full architectural rationale, component responsibilities, design patterns (Strategy, Factory, Plugin, Abstract Factory), ADRs, extension contracts, and the end-to-end Mermaid sequence diagram, see **[docs/architecture.md](docs/architecture.md)**.
+> 📐 For the full architectural rationale, component responsibilities, design patterns (Strategy, Factory, Plugin), ADRs, extension contracts, and the end-to-end Mermaid sequence diagram, see **[docs/architecture.md](docs/architecture.md)**.
 
 > 🤖 For AI-assisted development, an auto-generated code graph is available at [`docs/agent-graph/`](docs/agent-graph/). See [docs/agent-graph.md](docs/agent-graph.md) for usage.
 
@@ -140,27 +141,26 @@ Secret resolution for platform tokens is handled by **`KeyVaultService`** (`IKey
 
 ### AI & ML
 
-The AI layer is built on **Microsoft.Extensions.AI**, the provider-agnostic abstraction for .NET AI services. Each AI provider is registered as a keyed `IAiService` in the DI container and resolved at runtime by `AiServiceFactory` based on the `AiProvider` enum value set on each `ScheduledOrchestrationProfile`.
+The AI layer uses two capability interfaces — `ITextToTextProvider` (text summarisation + image prompt generation) and `ITextToImageProvider` (image generation) — registered as **keyed services** in the DI container, keyed by `AiProvider` enum value. `OrchestratorFactory` resolves both independently; a `null` result signals that the capability is unavailable for that provider and the orchestrator degrades gracefully.
 
 | Package | Version | Role |
 |---------|---------|------|
 | `Microsoft.Extensions.AI` | 10.6.0 | Provider-agnostic AI abstraction (chat + embeddings) |
 | `Microsoft.Extensions.AI.OpenAI` | 10.6.0 | OpenAI/Azure OpenAI bridge for `Microsoft.Extensions.AI` |
-| `Azure.AI.OpenAI` | 2.1.0 | Azure OpenAI REST client (used by `OpenAiService` and `AzureFoundryService`) |
+| `Azure.AI.OpenAI` | 2.1.0 | Azure OpenAI REST client |
 | `Azure.Identity` | 1.13.2 | Managed Identity / `DefaultAzureCredential` support |
 
 **Supported AI providers at runtime:**
 
-| `AiProvider` enum value | Concrete service | Text backend | Image backend |
-|-------------------------|-----------------|--------------|---------------|
-| `OpenAi` | `OpenAiService` | Azure OpenAI / OpenAI-compatible endpoint | Same endpoint (e.g. `dall-e-3`, `gpt-image-1`) |
-| `AzureFoundry` | `AzureFoundryService` | Azure AI Foundry deployment | Azure AI Foundry deployment |
-| `DeepSeekWithFal` | `HybridAiService` | `DeepSeekService` → DeepSeek API | `FalAiImageService` → fal.ai FLUX.2 Turbo |
-| `Perplexity` | `PerplexityService` | Perplexity Sonar Chat Completions API | ❌ Not supported — posts published text-only |
+| `AiProvider` value | `ITextToTextProvider` | `ITextToImageProvider` | Notes |
+|---|---|---|---|
+| `OpenAi` | ✅ `OpenAiService` | ✅ `OpenAiService` | Full text + image |
+| `AzureFoundry` | ✅ `AzureFoundryService` | ✅ `AzureFoundryService` | Full text + image |
+| `DeepSeek` | ✅ `DeepSeekService` | ❌ | Text only — posts published without image |
+| `Perplexity` | ✅ `PerplexityService` | ❌ | Text only — posts published without image |
+| `FalAi` | ❌ | ✅ `FalAiImageService` | Image only — only valid for orchestrators that handle null `textProvider` |
 
-> ℹ️ `DeepSeekService` and `FalAiImageService` are independent services, each with their own registration and test coverage. `HybridAiService` composes the two, delegating text requests to `DeepSeekService` and image requests to `FalAiImageService`. This composition is transparent to orchestrators, which always program to `IAiService`.
->
-> ℹ️ `PerplexityService` implements `IAiService` but does not support image generation. `GenerateImageAsync` always returns an empty byte array and logs a `Warning` — posts are published text-only when this provider is active.
+> ℹ️ `DeepSeekWithFal` / `HybridAiService` have been removed. Assign `AiProvider.DeepSeek` to text slots and `AiProvider.FalAi` to image slots independently in `DefaultSlotProfileProvider`.
 
 ### Social Media APIs
 
@@ -184,7 +184,7 @@ The AI layer is built on **Microsoft.Extensions.AI**, the provider-agnostic abst
 |---------|---------|------|
 | `Microsoft.Extensions.Http.Resilience` | 9.1.0 | Retry / resilience pipelines for outbound HTTP clients (`IHttpClientFactory`) |
 | `System.Text.Json` | 10.0.8 | JSON serialization / deserialization |
-| `Azure.Security.KeyVault.Secrets` | 4.7.0 | Azure Key Vault secret retrieval (used by `KeyVaultService`) |
+| `Azure.Extensions.AspNetCore.Configuration.Secrets` | 1.3.2 | Azure Key Vault Configuration Provider (startup secret loading) |
 | `Microsoft.AspNetCore.App` (framework ref) | 8.0 | ASP.NET Core primitives used by the Functions host |
 
 > ℹ️ `Microsoft.Extensions.Http` is resolved transitively and is not pinned explicitly in the project file to avoid NU1603 version conflicts.
@@ -211,8 +211,6 @@ The AI layer is built on **Microsoft.Extensions.AI**, the provider-agnostic abst
 | **fal.ai** | [fal.ai](https://fal.ai/) | Image only | [docs/integrations/setup-falai.md](docs/integrations/setup-falai.md) |
 | **Perplexity** | [perplexity.ai](https://www.perplexity.ai/) | Text only | [docs/integrations/setup-perplexity.md](docs/integrations/setup-perplexity.md) |
 
-> ℹ️ **DeepSeek** and **fal.ai** are used together as the `HybridAiService` — DeepSeek handles text generation and fal.ai handles image generation. See [docs/architecture.md](docs/architecture.md) for details.
->
 > ⚠️ The setup guides above are present and cover account creation, API key configuration, and troubleshooting. Some validation tasks (model names, key naming, SDK version checks) are tracked in issues [#130](https://github.com/artcava/XPoster/issues/130), [#131](https://github.com/artcava/XPoster/issues/131), and [#132](https://github.com/artcava/XPoster/issues/132) and will be completed before the next stable release.
 
 ### Clone the Repository
@@ -265,9 +263,9 @@ All configuration is driven by environment variables — there is no application
 - **Locally**: copy [`src/local.settings.json.example`](src/local.settings.json.example) to `src/local.settings.json` and fill in your values.
 - **On Azure**: add the same variables as Application Settings (**Azure Portal → Function App → Configuration**).
 
-Platform OAuth credentials (Twitter/X, LinkedIn, Instagram) are **not** stored as environment variables. They are resolved at runtime by `KeyVaultService` directly from **Azure Key Vault**, using `DefaultAzureCredential` — which picks up your `az login` session locally and the Function App's Managed Identity in production.
+Platform OAuth credentials (Twitter/X, LinkedIn, Instagram) are **not** stored as environment variables. They are loaded from **Azure Key Vault** at application startup via the Key Vault Configuration Provider and injected into senders through `IOptions<TCredentials>` — no runtime Key Vault calls occur during post publishing. `DefaultAzureCredential` picks up your `az login` session locally and the Function App's Managed Identity in production.
 
-> 📖 Full reference — variable names, types, defaults, allowed values, Key Vault secret names, and a step-by-step `DryRunSender` local-testing guide: **[docs/configuration.md](docs/configuration.md)**.
+> 📖 Full reference — variable names, types, defaults, allowed values, Key Vault secret names, `TagReplacementOptions` hashtag map, and a step-by-step `DryRunSender` local-testing guide: **[docs/configuration.md](docs/configuration.md)**.
 
 ---
 
@@ -385,8 +383,8 @@ The production schedule is defined in `DefaultSlotProfileProvider`, which return
 
 | UTC Hour | `SenderPlatform` | Orchestrator | AI Provider |
 |----------|------------------|--------------|-------------|
-| 6 | `LinkedIn` | `FeedOrchestrator` | OpenAi |
-| 8 | `X` | `FeedOrchestrator` | OpenAi |
+| 6 | `LinkedIn` | `FeedOrchestrator` | `OpenAi` |
+| 8 | `X` | `FeedOrchestrator` | `OpenAi` |
 | 14 | `LinkedIn` | `PowerLawOrchestrator` | *(default)* |
 | 16 | `X` | `PowerLawOrchestrator` | *(default)* |
 
@@ -411,7 +409,7 @@ To run the full pipeline locally without publishing to any social platform, acti
 | `EnableDryRunSlot` | `true` | Registers `DryRunSlotProfileProvider` in DI, which decorates `DefaultSlotProfileProvider` and appends a `DryRun` entry at hour 9 |
 | `ForceHour` | `9` | Overrides the UTC clock so `OrchestratorFactory` selects the dry-run slot at startup |
 
-`DryRunSender` will probe Key Vault connectivity (reads the `XApiKey` secret), log the generated post content (character count + full text and image presence), and return `true` — without calling any social platform API.
+`DryRunSender` runs the full orchestration pipeline — RSS fetch, AI summarisation, tag replacement, image generation — but **never publishes to any social platform**.
 
 > ⚠️ `EnableDryRunSlot` defaults to `false`. In production this key must be absent or explicitly set to `"false"`. Hour 9 is **never** part of the production schedule.
 
@@ -434,7 +432,9 @@ XPoster is designed with explicit extension points that allow new capabilities t
 |---|---|---|
 | **Sender Plugins** (`ISender`) | Implement `ISender`, register in DI, add a value to `SenderPlatform`, configure a `ScheduledOrchestrationProfile` | Platform-specific code is fully isolated behind a single interface, so adding a new social network has zero impact on orchestrators or scheduling |
 | **Content Orchestrators** (`BaseOrchestrator`) | Subclass `BaseOrchestrator`, override `OrchestrateAsync()` and `SupportedPlatforms`, add a `ScheduledOrchestrationProfile` entry | The Strategy pattern in `OrchestratorFactory` decouples content logic from scheduling, making it safe to introduce new content strategies independently |
-| **AI Providers** (`IAiService`) | Implement `IAiService`, register as a keyed service in DI, add an `AiProvider` enum value | All orchestrators depend only on `IAiService`, so swapping or adding a provider requires no changes outside the service layer and `Program.cs` |
+| **AI Providers** (`ITextToTextProvider` / `ITextToImageProvider`) | Implement the relevant capability interface(s), register as keyed services in `AddXPosterAiProviders()`, add an `AiProvider` enum value | Providers expose only the capabilities they support; `null` resolution is the canonical signal for "capability not available" — no switch expressions or factory classes to modify |
+| **Feed URL Providers** (`IFeedUrlProvider`) | Implement `IFeedUrlProvider`, register as `Singleton` in `Program.cs` replacing `ConfigurationFeedUrlProvider` | Feed URLs are a swappable dependency; sourcing them from a database or remote config requires zero changes to `FeedService` or any orchestrator |
+| **Tag Replacement Providers** (`ITagReplacementProvider`) | Implement `ITagReplacementProvider`, register as `Singleton` in `Program.cs` replacing `ConfigurationTagReplacementProvider` | The hashtag map is externalised from orchestrator code; changing, adding, or removing replacements requires only a configuration update — no redeployment |
 | **Scheduling profiles** (`ISlotProfileProvider`) | Implement `ISlotProfileProvider` (or subclass `DryRunSlotProfileProvider` as a decorator) and register it in `Program.cs` | The schedule is a swappable dependency injected into `OrchestratorFactory` — operators can alter or extend the slot list without touching factory or orchestrator code |
 
 > 📖 For step-by-step implementation guides, code contracts, design constraints, and worked examples for each extension point, see **[docs/extending-xposter.md](docs/extending-xposter.md)**.
@@ -449,11 +449,11 @@ The test suite uses **xUnit + Moq** with a unit-first approach. Tests are organi
 tests/
 ├── Contracts/        # AiProviderExtensions, BaseOrchestrator abstract contracts
 ├── Helpers/          # shared HTTP mock helpers for resilience tests
-├── Orchestrators/    # FeedOrchestrator, PowerLawOrchestrator, OrchestratorFactory, AiServiceFactory…
+├── Orchestrators/    # FeedOrchestrator, PowerLawOrchestrator, OrchestratorFactory, ConfigurationTagReplacementProvider…
 ├── Integration/      # Polly resilience pipelines — not run in CI
 ├── Models/           # domain model invariants, options validators
 ├── SenderPlugins/    # XSender, InSender, IgSender, DryRunSender
-└── Services/         # OpenAiService, AzureFoundryService, KeyVaultService…
+└── Services/         # OpenAiService, AzureFoundryService, DeepSeekService, FalAiImageService, PerplexityService…
 ```
 
 ### Running Tests
@@ -501,7 +501,7 @@ Key monitoring capabilities at a glance:
 - [x] Configuration externalization
 - [x] AI provider expansion
 - [x] Retry & resilience for external HTTP calls [Issue #133](https://github.com/artcava/XPoster/issues/133)
-- [ ] Extension-point refactoring — ADR-005 status: **Proposed** — implementation tracked in [Issue #134](https://github.com/artcava/XPoster/issues/134)
+- [x] `FeedOrchestrator` explicit pipeline + tag replacement externalization [Issue #216](https://github.com/artcava/XPoster/issues/216)
 - [x] Test coverage gate at 80%
 
 ### 🎨 Phase 3: Admin Dashboard (TBD)

--- a/README.md
+++ b/README.md
@@ -205,11 +205,11 @@ The AI layer uses two capability interfaces — `ITextToTextProvider` (text summ
 
 | Provider | Website | Capabilities | Setup Guide |
 |----------|---------|--------------|-------------|
-| **Azure AI Foundry** | [azure.microsoft.com/ai-foundry](https://azure.microsoft.com/en-us/products/ai-foundry/) | Text + Image | [docs/integrations/setup-azure-foundry.md](docs/integrations/setup-azure-foundry.md) |
-| **OpenAI** | [platform.openai.com](https://platform.openai.com/) | Text + Image | [docs/integrations/setup-openai.md](docs/integrations/setup-openai.md) |
-| **DeepSeek** | [platform.deepseek.com](https://platform.deepseek.com/) | Text only | [docs/integrations/setup-deepseek.md](docs/integrations/setup-deepseek.md) |
-| **fal.ai** | [fal.ai](https://fal.ai/) | Image only | [docs/integrations/setup-falai.md](docs/integrations/setup-falai.md) |
-| **Perplexity** | [perplexity.ai](https://www.perplexity.ai/) | Text only | [docs/integrations/setup-perplexity.md](docs/integrations/setup-perplexity.md) |
+| **Azure AI Foundry** | [azure.microsoft.com/ai-foundry](https://azure.microsoft.com/en-us/products/ai-foundry/) | Text + Image | [setup-azure-foundry.md](docs/integrations/AiProviders/setup-azure-foundry.md) |
+| **OpenAI** | [platform.openai.com](https://platform.openai.com/) | Text + Image | [setup-openai.md](docs/integrations/AiProviders/setup-openai.md) |
+| **DeepSeek** | [platform.deepseek.com](https://platform.deepseek.com/) | Text only | [setup-deepseek.md](docs/integrations/AiProviders/setup-deepseek.md) |
+| **fal.ai** | [fal.ai](https://fal.ai/) | Image only | [setup-falai.md](docs/integrations/AiProviders/setup-falai.md) |
+| **Perplexity** | [perplexity.ai](https://www.perplexity.ai/) | Text only | [setup-perplexity.md](docs/integrations/AiProviders/setup-perplexity.md) |
 
 > ⚠️ The setup guides above are present and cover account creation, API key configuration, and troubleshooting. Some validation tasks (model names, key naming, SDK version checks) are tracked in issues [#130](https://github.com/artcava/XPoster/issues/130), [#131](https://github.com/artcava/XPoster/issues/131), and [#132](https://github.com/artcava/XPoster/issues/132) and will be completed before the next stable release.
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,6 @@ The AI layer uses two capability interfaces — `ITextToTextProvider` (text summ
 | `Perplexity` | ✅ `PerplexityService` | ❌ | Text only — posts published without image |
 | `FalAi` | ❌ | ✅ `FalAiImageService` | Image only — only valid for orchestrators that handle null `textProvider` |
 
-> ℹ️ `DeepSeekWithFal` / `HybridAiService` have been removed. Assign `AiProvider.DeepSeek` to `TextProvider` and `AiProvider.FalAi` to `ImageProvider` independently in `DefaultSlotProfileProvider`.
-
 ### Social Media APIs
 
 | Library / API | Version | Platform |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,7 @@ XPoster is a **serverless, event-driven pipeline** that runs on a timer, selects
     │ • Feed Service     │ ◄─── RSS Parser (IHttpClientFactory + Polly)
     │ • Crypto Service   │ ◄─── CryptoPrices HTTP client
     │ • FeedUrlProvider  │ ◄─── Feed URL resolution (IFeedUrlProvider)
+    │ • TagReplacement   │ ◄─── Hashtag map resolution (ITagReplacementProvider)
     └────────┬───────────┘
              │
              ▼
@@ -101,7 +102,15 @@ The factory enforces the invariant that every unscheduled hour resolves to `NoOr
 
 Each orchestrator extends `BaseOrchestrator` and encapsulates a specific **content production algorithm**:
 
-- **FeedOrchestrator**: fetches RSS entries via `FeedService`, calls `ITextToTextProvider` to produce a text summary and an image prompt, then calls `ITextToImageProvider` to generate an image. Feed URLs are resolved at runtime via `IFeedUrlProvider` (default: `ConfigurationFeedUrlProvider`, bound from `FeedOptions__Urls__N` app settings). If the provider returns an empty list, `OrchestrateAsync()` returns `null` immediately with no AI or sender invocation. Both AI capability providers are injected as nullable — `FeedOrchestrator` handles `null` text or image providers explicitly at the point of use.
+- **FeedOrchestrator**: executes a five-step pipeline to produce a social post from RSS news:
+  1. **Acquire feed content** — resolves URLs via `IFeedUrlProvider`, fetches RSS entries via `FeedService`, aggregates content from the last 24 hours.
+  2. **Generate summary** — calls `ITextToTextProvider.GetSummaryAsync()` with the aggregated content and the sender's `MessageMaxLength`.
+  3. **Apply tag replacements** — calls `ITagReplacementProvider.GetReplacements()` and replaces the first occurrence of each configured word with its hashtag equivalent (e.g. `bitcoin` → `#Bitcoin`). The replacement map is resolved from `TagReplacementOptions:Replacements` via `ConfigurationTagReplacementProvider` (registered as `Singleton`). An empty map is a valid configuration — the summary passes through unchanged.
+  4. **Generate image prompt** — calls `ITextToTextProvider.GetImagePromptAsync()` on the tagged summary; falls back to using the summary directly if the prompt is empty.
+  5. **Generate image** — calls `ITextToImageProvider.GenerateImageAsync()` with the prompt; returns the post without an image if the provider is `null`, returns empty bytes, or throws.
+
+  Both `IFeedUrlProvider` and `ITagReplacementProvider` follow the same provider pattern: registered as `Singleton`, bound from app settings, swappable via DI without touching orchestrator logic. If `IFeedUrlProvider` returns an empty list, `OrchestrateAsync()` returns `null` immediately with no AI or sender invocation. Both AI capability providers are injected as nullable — `FeedOrchestrator` handles `null` text or image providers explicitly at the point of use.
+
 - **PowerLawOrchestrator**: constructs posts based on the Bitcoin Power Law model (`value = 10⁻¹⁷ × days^5.83`, where `days` is elapsed since the Bitcoin genesis block on 2009-01-03). It consumes `CryptoService` to fetch the live BTC price and compares it against the model's fair-value estimate. It has no dependency on AI providers.
 - **NoOrchestrator**: a null-object implementation that returns `null` immediately, allowing the factory to represent "no posting" without null-checks in `XFunction`.
 
@@ -112,6 +121,7 @@ Services are registered as singletons or transients in the DI container and are 
 - **AiServiceHelper**: a shared utility class used internally by AI service implementations. It encapsulates HTTP response parsing logic and rate-limit (HTTP 429) handling, keeping individual service classes focused on their provider-specific contracts.
 - **FeedService**: RSS parser with in-memory caching (24-hour TTL) and keyword/date filtering. Uses the named `"Feed"` `HttpClient` created via `IHttpClientFactory`, backed by a Polly standard resilience pipeline (retry, circuit breaker, attempt timeout). This aligns `FeedService` with all other HTTP-consuming services in the codebase and eliminates the per-invocation socket allocation that `new HttpClient()` would cause on Azure Functions.
 - **ConfigurationFeedUrlProvider** (`IFeedUrlProvider`): resolves the list of RSS feed URLs consumed by `FeedOrchestrator` from the `FeedOptions` configuration section (bound via `FeedOptions__Urls__N` double-underscore notation). Registered as `Singleton`. To load URLs from a different source (database, Key Vault, remote config), implement `IFeedUrlProvider` and register the new implementation in `Program.cs` in place of `ConfigurationFeedUrlProvider`.
+- **ConfigurationTagReplacementProvider** (`ITagReplacementProvider`): resolves the word-to-hashtag replacement map consumed by `FeedOrchestrator` from the `TagReplacementOptions:Replacements` configuration section (bound via `TagReplacementOptions__Replacements__<word>` double-underscore notation). Registered as `Singleton`. Matching is case-insensitive; only the first occurrence of each word per post is replaced. An empty or absent section is valid — the summary passes through unchanged. To source replacements from a different store (database, remote config), implement `ITagReplacementProvider` and swap the registration in `Program.cs`.
 - **CryptoService**: thin HTTP client that polls `cryptoprices.cc` to retrieve the current market price for a given cryptocurrency symbol. Returns `0` on failure to allow graceful degradation in orchestrators.
 
 **AI Provider Services** — registered as **keyed services** by `AiProvider` via `AddXPosterAiProviders()` in `Program.cs`:
@@ -272,6 +282,7 @@ sequenceDiagram
     participant T2T as ITextToTextProvider<br/>(resolved by AiProvider)
     participant T2I as ITextToImageProvider<br/>(resolved by AiProvider)
     participant FeedUrl as IFeedUrlProvider
+    participant TagRepl as ITagReplacementProvider
     participant Feed as FeedService<br/>(RSS + IHttpClientFactory)
     participant Crypto as CryptoService<br/>(cryptoprices.cc)
     participant Sender as ISender<br/>(X / LinkedIn / Instagram)
@@ -299,17 +310,27 @@ sequenceDiagram
 
     Fn->>Orch: OrchestrateAsync()
 
-    alt FeedOrchestrator
+    alt FeedOrchestrator — 5-step pipeline
+        Note over Orch,TagRepl: Step 1 — Acquire feed content
         Orch->>FeedUrl: GetFeedUrls()
         FeedUrl-->>Orch: IReadOnlyList<string>
-        Orch->>Feed: GetLatestItemAsync(url)
-        Feed-->>Orch: FeedItem (title, url, content)
+        Orch->>TagRepl: GetReplacements() (keys used as feed keywords)
+        TagRepl-->>Orch: IReadOnlyDictionary<string,string>
+        Orch->>Feed: GetFeedsAsync(url, start, end, keywords)
+        Feed-->>Orch: List<RSSFeed>
+        Note over Orch,T2T: Step 2 — Generate summary
         Orch->>T2T: GetSummaryAsync(content, maxLength)
         T2T-->>Orch: summary text
-        Orch->>T2T: GetImagePromptAsync(title)
-        T2T-->>Orch: image prompt
+        Note over Orch,TagRepl: Step 3 — Apply tag replacements
+        Orch->>TagRepl: GetReplacements()
+        TagRepl-->>Orch: IReadOnlyDictionary<string,string>
+        Orch->>Orch: ApplyTagReplacements(summary)
+        Note over Orch,T2T: Step 4 — Generate image prompt
+        Orch->>T2T: GetImagePromptAsync(taggedSummary)
+        T2T-->>Orch: image prompt (falls back to summary if empty)
+        Note over Orch,T2I: Step 5 — Generate image
         Orch->>T2I: GenerateImageAsync(prompt)
-        T2I-->>Orch: image bytes
+        T2I-->>Orch: image bytes (null if provider absent or error)
     else PowerLawOrchestrator
         Orch->>Crypto: GetPriceAsync(symbol)
         Crypto-->>Orch: current price

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,14 @@ The file below mirrors [`src/local.settings.json.example`](../src/local.settings
     "FeedOptions__CircuitBreakerSamplingDurationSeconds": "30",
     "FeedOptions__CircuitBreakerBreakDurationSeconds": "15",
 
+    // ── Tag Replacements ─────────────────────────────────────────
+    // Optional. Maps plain words in the AI summary to hashtag equivalents.
+    // FeedOrchestrator replaces the first occurrence of each key (case-insensitive).
+    // An absent or empty section is valid — summaries pass through unchanged.
+    "TagReplacementOptions__Replacements__bitcoin": "#Bitcoin",
+    "TagReplacementOptions__Replacements__btc": "#BTC",
+    // Add further entries as TagReplacementOptions__Replacements__<word>.
+
     // ── AI Provider Selector ──────────────────────────────────────────
     "AiProvider": "OpenAi",
 
@@ -226,6 +234,34 @@ All five resilience settings are optional. When omitted the values shown in the 
 | `FeedOptions__CircuitBreakerBreakDurationSeconds` | int | No | `15` | Duration in seconds the circuit stays open before allowing a single probe request. |
 
 > **Tuning guidance:** For feeds served by CDNs or well-maintained public endpoints the defaults are appropriate. For slow or unreliable internal feeds, increase `AttemptTimeoutSeconds` and reduce `RetryCount` to avoid long tail latencies. For high-frequency schedules where a broken feed should not block the pipeline, lower `CircuitBreakerFailureThreshold` to trip the breaker faster.
+
+---
+
+## Tag Replacements
+
+`FeedOrchestrator` applies a word-to-hashtag replacement pass on the AI-generated summary before producing the image prompt (Step 3 of the pipeline). Replacements are resolved at runtime by `ITagReplacementProvider`. The default implementation, `ConfigurationTagReplacementProvider`, reads from the `TagReplacementOptions:Replacements` section bound via double-underscore notation.
+
+**Matching rules:**
+- Only the **first occurrence** of each configured word per post is replaced.
+- Matching is **case-insensitive** — the key `bitcoin` matches `Bitcoin`, `BITCOIN`, etc.
+- The replacement value is used verbatim (e.g. `#Bitcoin` preserves the casing you configure).
+- Keys from this map are also passed as keywords to `FeedService.GetFeedsAsync()` to pre-filter feed items that mention the configured topics.
+
+| Variable | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `TagReplacementOptions__Replacements__<word>` | string | No | — | Maps `<word>` to its hashtag replacement. E.g. `TagReplacementOptions__Replacements__bitcoin` = `#Bitcoin`. |
+
+**Example — Azure App Settings (flat key notation):**
+
+```
+TagReplacementOptions__Replacements__bitcoin   →   #Bitcoin
+TagReplacementOptions__Replacements__btc       →   #BTC
+TagReplacementOptions__Replacements__fed       →   #FED
+```
+
+**Behaviour with an empty or absent section:** `ConfigurationTagReplacementProvider` returns an empty `IReadOnlyDictionary<string, string>`. `FeedOrchestrator` applies no replacements and passes the summary through unchanged. This is a valid configuration — no warning is emitted.
+
+**Extending the provider:** to source replacements from a different store (database, remote config, Key Vault), implement `ITagReplacementProvider` and register the new implementation in `Program.cs` in place of `ConfigurationTagReplacementProvider`.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -300,7 +300,7 @@ The following combinations will cause `FeedOrchestrator` to surface an explicit 
 All sender OAuth credentials (Twitter/X, LinkedIn, Instagram) are loaded from Azure Key Vault **at application startup** via the [Azure Key Vault Configuration Provider](https://learn.microsoft.com/en-us/azure/key-vault/general/key-vault-integrate-kubernetes) registered in `Program.cs` (`builder.Configuration.AddAzureKeyVault(...)`). Secrets are merged into `IConfiguration` and injected into senders through standard `IOptions` / `IConfiguration` binding — no runtime Key Vault calls occur during post publishing.
 
 | Variable | Type | Required | Description |
-|---|---|---|
+|---|---|---|---|
 | `KEYVAULT_URI` | string | ✅ Yes | Full URI of the Azure Key Vault instance, e.g. `https://<vault-name>.vault.azure.net/`. |
 
 ### Authentication

--- a/docs/extending-xposter.md
+++ b/docs/extending-xposter.md
@@ -1,6 +1,6 @@
 # Extending XPoster
 
-XPoster is designed around four extension points: **Senders** (platform plugins), **Orchestrators** (content strategies), **AI Providers** (model integrations), and **Tag Replacement Providers** (hashtag mapping sources). Each maps to a dedicated abstraction and can be implemented without modifying any existing component.
+XPoster is designed around five extension points: **Senders** (platform plugins), **Orchestrators** (content strategies), **AI Providers** (model integrations), **Feed URL Providers** (RSS/Atom feed sources), and **Tag Replacement Providers** (hashtag mapping sources). Each maps to a dedicated abstraction and can be implemented without modifying any existing component.
 
 > For the architectural rationale behind each extension point, see [architecture.md §5](architecture.md#5-extension-points).
 
@@ -412,6 +412,75 @@ Key rules for this file:
 
 ---
 
+## Adding a New Feed URL Provider
+
+The feed URL provider supplies the list of RSS/Atom URLs that `FeedService` fetches on every timer-trigger execution. The default implementation, `ConfigurationFeedUrlProvider`, reads from the `FeedOptions:Urls` list in app settings. If you need to source URLs from a different store — a database, a remote API, Azure App Configuration, or a feature-flag service — implement `IFeedUrlProvider` and swap the registration in `Program.cs`.
+
+### Contract
+
+```csharp
+// src/Contracts/IFeedUrlProvider.cs
+public interface IFeedUrlProvider
+{
+    IReadOnlyList<string> GetUrls();
+}
+```
+
+`GetUrls()` must:
+- Return an `IReadOnlyList<string>` of absolute RSS/Atom feed URLs.
+- Return an **empty list** — never `null` — when no URLs are configured. `FeedOrchestrator` treats an empty list as a valid no-op and emits a `LogWarning` without calling any AI provider.
+- Be **synchronous and cheap**. `FeedService` calls `GetUrls()` once per execution, before issuing any HTTP request. Load data at construction time or cache it; do not make blocking I/O calls inside `GetUrls()`.
+
+### Step 1 — Implement IFeedUrlProvider
+
+```csharp
+// src/Services/DatabaseFeedUrlProvider.cs
+using XPoster.Contracts;
+
+namespace XPoster.Services;
+
+/// <summary>
+/// Loads RSS/Atom feed URLs from a remote database, refreshed at startup.
+/// </summary>
+public class DatabaseFeedUrlProvider : IFeedUrlProvider
+{
+    private readonly IReadOnlyList<string> _urls;
+
+    public DatabaseFeedUrlProvider(IMyDatabaseClient db)
+    {
+        // Load once at construction time; FeedService calls GetUrls() synchronously.
+        _urls = db.FetchFeedUrls().ToList().AsReadOnly();
+    }
+
+    public IReadOnlyList<string> GetUrls() => _urls;
+}
+```
+
+> If your URL source changes frequently and must be refreshed between executions, wrap the load in a cached background service and inject the cache here rather than fetching inside `GetUrls()`. The synchronous contract of the interface must be respected — `FeedService` does not `await` this call.
+
+### Step 2 — Register in DI
+
+Replace the existing `ConfigurationFeedUrlProvider` registration in `Program.cs` with your implementation. Keep the lifetime as `Singleton` — `FeedService` is resolved per-trigger and `GetUrls()` must be cheap.
+
+```csharp
+// src/Program.cs
+// Remove or comment out:
+// builder.Services.AddSingleton<IFeedUrlProvider, ConfigurationFeedUrlProvider>();
+
+// Add your implementation:
+builder.Services.AddSingleton<IFeedUrlProvider, DatabaseFeedUrlProvider>();
+```
+
+No other change is required. `FeedService` and `FeedOrchestrator` depend only on `IFeedUrlProvider` — they are unaware of the concrete implementation.
+
+### Step 3 — Remove the `FeedOptions__Urls__*` configuration keys (optional)
+
+If your new provider does not use `FeedOptions`, you can remove the `FeedOptions__Urls__*` keys from `local.settings.json` and Azure App Settings. The `ConfigurationFeedUrlProvider` binding will no longer be active.
+
+> The `FeedOptions` resilience keys (`AttemptTimeoutSeconds`, `RetryCount`, etc.) are consumed by the HTTP client pipeline registered in `HttpClientExtensions`, **not** by `ConfigurationFeedUrlProvider`. Removing the URL keys does not affect HTTP resilience configuration.
+
+---
+
 ## Adding a New Tag Replacement Provider
 
 The tag replacement provider resolves the word-to-hashtag map consumed by `FeedOrchestrator` at Step 3 of its pipeline. The default implementation, `ConfigurationTagReplacementProvider`, reads the map from `TagReplacementOptions:Replacements` in app settings. If you need to source replacements from a different store — a database, a remote API, Azure App Configuration, or Key Vault — implement `ITagReplacementProvider` and swap the registration in `Program.cs`.
@@ -496,10 +565,11 @@ All extensions must respect the following invariants to integrate correctly with
 - **Orchestrators must implement `SupportedPlatforms`.** The property must include every `SenderPlatform` value the orchestrator has been validated against, and always include `SenderPlatform.DryRun`. `NoOrchestrator` is the only valid exception (empty list).
 - **Orchestrators must be idempotent where possible.** Avoid side effects beyond returning a `Post`. In particular, do not call `ISender.SendAsync` from inside an orchestrator — that responsibility belongs to `XFunction`.
 - **Orchestrators must handle null capability providers explicitly.** `ITextToTextProvider?` and `ITextToImageProvider?` are injected as nullable. Check before use and degrade gracefully: return a text-only post when `imageProvider` is null, return `null` early when `textProvider` is null and text generation is required.
-- **AI provider services must implement only the capability interfaces they actually support.** Do not implement `ITextToImageProvider` on a text-only provider as a no-op or a `NotSupportedException` stub — leave the interface unimplemented and omit the keyed DI registration. The `null`-resolution contract is the canonical signal for “capability not available”.
+- **AI provider services must implement only the capability interfaces they actually support.** Do not implement `ITextToImageProvider` on a text-only provider as a no-op or a `NotSupportedException` stub — leave the interface unimplemented and omit the keyed DI registration. The `null`-resolution contract is the canonical signal for "capability not available".
 - **Keyed AI provider registrations live exclusively in `AddXPosterAiProviders()`.** Never add `AddKeyedTransient<ITextToTextProvider, ...>` or `AddKeyedTransient<ITextToImageProvider, ...>` calls outside that method.
 - **All external HTTP calls must go through `IHttpClientFactory`.** This ensures connection pooling, Polly resilience pipelines (retry, circuit breaker, attempt timeout), and consistent timeout configuration across the entire codebase. All services — including `FeedService` (named client `"Feed"`, registered in `HttpClientExtensions`) — conform to this constraint. Creating `new HttpClient()` inline is prohibited.
 - **Every new sender must include a `*CredentialsExtensions.cs` file** in `src/Credentials/`, declaring `SectionName` on the credentials DTO and the `Add*Credentials(IServiceCollection, IConfiguration)` extension method. `Program.cs` must use only the extension method — never raw `Configure<T>` + `GetSection("...")` literals for sender credentials.
 - **Every new AI provider must include an `*OptionsExtensions.cs` file** in its `src/Models/<ProviderName>/` folder, declaring `SectionName` and the `Add*Options(IServiceCollection, IConfiguration)` extension method. `Program.cs` must use only the extension method — never raw `Configure<T>` + `GetSection("...")` literals for AI provider options.
+- **`IFeedUrlProvider` must return an empty list — never `null`.** `FeedService` iterates the result directly; returning `null` causes a `NullReferenceException` at runtime.
 - **`ITagReplacementProvider` must return an empty dictionary — never `null`.** `FeedOrchestrator` iterates the result directly without a null-guard; returning `null` causes a `NullReferenceException` at runtime.
 - See [architecture.md](architecture.md) for full ADRs and design pattern rationale.

--- a/docs/extending-xposter.md
+++ b/docs/extending-xposter.md
@@ -1,6 +1,6 @@
 # Extending XPoster
 
-XPoster is designed around three extension points: **Senders** (platform plugins), **Orchestrators** (content strategies), and **AI Providers** (model integrations). Each maps to a dedicated abstraction and can be implemented without modifying any existing component.
+XPoster is designed around four extension points: **Senders** (platform plugins), **Orchestrators** (content strategies), **AI Providers** (model integrations), and **Tag Replacement Providers** (hashtag mapping sources). Each maps to a dedicated abstraction and can be implemented without modifying any existing component.
 
 > For the architectural rationale behind each extension point, see [architecture.md §5](architecture.md#5-extension-points).
 
@@ -412,6 +412,79 @@ Key rules for this file:
 
 ---
 
+## Adding a New Tag Replacement Provider
+
+The tag replacement provider resolves the word-to-hashtag map consumed by `FeedOrchestrator` at Step 3 of its pipeline. The default implementation, `ConfigurationTagReplacementProvider`, reads the map from `TagReplacementOptions:Replacements` in app settings. If you need to source replacements from a different store — a database, a remote API, Azure App Configuration, or Key Vault — implement `ITagReplacementProvider` and swap the registration in `Program.cs`.
+
+### Contract
+
+```csharp
+// src/Contracts/ITagReplacementProvider.cs
+public interface ITagReplacementProvider
+{
+    IReadOnlyDictionary<string, string> GetReplacements();
+}
+```
+
+`GetReplacements()` must:
+- Return an `IReadOnlyDictionary<string, string>` mapping plain words (keys) to their hashtag replacements (values).
+- Return an **empty dictionary** — never `null` — when no replacements are configured. `FeedOrchestrator` treats an empty map as a valid no-op.
+- Be **synchronous and cheap**. `FeedOrchestrator` calls it twice per execution (once for feed keyword filtering, once for post-summary replacement). Load data at construction time or cache it; do not make blocking HTTP calls inside `GetReplacements()`.
+
+### Step 1 — Implement ITagReplacementProvider
+
+```csharp
+// src/Orchestrators/DatabaseTagReplacementProvider.cs
+using XPoster.Contracts;
+
+namespace XPoster.Orchestrators;
+
+/// <summary>
+/// Loads word-to-hashtag replacements from a remote database, refreshed at startup.
+/// </summary>
+public class DatabaseTagReplacementProvider : ITagReplacementProvider
+{
+    private readonly IReadOnlyDictionary<string, string> _replacements;
+
+    public DatabaseTagReplacementProvider(IMyDatabaseClient db)
+    {
+        // Load once at construction; FeedOrchestrator calls GetReplacements() synchronously.
+        var rows = db.FetchReplacements();
+        _replacements = rows.ToDictionary(
+            r => r.Word,
+            r => r.Hashtag,
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    public IReadOnlyDictionary<string, string> GetReplacements() => _replacements;
+}
+```
+
+> Use `StringComparer.OrdinalIgnoreCase` on the dictionary to honour the case-insensitive matching contract. `FeedOrchestrator.ReplaceEveryFirstOccurrenceOf()` performs its own case-insensitive scan, but a case-insensitive dictionary prevents duplicate keys with different casing from causing silent overrides.
+
+### Step 2 — Register in DI
+
+Replace the existing `ConfigurationTagReplacementProvider` registration in `Program.cs` with your implementation. The registration must remain `Singleton` — `FeedOrchestrator` is resolved per-trigger and expects the provider to be cheap to call.
+
+```csharp
+// src/Program.cs
+// Remove or comment out:
+// builder.Services.AddSingleton<ITagReplacementProvider, ConfigurationTagReplacementProvider>();
+
+// Add your implementation:
+builder.Services.AddSingleton<ITagReplacementProvider, DatabaseTagReplacementProvider>();
+```
+
+No other change is required. `FeedOrchestrator` depends only on `ITagReplacementProvider` — it is unaware of the concrete implementation.
+
+### Step 3 — Remove the `TagReplacementOptions` configuration keys (optional)
+
+If your new provider does not use `TagReplacementOptions`, you can remove the `TagReplacementOptions__Replacements__*` keys from `local.settings.json` and Azure App Settings. The `ConfigurationTagReplacementProvider` binding will no longer be active.
+
+> If you keep the configuration keys but switch to a different provider, the bound `TagReplacementOptions` values are simply ignored — no error is raised.
+
+---
+
 ## Design Constraints
 
 All extensions must respect the following invariants to integrate correctly with the pipeline:
@@ -423,9 +496,10 @@ All extensions must respect the following invariants to integrate correctly with
 - **Orchestrators must implement `SupportedPlatforms`.** The property must include every `SenderPlatform` value the orchestrator has been validated against, and always include `SenderPlatform.DryRun`. `NoOrchestrator` is the only valid exception (empty list).
 - **Orchestrators must be idempotent where possible.** Avoid side effects beyond returning a `Post`. In particular, do not call `ISender.SendAsync` from inside an orchestrator — that responsibility belongs to `XFunction`.
 - **Orchestrators must handle null capability providers explicitly.** `ITextToTextProvider?` and `ITextToImageProvider?` are injected as nullable. Check before use and degrade gracefully: return a text-only post when `imageProvider` is null, return `null` early when `textProvider` is null and text generation is required.
-- **AI provider services must implement only the capability interfaces they actually support.** Do not implement `ITextToImageProvider` on a text-only provider as a no-op or a `NotSupportedException` stub — leave the interface unimplemented and omit the keyed DI registration. The `null`-resolution contract is the canonical signal for "capability not available".
+- **AI provider services must implement only the capability interfaces they actually support.** Do not implement `ITextToImageProvider` on a text-only provider as a no-op or a `NotSupportedException` stub — leave the interface unimplemented and omit the keyed DI registration. The `null`-resolution contract is the canonical signal for “capability not available”.
 - **Keyed AI provider registrations live exclusively in `AddXPosterAiProviders()`.** Never add `AddKeyedTransient<ITextToTextProvider, ...>` or `AddKeyedTransient<ITextToImageProvider, ...>` calls outside that method.
 - **All external HTTP calls must go through `IHttpClientFactory`.** This ensures connection pooling, Polly resilience pipelines (retry, circuit breaker, attempt timeout), and consistent timeout configuration across the entire codebase. All services — including `FeedService` (named client `"Feed"`, registered in `HttpClientExtensions`) — conform to this constraint. Creating `new HttpClient()` inline is prohibited.
 - **Every new sender must include a `*CredentialsExtensions.cs` file** in `src/Credentials/`, declaring `SectionName` on the credentials DTO and the `Add*Credentials(IServiceCollection, IConfiguration)` extension method. `Program.cs` must use only the extension method — never raw `Configure<T>` + `GetSection("...")` literals for sender credentials.
 - **Every new AI provider must include an `*OptionsExtensions.cs` file** in its `src/Models/<ProviderName>/` folder, declaring `SectionName` and the `Add*Options(IServiceCollection, IConfiguration)` extension method. `Program.cs` must use only the extension method — never raw `Configure<T>` + `GetSection("...")` literals for AI provider options.
+- **`ITagReplacementProvider` must return an empty dictionary — never `null`.** `FeedOrchestrator` iterates the result directly without a null-guard; returning `null` causes a `NullReferenceException` at runtime.
 - See [architecture.md](architecture.md) for full ADRs and design pattern rationale.

--- a/src/Contracts/ITagReplacementProvider.cs
+++ b/src/Contracts/ITagReplacementProvider.cs
@@ -1,0 +1,18 @@
+namespace XPoster.Contracts;
+
+/// <summary>
+/// Provides the word-to-hashtag replacement map applied to generated summaries.
+/// </summary>
+/// <remarks>
+/// Decouples tag-replacement configuration from <see cref="XPoster.Orchestrators.FeedOrchestrator"/>,
+/// following the same pattern as <see cref="IFeedUrlProvider"/>.
+/// Swap implementations via DI without touching orchestrator logic.
+/// </remarks>
+public interface ITagReplacementProvider
+{
+    /// <summary>
+    /// Returns the replacement dictionary mapping plain words to their hashtag equivalents
+    /// (e.g. <c>"bitcoin"</c> → <c>"#Bitcoin"</c>).
+    /// </summary>
+    IReadOnlyDictionary<string, string> GetReplacements();
+}

--- a/src/Models/TagReplacementOptions.cs
+++ b/src/Models/TagReplacementOptions.cs
@@ -1,0 +1,20 @@
+namespace XPoster.Models;
+
+/// <summary>
+/// Configuration model for the word-to-hashtag replacement map consumed by
+/// <see cref="XPoster.Orchestrators.ConfigurationTagReplacementProvider"/>.
+/// Bind from the <c>TagReplacementOptions</c> section in app settings.
+/// </summary>
+public sealed class TagReplacementOptions
+{
+    /// <summary>App-settings section name: <c>TagReplacementOptions</c>.</summary>
+    public const string SectionName = "TagReplacementOptions";
+
+    /// <summary>
+    /// Dictionary mapping plain words to their hashtag replacements
+    /// (e.g. <c>"bitcoin"</c> → <c>"#Bitcoin"</c>).
+    /// Matching is case-insensitive at application time.
+    /// Defaults to an empty dictionary when the section is absent.
+    /// </summary>
+    public Dictionary<string, string> Replacements { get; set; } = new();
+}

--- a/src/Orchestrators/ConfigurationTagReplacementProvider.cs
+++ b/src/Orchestrators/ConfigurationTagReplacementProvider.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Options;
+using XPoster.Contracts;
+using XPoster.Models;
+
+namespace XPoster.Orchestrators;
+
+/// <summary>
+/// Returns the word-to-hashtag replacement map from the static app-settings
+/// section <c>TagReplacementOptions:Replacements</c>.
+/// </summary>
+/// <remarks>
+/// This is the default <see cref="ITagReplacementProvider"/> implementation.
+/// Registered as <c>Singleton</c>; the underlying <see cref="TagReplacementOptions"/> is bound
+/// via <see cref="IOptions{TOptions}"/> at startup.
+/// </remarks>
+public sealed class ConfigurationTagReplacementProvider : ITagReplacementProvider
+{
+    private readonly IReadOnlyDictionary<string, string> _replacements;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="ConfigurationTagReplacementProvider"/>.
+    /// </summary>
+    /// <param name="options">Bound <see cref="TagReplacementOptions"/> from app settings.</param>
+    public ConfigurationTagReplacementProvider(IOptions<TagReplacementOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _replacements = options.Value.Replacements ?? new Dictionary<string, string>();
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyDictionary<string, string> GetReplacements() => _replacements;
+}

--- a/src/Orchestrators/FeedOrchestrator.cs
+++ b/src/Orchestrators/FeedOrchestrator.cs
@@ -14,12 +14,10 @@ public class FeedOrchestrator : BaseOrchestrator
 {
     private readonly IFeedService _feedService;
     private readonly IFeedUrlProvider _feedUrlProvider;
+    private readonly ITagReplacementProvider _tagReplacementProvider;
     private readonly ITextToTextProvider? _textProvider;
     private readonly ITextToImageProvider? _imageProvider;
     private bool _sendIt = true;
-
-    /// <summary>Word-to-hashtag replacement map applied to the generated summary.</summary>
-    private Dictionary<string, string> _replacements = new Dictionary<string, string> { { "bitcoin", "#Bitcoin" }, { "btc", "#BTC" }, { "blockchain", "#Blockchain" }, { "fed", "#FED" } };
 
     /// <inheritdoc/>
     public override string Name => typeof(FeedOrchestrator).Name;
@@ -43,20 +41,28 @@ public class FeedOrchestrator : BaseOrchestrator
         ILogger<FeedOrchestrator> logger,
         IFeedService feedService,
         IFeedUrlProvider feedUrlProvider,
+        ITagReplacementProvider tagReplacementProvider,
         ITextToTextProvider? textProvider,
         ITextToImageProvider? imageProvider)
         : base(sender, logger)
     {
         _feedService = feedService;
         _feedUrlProvider = feedUrlProvider;
+        _tagReplacementProvider = tagReplacementProvider;
         _textProvider = textProvider;
         _imageProvider = imageProvider;
     }
 
     /// <summary>
-    /// Fetches recent RSS items, generates an AI summary, derives an image prompt,
-    /// and returns a <see cref="Post"/> ready for publishing.
-    /// Posting is disabled and <c>null</c> is returned if no relevant news is found or summarisation fails.
+    /// Executes the five-step content production pipeline:
+    /// <list type="number">
+    ///   <item>Acquire feed content from the configured URLs.</item>
+    ///   <item>Generate a summary via the text provider.</item>
+    ///   <item>Apply word-to-hashtag tag replacements via the tag replacement provider.</item>
+    ///   <item>Generate an image prompt via the text provider.</item>
+    ///   <item>Generate the image via the image provider.</item>
+    /// </list>
+    /// Posting is disabled and <c>null</c> is returned if any mandatory step fails.
     /// </summary>
     public override async Task<Post?> OrchestrateAsync()
     {
@@ -67,43 +73,26 @@ public class FeedOrchestrator : BaseOrchestrator
             return null;
         }
 
-        var summary = await GenerateMessage();
-        if (string.IsNullOrWhiteSpace(summary))
+        // Step 1 – Acquire feed content
+        var feedContent = await AcquireFeedContentAsync();
+        if (string.IsNullOrWhiteSpace(feedContent))
         {
-            _logger.LogInformation("No summary generated");
-            SendIt = false;
             return null;
         }
 
-        byte[]? image = null;
-
-        if (_imageProvider == null)
+        // Step 2 – Generate summary
+        var summary = await GenerateSummaryAsync(feedContent);
+        if (string.IsNullOrWhiteSpace(summary))
         {
-            _logger.LogWarning("No ITextToImageProvider configured for this slot. Post will be published without image.");
+            return null;
         }
-        else
-        {
-            var prompt4Image = await _textProvider.GetImagePromptAsync(summary);
-            if (string.IsNullOrWhiteSpace(prompt4Image))
-            {
-                _logger.LogError("Unable to get image prompt from text provider. Falling back to summary as prompt.");
-                prompt4Image = summary;
-            }
 
-            try
-            {
-                image = await _imageProvider.GenerateImageAsync(prompt4Image);
-                if (image == null || image.Length == 0)
-                {
-                    _logger.LogWarning("Image generation returned empty result for prompt: {Prompt}. Post will be published without image.", prompt4Image);
-                    image = null;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Exception occurred while generating image with prompt: {Prompt}. Post will be published without image.", prompt4Image);
-            }
-        }
+        // Step 3 – Apply tag replacements
+        summary = ApplyTagReplacements(summary);
+
+        // Step 4 – Generate image prompt
+        // Step 5 – Generate image
+        var image = await GenerateImageAsync(summary);
 
         return new Post
         {
@@ -112,11 +101,8 @@ public class FeedOrchestrator : BaseOrchestrator
         };
     }
 
-    private async Task<string> GenerateMessage()
+    private async Task<string> AcquireFeedContentAsync()
     {
-        var end = DateTimeOffset.UtcNow;
-        var start = end.AddDays(-1);
-
         var feedUrls = _feedUrlProvider.GetFeedUrls();
 
         if (feedUrls.Count == 0)
@@ -126,10 +112,14 @@ public class FeedOrchestrator : BaseOrchestrator
             return string.Empty;
         }
 
+        var end = DateTimeOffset.UtcNow;
+        var start = end.AddDays(-1);
+        var keywords = _tagReplacementProvider.GetReplacements().Keys;
+
         var allFeeds = new List<RSSFeed>();
         foreach (string url in feedUrls)
         {
-            var feeds = await _feedService.GetFeedsAsync(url, start, end, _replacements.Keys);
+            var feeds = await _feedService.GetFeedsAsync(url, start, end, keywords);
             if (feeds != null && feeds.Any())
             {
                 allFeeds.AddRange(feeds);
@@ -138,11 +128,18 @@ public class FeedOrchestrator : BaseOrchestrator
 
         if (!allFeeds.Any())
         {
-            _logger.LogInformation("No feeds found");
+            _logger.LogInformation("No feeds found in the last 24 hours.");
             SendIt = false;
             return string.Empty;
         }
 
+        return allFeeds
+            .Select(f => f.Content)
+            .Aggregate(string.Empty, (current, next) => current + "\n" + next);
+    }
+
+    private async Task<string> GenerateSummaryAsync(string feedContent)
+    {
         if (_sender == null)
         {
             _logger.LogError("No sender configured for FeedOrchestrator.");
@@ -150,7 +147,6 @@ public class FeedOrchestrator : BaseOrchestrator
             return string.Empty;
         }
 
-        string feedContent = allFeeds.Select(f => f.Content).Aggregate(string.Empty, (current, next) => current + "\n" + next);
         var summary = await _textProvider!.GetSummaryAsync(feedContent, _sender.MessageMaxLenght);
         if (string.IsNullOrWhiteSpace(summary))
         {
@@ -160,26 +156,60 @@ public class FeedOrchestrator : BaseOrchestrator
         }
 
         _logger.LogInformation("Generated summary: {Summary}", summary);
-        summary = ReplaceEveryFirstOccurenceOf(summary, _replacements);
         return summary;
     }
 
-    private string ReplaceEveryFirstOccurenceOf(string text, Dictionary<string, string> replacements)
+    private string ApplyTagReplacements(string text)
     {
+        var replacements = _tagReplacementProvider.GetReplacements();
+        if (replacements.Count == 0)
+        {
+            return text;
+        }
+
         var sb = new StringBuilder(text);
         foreach (var entry in replacements)
         {
-            string key = entry.Key;
-            string value = entry.Value;
-            string pattern = @"\b" + Regex.Escape(key) + @"\b";
+            string pattern = @"\b" + Regex.Escape(entry.Key) + @"\b";
             Match match = Regex.Match(sb.ToString(), pattern, RegexOptions.IgnoreCase);
             if (match.Success)
             {
-                int index = match.Index;
-                sb.Remove(index, key.Length);
-                sb.Insert(index, value);
+                sb.Remove(match.Index, entry.Key.Length);
+                sb.Insert(match.Index, entry.Value);
             }
         }
         return sb.ToString();
+    }
+
+    private async Task<byte[]?> GenerateImageAsync(string summary)
+    {
+        if (_imageProvider == null)
+        {
+            _logger.LogWarning("No ITextToImageProvider configured for this slot. Post will be published without image.");
+            return null;
+        }
+
+        var prompt = await _textProvider!.GetImagePromptAsync(summary);
+        if (string.IsNullOrWhiteSpace(prompt))
+        {
+            _logger.LogError("Unable to get image prompt from text provider. Falling back to summary as prompt.");
+            prompt = summary;
+        }
+
+        try
+        {
+            var image = await _imageProvider.GenerateImageAsync(prompt);
+            if (image == null || image.Length == 0)
+            {
+                _logger.LogWarning("Image generation returned empty result for prompt: {Prompt}. Post will be published without image.", prompt);
+                return null;
+            }
+            return image;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception occurred while generating image with prompt: {Prompt}. Post will be published without image.", prompt);
+            return null;
+        }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -110,6 +110,10 @@ builder.Services.AddTransient<IFeedService, FeedService>();
 builder.Services.Configure<FeedOptions>(builder.Configuration.GetSection(FeedOptions.SectionName));
 builder.Services.AddSingleton<IFeedUrlProvider, ConfigurationFeedUrlProvider>();
 
+// ITagReplacementProvider registration — reads TagReplacementOptions:Replacements from app settings.
+builder.Services.Configure<TagReplacementOptions>(builder.Configuration.GetSection(TagReplacementOptions.SectionName));
+builder.Services.AddSingleton<ITagReplacementProvider, ConfigurationTagReplacementProvider>();
+
 // AI provider options: each extension method owns its SectionName constant
 // and encapsulates Configure<T> + AddSingleton<IValidateOptions<T>> in one call.
 builder.Services.AddOpenAiOptions(builder.Configuration);

--- a/src/local.settings.json.example
+++ b/src/local.settings.json.example
@@ -140,6 +140,17 @@
     "FeedOptions__Urls__0": "https://cointelegraph.com/rss/tag/bitcoin",
     "FeedOptions__Urls__1": "https://www.coindesk.com/arc/outboundfeeds/rss",
 
+    // -----------------------------------------------------------------------
+    // Tag replacement provider — word-to-hashtag map applied to generated summaries.
+    // Uses flat Azure Functions naming convention: TagReplacementOptions__Replacements__<word>.
+    // Keys are matched case-insensitively; only the first occurrence per word is replaced.
+    // Add or remove entries freely without code changes or redeployment.
+    // -----------------------------------------------------------------------
+    "TagReplacementOptions__Replacements__bitcoin": "#Bitcoin",
+    "TagReplacementOptions__Replacements__btc": "#BTC",
+    "TagReplacementOptions__Replacements__blockchain": "#Blockchain",
+    "TagReplacementOptions__Replacements__fed": "#FED",
+
     "APPLICATIONINSIGHTS_CONNECTION_STRING": ""
   }
 }

--- a/tests/Orchestrators/ConfigurationTagReplacementProviderTests.cs
+++ b/tests/Orchestrators/ConfigurationTagReplacementProviderTests.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Options;
+using XPoster.Orchestrators;
+using XPoster.Models;
+
+namespace XPoster.Tests.Orchestrators;
+
+public class ConfigurationTagReplacementProviderTests
+{
+    // --- Happy path ---
+
+    [Fact]
+    public void GetReplacements_Should_ReturnConfiguredReplacements_When_OptionsContainsEntries()
+    {
+        // ARRANGE
+        var expected = new Dictionary<string, string>
+        {
+            { "bitcoin", "#Bitcoin" },
+            { "btc",     "#BTC" }
+        };
+        var options  = Options.Create(new TagReplacementOptions { Replacements = expected });
+        var provider = new ConfigurationTagReplacementProvider(options);
+
+        // ACT
+        var result = provider.GetReplacements();
+
+        // ASSERT
+        Assert.Equal(2, result.Count);
+        Assert.Equal("#Bitcoin", result["bitcoin"]);
+        Assert.Equal("#BTC",     result["btc"]);
+    }
+
+    [Fact]
+    public void GetReplacements_Should_PreserveAllEntries_When_MultipleReplacementsConfigured()
+    {
+        // ARRANGE
+        var replacements = new Dictionary<string, string>
+        {
+            { "bitcoin",    "#Bitcoin"    },
+            { "btc",        "#BTC"        },
+            { "blockchain", "#Blockchain" },
+            { "fed",        "#FED"        }
+        };
+        var options  = Options.Create(new TagReplacementOptions { Replacements = replacements });
+        var provider = new ConfigurationTagReplacementProvider(options);
+
+        // ACT
+        var result = provider.GetReplacements();
+
+        // ASSERT
+        Assert.Equal(4, result.Count);
+        foreach (var (key, value) in replacements)
+            Assert.Equal(value, result[key]);
+    }
+
+    // --- Edge cases ---
+
+    [Fact]
+    public void GetReplacements_Should_ReturnEmptyDictionary_When_ReplacementsPropertyIsNull()
+    {
+        // ARRANGE
+        var options  = Options.Create(new TagReplacementOptions { Replacements = null! });
+        var provider = new ConfigurationTagReplacementProvider(options);
+
+        // ACT
+        var result = provider.GetReplacements();
+
+        // ASSERT
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetReplacements_Should_ReturnEmptyDictionary_When_ReplacementsIsEmpty()
+    {
+        // ARRANGE
+        var options  = Options.Create(new TagReplacementOptions { Replacements = new Dictionary<string, string>() });
+        var provider = new ConfigurationTagReplacementProvider(options);
+
+        // ACT
+        var result = provider.GetReplacements();
+
+        // ASSERT
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Constructor_Should_Throw_When_OptionsIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new ConfigurationTagReplacementProvider(null!));
+    }
+
+    [Fact]
+    public void GetReplacements_Should_ReturnReadOnlyDictionary()
+    {
+        // ARRANGE
+        var options  = Options.Create(new TagReplacementOptions { Replacements = new Dictionary<string, string> { { "bitcoin", "#Bitcoin" } } });
+        var provider = new ConfigurationTagReplacementProvider(options);
+
+        // ACT
+        var result = provider.GetReplacements();
+
+        // ASSERT
+        Assert.IsAssignableFrom<IReadOnlyDictionary<string, string>>(result);
+    }
+}

--- a/tests/Orchestrators/FeedOrchestratorFeedUrlProviderTests.cs
+++ b/tests/Orchestrators/FeedOrchestratorFeedUrlProviderTests.cs
@@ -12,28 +12,33 @@ namespace XPoster.Tests.Orchestrators;
 /// </summary>
 public class FeedOrchestratorFeedUrlProviderTests
 {
-    private readonly Mock<ISender> _mockSender;
-    private readonly Mock<ILogger<FeedOrchestrator>> _mockLogger;
-    private readonly Mock<IFeedService> _mockFeedService;
-    private readonly Mock<IFeedUrlProvider> _mockFeedUrlProvider;
-    private readonly Mock<ITextToTextProvider> _mockTextProvider;
-    private readonly Mock<ITextToImageProvider> _mockImageProvider;
+    private readonly Mock<ISender>                     _mockSender;
+    private readonly Mock<ILogger<FeedOrchestrator>>   _mockLogger;
+    private readonly Mock<IFeedService>                _mockFeedService;
+    private readonly Mock<IFeedUrlProvider>            _mockFeedUrlProvider;
+    private readonly Mock<ITagReplacementProvider>     _mockTagReplacementProvider;
+    private readonly Mock<ITextToTextProvider>         _mockTextProvider;
+    private readonly Mock<ITextToImageProvider>        _mockImageProvider;
 
     public FeedOrchestratorFeedUrlProviderTests()
     {
-        _mockSender          = new Mock<ISender>();
-        _mockLogger          = new Mock<ILogger<FeedOrchestrator>>();
-        _mockFeedService     = new Mock<IFeedService>();
-        _mockFeedUrlProvider = new Mock<IFeedUrlProvider>();
-        _mockTextProvider    = new Mock<ITextToTextProvider>();
-        _mockImageProvider   = new Mock<ITextToImageProvider>();
+        _mockSender                 = new Mock<ISender>();
+        _mockLogger                 = new Mock<ILogger<FeedOrchestrator>>();
+        _mockFeedService            = new Mock<IFeedService>();
+        _mockFeedUrlProvider        = new Mock<IFeedUrlProvider>();
+        _mockTagReplacementProvider = new Mock<ITagReplacementProvider>();
+        _mockTextProvider           = new Mock<ITextToTextProvider>();
+        _mockImageProvider          = new Mock<ITextToImageProvider>();
 
         _mockSender.Setup(s => s.MessageMaxLenght).Returns(280);
+        _mockTagReplacementProvider.Setup(p => p.GetReplacements())
+            .Returns(new Dictionary<string, string>());
     }
 
     private FeedOrchestrator CreateOrchestrator() =>
         new(_mockSender.Object, _mockLogger.Object, _mockFeedService.Object,
-            _mockFeedUrlProvider.Object, _mockTextProvider.Object, _mockImageProvider.Object);
+            _mockFeedUrlProvider.Object, _mockTagReplacementProvider.Object,
+            _mockTextProvider.Object, _mockImageProvider.Object);
 
     [Fact]
     public async Task OrchestrateAsync_Should_CallGetFeedUrls_Once()

--- a/tests/Orchestrators/FeedOrchestratorTests.cs
+++ b/tests/Orchestrators/FeedOrchestratorTests.cs
@@ -8,12 +8,13 @@ namespace XPoster.Tests.Orchestrators;
 
 public class FeedOrchestratorTests
 {
-    private readonly Mock<ISender> _mockSender;
-    private readonly Mock<ILogger<FeedOrchestrator>> _mockLogger;
-    private readonly Mock<IFeedService> _mockFeedService;
-    private readonly Mock<IFeedUrlProvider> _mockFeedUrlProvider;
-    private readonly Mock<ITextToTextProvider> _mockTextProvider;
-    private readonly Mock<ITextToImageProvider> _mockImageProvider;
+    private readonly Mock<ISender>                     _mockSender;
+    private readonly Mock<ILogger<FeedOrchestrator>>   _mockLogger;
+    private readonly Mock<IFeedService>                _mockFeedService;
+    private readonly Mock<IFeedUrlProvider>            _mockFeedUrlProvider;
+    private readonly Mock<ITagReplacementProvider>     _mockTagReplacementProvider;
+    private readonly Mock<ITextToTextProvider>         _mockTextProvider;
+    private readonly Mock<ITextToImageProvider>        _mockImageProvider;
 
     private static readonly List<string> DefaultUrls =
     [
@@ -21,16 +22,26 @@ public class FeedOrchestratorTests
         "https://www.coindesk.com/arc/outboundfeeds/rss"
     ];
 
+    private static readonly Dictionary<string, string> DefaultReplacements = new()
+    {
+        { "bitcoin",    "#Bitcoin"    },
+        { "btc",        "#BTC"        },
+        { "fed",        "#FED"        }
+    };
+
     public FeedOrchestratorTests()
     {
-        _mockSender        = new Mock<ISender>();
-        _mockLogger        = new Mock<ILogger<FeedOrchestrator>>();
-        _mockFeedService   = new Mock<IFeedService>();
-        _mockFeedUrlProvider = new Mock<IFeedUrlProvider>();
-        _mockTextProvider  = new Mock<ITextToTextProvider>();
-        _mockImageProvider = new Mock<ITextToImageProvider>();
+        _mockSender                 = new Mock<ISender>();
+        _mockLogger                 = new Mock<ILogger<FeedOrchestrator>>();
+        _mockFeedService            = new Mock<IFeedService>();
+        _mockFeedUrlProvider        = new Mock<IFeedUrlProvider>();
+        _mockTagReplacementProvider = new Mock<ITagReplacementProvider>();
+        _mockTextProvider           = new Mock<ITextToTextProvider>();
+        _mockImageProvider          = new Mock<ITextToImageProvider>();
 
         _mockFeedUrlProvider.Setup(p => p.GetFeedUrls()).Returns(DefaultUrls);
+        _mockTagReplacementProvider.Setup(p => p.GetReplacements())
+            .Returns(DefaultReplacements);
     }
 
     /// <summary>
@@ -39,13 +50,18 @@ public class FeedOrchestratorTests
     /// </summary>
     private FeedOrchestrator CreateOrchestrator() =>
         new(_mockSender.Object, _mockLogger.Object, _mockFeedService.Object,
-            _mockFeedUrlProvider.Object, _mockTextProvider.Object, _mockImageProvider.Object);
+            _mockFeedUrlProvider.Object, _mockTagReplacementProvider.Object,
+            _mockTextProvider.Object, _mockImageProvider.Object);
+
+    // ---------------------------------------------------------------------------
+    // Happy path
+    // ---------------------------------------------------------------------------
 
     [Fact]
     public async Task OrchestrateAsync_Should_CreateMessageWithImage_WhenFeedsAreFound()
     {
         // ARRANGE
-        var fakeFeeds  = new List<RSSFeed> { new() { Title = "Il Bitcoin", Content = "Notizia su Bitcoin", Link = "https://bitcoin.org/" } };
+        var fakeFeeds   = new List<RSSFeed> { new() { Title = "Il Bitcoin", Content = "Notizia su Bitcoin", Link = "https://bitcoin.org/" } };
         var fakeSummary = "Questo è un riassunto";
         var fakePrompt  = "Prompt per immagine";
         var fakeImage   = new byte[] { 1, 2, 3 };
@@ -56,7 +72,7 @@ public class FeedOrchestratorTests
             .ReturnsAsync(fakeFeeds);
         _mockTextProvider.Setup(s => s.GetSummaryAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(fakeSummary);
-        _mockTextProvider.Setup(s => s.GetImagePromptAsync(fakeSummary, It.IsAny<CancellationToken>()))
+        _mockTextProvider.Setup(s => s.GetImagePromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(fakePrompt);
         _mockImageProvider.Setup(s => s.GenerateImageAsync(fakePrompt, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fakeImage);
@@ -76,20 +92,22 @@ public class FeedOrchestratorTests
             It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<string>>()),
             Times.Exactly(2));
         _mockTextProvider.Verify(s => s.GetSummaryAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
-        _mockTextProvider.Verify(s => s.GetImagePromptAsync(fakeSummary, It.IsAny<CancellationToken>()), Times.Once);
+        _mockTextProvider.Verify(s => s.GetImagePromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
         _mockImageProvider.Verify(s => s.GenerateImageAsync(fakePrompt, It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    // ---------------------------------------------------------------------------
+    // Step 1 — AcquireFeedContentAsync failure paths
+    // ---------------------------------------------------------------------------
 
     [Fact]
     public async Task OrchestrateAsync_Should_ReturnNull_When_NoFeedsFound()
     {
         // ARRANGE
-        var emptyFeeds = new List<RSSFeed>();
-
         _mockSender.Setup(s => s.MessageMaxLenght).Returns(280);
         _mockFeedService.Setup(s => s.GetFeedsAsync(
                 It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<string>>()))
-            .ReturnsAsync(emptyFeeds);
+            .ReturnsAsync(new List<RSSFeed>());
 
         var orchestrator = CreateOrchestrator();
 
@@ -102,6 +120,29 @@ public class FeedOrchestratorTests
         _mockTextProvider.Verify(s => s.GetSummaryAsync(
             It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
+
+    [Fact]
+    public async Task OrchestrateAsync_Should_ReturnNull_When_FeedUrlProviderReturnsEmptyList()
+    {
+        // ARRANGE
+        _mockFeedUrlProvider.Setup(p => p.GetFeedUrls()).Returns(new List<string>());
+
+        var orchestrator = CreateOrchestrator();
+
+        // ACT
+        var result = await orchestrator.OrchestrateAsync();
+
+        // ASSERT
+        Assert.Null(result);
+        Assert.False(orchestrator.SendIt);
+        _mockFeedService.Verify(s => s.GetFeedsAsync(
+            It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<string>>()),
+            Times.Never);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Step 2 — GenerateSummaryAsync failure paths
+    // ---------------------------------------------------------------------------
 
     [Fact]
     public async Task OrchestrateAsync_Should_ReturnNull_When_SummaryGenerationFails()
@@ -129,13 +170,16 @@ public class FeedOrchestratorTests
             It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    // ---------------------------------------------------------------------------
+    // Step 3 — ApplyTagReplacements
+    // ---------------------------------------------------------------------------
+
     [Fact]
-    public async Task OrchestrateAsync_Should_ReturnPostWithoutImage_When_ImageGenerationReturnsEmpty()
+    public async Task OrchestrateAsync_Should_CallTagReplacementProvider_ExactlyOnce_WhenOrchestrationSucceeds()
     {
         // ARRANGE
-        var fakeFeeds   = new List<RSSFeed> { new() { Title = "Il Bitcoin", Content = "Test", Link = "https://bitcoin.org/" } };
-        var fakeSummary = "Summary";
-        var fakePrompt  = "Prompt";
+        var fakeFeeds   = new List<RSSFeed> { new() { Title = "Bitcoin", Content = "Test", Link = "https://bitcoin.org/" } };
+        var fakeSummary = "Summary text";
 
         _mockSender.Setup(s => s.MessageMaxLenght).Returns(280);
         _mockFeedService.Setup(s => s.GetFeedsAsync(
@@ -144,90 +188,27 @@ public class FeedOrchestratorTests
         _mockTextProvider.Setup(s => s.GetSummaryAsync(
                 It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(fakeSummary);
-        _mockTextProvider.Setup(s => s.GetImagePromptAsync(fakeSummary, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(fakePrompt);
-        _mockImageProvider.Setup(s => s.GenerateImageAsync(fakePrompt, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<byte>());
+        _mockTextProvider.Setup(s => s.GetImagePromptAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("prompt");
+        _mockImageProvider.Setup(s => s.GenerateImageAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 1 });
 
         var orchestrator = CreateOrchestrator();
 
         // ACT
-        var result = await orchestrator.OrchestrateAsync();
+        await orchestrator.OrchestrateAsync();
 
-        // ASSERT
-        Assert.NotNull(result);
-        Assert.Equal(fakeSummary, result.Content);
-        Assert.Null(result.Image);
-        Assert.True(orchestrator.SendIt);
-    }
-
-    [Fact]
-    public async Task OrchestrateAsync_Should_ReturnPostWithoutImage_When_ImageGenerationThrowsException()
-    {
-        // ARRANGE
-        var fakeFeeds   = new List<RSSFeed> { new() { Title = "Il Bitcoin", Content = "Test", Link = "https://bitcoin.org/" } };
-        var fakeSummary = "Summary";
-        var fakePrompt  = "Prompt";
-
-        _mockSender.Setup(s => s.MessageMaxLenght).Returns(280);
-        _mockFeedService.Setup(s => s.GetFeedsAsync(
-                It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<string>>()))
-            .ReturnsAsync(fakeFeeds);
-        _mockTextProvider.Setup(s => s.GetSummaryAsync(
-                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(fakeSummary);
-        _mockTextProvider.Setup(s => s.GetImagePromptAsync(fakeSummary, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(fakePrompt);
-        _mockImageProvider.Setup(s => s.GenerateImageAsync(fakePrompt, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new Exception("Image generation failed"));
-
-        var orchestrator = CreateOrchestrator();
-
-        // ACT
-        var result = await orchestrator.OrchestrateAsync();
-
-        // ASSERT
-        Assert.NotNull(result);
-        Assert.Equal(fakeSummary, result.Content);
-        Assert.Null(result.Image);
-        Assert.True(orchestrator.SendIt);
-    }
-
-    [Fact]
-    public async Task OrchestrateAsync_Should_ReturnPostWithoutImage_When_ImageProviderIsNull()
-    {
-        // ARRANGE — slot uses a text-only provider (e.g. DeepSeek or Perplexity)
-        var fakeFeeds   = new List<RSSFeed> { new() { Title = "Il Bitcoin", Content = "Test", Link = "https://bitcoin.org/" } };
-        var fakeSummary = "Summary";
-
-        _mockSender.Setup(s => s.MessageMaxLenght).Returns(280);
-        _mockFeedService.Setup(s => s.GetFeedsAsync(
-                It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<string>>()))
-            .ReturnsAsync(fakeFeeds);
-        _mockTextProvider.Setup(s => s.GetSummaryAsync(
-                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(fakeSummary);
-
-        var orchestrator = new FeedOrchestrator(
-            _mockSender.Object, _mockLogger.Object, _mockFeedService.Object,
-            _mockFeedUrlProvider.Object, _mockTextProvider.Object, imageProvider: null);
-
-        // ACT
-        var result = await orchestrator.OrchestrateAsync();
-
-        // ASSERT
-        Assert.NotNull(result);
-        Assert.Equal(fakeSummary, result.Content);
-        Assert.Null(result.Image);
-        Assert.True(orchestrator.SendIt);
-        _mockTextProvider.Verify(s => s.GetImagePromptAsync(
-            It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        // ASSERT — GetReplacements called once in AcquireFeedContentAsync (for keywords)
+        //          and once in ApplyTagReplacements — total: 2
+        _mockTagReplacementProvider.Verify(p => p.GetReplacements(), Times.Exactly(2));
     }
 
     [Fact]
     public async Task OrchestrateAsync_Should_ApplyHashtagsCorrectly()
     {
-        // ARRANGE
+        // ARRANGE — provider returns standard replacement map
         var fakeFeeds   = new List<RSSFeed> { new() { Title = "Il Bitcoin", Content = "News about bitcoin and BTC and fed policy", Link = "https://bitcoin.org/" } };
         var fakeSummary = "News about bitcoin and btc. The fed decided...";
         var fakePrompt  = "Image prompt";
@@ -261,11 +242,150 @@ public class FeedOrchestratorTests
     }
 
     [Fact]
+    public async Task OrchestrateAsync_Should_ReturnPostWithUnmodifiedContent_When_ProviderReturnsEmptyReplacements()
+    {
+        // ARRANGE — provider returns no replacements: content must pass through unchanged
+        _mockTagReplacementProvider.Setup(p => p.GetReplacements())
+            .Returns(new Dictionary<string, string>());
+
+        var fakeFeeds   = new List<RSSFeed> { new() { Title = "Bitcoin", Content = "bitcoin news", Link = "https://bitcoin.org/" } };
+        var fakeSummary = "bitcoin summary";
+
+        _mockSender.Setup(s => s.MessageMaxLenght).Returns(280);
+        _mockFeedService.Setup(s => s.GetFeedsAsync(
+                It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(fakeFeeds);
+        _mockTextProvider.Setup(s => s.GetSummaryAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakeSummary);
+        _mockTextProvider.Setup(s => s.GetImagePromptAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("prompt");
+        _mockImageProvider.Setup(s => s.GenerateImageAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 1 });
+
+        var orchestrator = CreateOrchestrator();
+
+        // ACT
+        var result = await orchestrator.OrchestrateAsync();
+
+        // ASSERT
+        Assert.NotNull(result);
+        Assert.Equal(fakeSummary, result.Content);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Steps 4+5 — GenerateImageAsync paths
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task OrchestrateAsync_Should_ReturnPostWithoutImage_When_ImageGenerationReturnsEmpty()
+    {
+        // ARRANGE
+        var fakeFeeds   = new List<RSSFeed> { new() { Title = "Il Bitcoin", Content = "Test", Link = "https://bitcoin.org/" } };
+        var fakeSummary = "Summary";
+        var fakePrompt  = "Prompt";
+
+        _mockSender.Setup(s => s.MessageMaxLenght).Returns(280);
+        _mockFeedService.Setup(s => s.GetFeedsAsync(
+                It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(fakeFeeds);
+        _mockTextProvider.Setup(s => s.GetSummaryAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakeSummary);
+        _mockTextProvider.Setup(s => s.GetImagePromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakePrompt);
+        _mockImageProvider.Setup(s => s.GenerateImageAsync(fakePrompt, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<byte>());
+
+        var orchestrator = CreateOrchestrator();
+
+        // ACT
+        var result = await orchestrator.OrchestrateAsync();
+
+        // ASSERT
+        Assert.NotNull(result);
+        Assert.Equal(fakeSummary, result.Content);
+        Assert.Null(result.Image);
+        Assert.True(orchestrator.SendIt);
+    }
+
+    [Fact]
+    public async Task OrchestrateAsync_Should_ReturnPostWithoutImage_When_ImageGenerationThrowsException()
+    {
+        // ARRANGE
+        var fakeFeeds   = new List<RSSFeed> { new() { Title = "Il Bitcoin", Content = "Test", Link = "https://bitcoin.org/" } };
+        var fakeSummary = "Summary";
+        var fakePrompt  = "Prompt";
+
+        _mockSender.Setup(s => s.MessageMaxLenght).Returns(280);
+        _mockFeedService.Setup(s => s.GetFeedsAsync(
+                It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(fakeFeeds);
+        _mockTextProvider.Setup(s => s.GetSummaryAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakeSummary);
+        _mockTextProvider.Setup(s => s.GetImagePromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakePrompt);
+        _mockImageProvider.Setup(s => s.GenerateImageAsync(fakePrompt, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Image generation failed"));
+
+        var orchestrator = CreateOrchestrator();
+
+        // ACT
+        var result = await orchestrator.OrchestrateAsync();
+
+        // ASSERT
+        Assert.NotNull(result);
+        Assert.Equal(fakeSummary, result.Content);
+        Assert.Null(result.Image);
+        Assert.True(orchestrator.SendIt);
+    }
+
+    [Fact]
+    public async Task OrchestrateAsync_Should_ReturnPostWithoutImage_When_ImageProviderIsNull()
+    {
+        // ARRANGE — slot uses a text-only provider (e.g. DeepSeek or Perplexity)
+        var fakeFeeds   = new List<RSSFeed> { new() { Title = "Il Bitcoin", Content = "Test", Link = "https://bitcoin.org/" } };
+        var fakeSummary = "Summary";
+
+        _mockSender.Setup(s => s.MessageMaxLenght).Returns(280);
+        _mockFeedService.Setup(s => s.GetFeedsAsync(
+                It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(fakeFeeds);
+        _mockTextProvider.Setup(s => s.GetSummaryAsync(
+                It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(fakeSummary);
+
+        var orchestrator = new FeedOrchestrator(
+            _mockSender.Object, _mockLogger.Object, _mockFeedService.Object,
+            _mockFeedUrlProvider.Object, _mockTagReplacementProvider.Object,
+            _mockTextProvider.Object, imageProvider: null);
+
+        // ACT
+        var result = await orchestrator.OrchestrateAsync();
+
+        // ASSERT
+        Assert.NotNull(result);
+        Assert.Equal(fakeSummary, result.Content);
+        Assert.Null(result.Image);
+        Assert.True(orchestrator.SendIt);
+        _mockTextProvider.Verify(s => s.GetImagePromptAsync(
+            It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Guard paths — null providers
+    // ---------------------------------------------------------------------------
+
+    [Fact]
     public async Task OrchestrateAsync_Should_ReturnNull_When_TextProviderIsNull()
     {
         var orchestrator = new FeedOrchestrator(
             _mockSender.Object, _mockLogger.Object, _mockFeedService.Object,
-            _mockFeedUrlProvider.Object, textProvider: null, imageProvider: null);
+            _mockFeedUrlProvider.Object, _mockTagReplacementProvider.Object,
+            textProvider: null, imageProvider: null);
 
         var result = await orchestrator.OrchestrateAsync();
 
@@ -279,6 +399,7 @@ public class FeedOrchestratorTests
     [Fact]
     public async Task OrchestrateAsync_Should_ReturnNull_When_SenderIsNull()
     {
+        // ARRANGE
         var fakeFeeds = new List<RSSFeed> { new() { Title = "Bitcoin", Content = "Test content", Link = "https://bitcoin.org/" } };
 
         _mockFeedService.Setup(s => s.GetFeedsAsync(
@@ -287,10 +408,13 @@ public class FeedOrchestratorTests
 
         var orchestrator = new FeedOrchestrator(
             null!, _mockLogger.Object, _mockFeedService.Object,
-            _mockFeedUrlProvider.Object, _mockTextProvider.Object, _mockImageProvider.Object);
+            _mockFeedUrlProvider.Object, _mockTagReplacementProvider.Object,
+            _mockTextProvider.Object, _mockImageProvider.Object);
 
+        // ACT
         var result = await orchestrator.OrchestrateAsync();
 
+        // ASSERT
         Assert.Null(result);
         Assert.False(orchestrator.SendIt);
         _mockTextProvider.Verify(s => s.GetSummaryAsync(
@@ -316,7 +440,6 @@ public class FeedOrchestratorTests
         _mockTextProvider.Setup(s => s.GetSummaryAsync(
                 It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(fakeSummary);
-        // GetImagePromptAsync returns empty — triggers the fallback branch
         _mockTextProvider.Setup(s => s.GetImagePromptAsync(
                 It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(string.Empty);
@@ -329,12 +452,10 @@ public class FeedOrchestratorTests
         // ACT
         var result = await orchestrator.OrchestrateAsync();
 
-        // ASSERT — post is published with image; summary was used as fallback prompt
+        // ASSERT — post published with image; summary used as fallback prompt
         Assert.NotNull(result);
-        Assert.Equal(fakeSummary, result.Content);
         Assert.Equal(fakeImage, result.Image);
         Assert.True(orchestrator.SendIt);
-        // GenerateImageAsync must have been called with the summary as fallback prompt
         _mockImageProvider.Verify(
             s => s.GenerateImageAsync(fakeSummary, It.IsAny<CancellationToken>()),
             Times.Once);
@@ -355,7 +476,6 @@ public class FeedOrchestratorTests
         _mockTextProvider.Setup(s => s.GetSummaryAsync(
                 It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(fakeSummary);
-        // whitespace triggers the same fallback as empty string
         _mockTextProvider.Setup(s => s.GetImagePromptAsync(
                 It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync("   ");

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,7 +13,8 @@ XPoster uses a **unit-first** approach:
 | Layer | Test Type | Goal |
 |---|---|---|
 | Orchestrators (`FeedOrchestrator`, `PowerLawOrchestrator`, `NoOrchestrator`) | Unit | Verify content-production logic in isolation, with all external services mocked |
-| Services (`OpenAiService`, `AzureFoundryService`, `DeepSeekService`, `PerplexityService`, `HybridAiService`, `FalAiImageService`, `FeedService`, `CryptoService`, `AiServiceHelper`) | Unit | Verify transformation and parsing logic; mock HTTP calls |
+| Providers (`ConfigurationFeedUrlProvider`, `ConfigurationTagReplacementProvider`) | Unit | Verify config-backed provider contract: correct return value from bound `IOptions`, empty-collection on absent/null config, `ArgumentNullException` on null options |
+| Services (`OpenAiService`, `AzureFoundryService`, `DeepSeekService`, `PerplexityService`, `FalAiImageService`, `FeedService`, `CryptoService`, `AiServiceHelper`) | Unit | Verify transformation and parsing logic; mock HTTP calls |
 | Sender plugins (`XSender`, `InSender`, `IgSender`, `DryRunSender`) | Unit | Verify request construction and error handling; mock the underlying API client. Sender credentials are injected via `IOptions<TCredentials>` and bound from configuration — no `IKeyVaultService` mock required. `DryRunSender` additionally verifies the null-guard path and that no outbound social API call is made |
 | `OrchestratorFactory` | Unit | Verify correct orchestrator and sender selection per hour slot |
 | Polly resilience pipelines | Integration | Verify retry, circuit-breaker, and attempt-timeout policies end-to-end using a real `IServiceProvider`; innermost `HttpMessageHandler` replaced with a test double — no outbound network calls |
@@ -51,8 +52,9 @@ tests/
 ├── Orchestrators/                                # mirrors src/Orchestrators/
 │   ├── AiServiceFactoryTests.cs                  # AiServiceFactory — provider resolution by AiProvider enum (includes Perplexity case)
 │   ├── ConfigurationFeedUrlProviderTests.cs      # ConfigurationFeedUrlProvider — URL list from config
+│   ├── ConfigurationTagReplacementProviderTests.cs  # ConfigurationTagReplacementProvider — replacement map from config (#216)
 │   ├── FeedOrchestratorFeedUrlProviderTests.cs   # FeedOrchestrator — IFeedUrlProvider integration paths
-│   ├── FeedOrchestratorTests.cs                  # FeedOrchestrator — main happy/failure paths
+│   ├── FeedOrchestratorTests.cs                  # FeedOrchestrator — main happy/failure paths + #216 new scenarios
 │   ├── NoOrchestratorTests.cs                    # NoOrchestrator — null-object contract
 │   ├── OrchestratorFactoryTests.cs               # OrchestratorFactory + SlotProfileProvider behaviour
 │   └── PowerLawOrchestratorTests.cs              # PowerLawOrchestrator — price/model computation
@@ -90,13 +92,14 @@ tests/
     ├── DeepSeekServiceTests.cs
     ├── FalAiImageServiceTests.cs
     ├── FeedServiceTests.cs
-    ├── HybridAiServiceTests.cs
     ├── OpenAiServiceTests.cs
     ├── PerplexityServiceTests.cs                 # PerplexityService — summary, image prompt, GenerateImageAsync graceful degradation
     └── TimeProviderTests.cs
 ```
 
 > `KeyVaultServiceTests.cs` has been removed. `KeyVaultService` / `IKeyVaultService` are no longer part of the production codebase — secrets are loaded at startup via the Azure Key Vault Configuration Provider and consumed through `IOptions<TCredentials>` in each sender.
+
+> `HybridAiServiceTests.cs` has been removed. `HybridAiService` / `DeepSeekWithFal` have been removed from the production codebase. `DeepSeekService` and `FalAiImageService` are tested independently in `Services/`.
 
 ### Folder responsibilities
 
@@ -105,11 +108,11 @@ tests/
 | *(root)* | `XPoster` | `XFunction` entry point — happy path and missing-branch edge cases |
 | `Contracts/` | `XPoster.Contracts`, `XPoster.Abstraction` | `AiProviderExtensions` enum extension method contracts; `BaseOrchestrator` abstract class contracts |
 | `Helpers/` | — | Shared test utilities for resilience and HTTP mock setup (`ResilienceTestHelpers`) |
-| `Orchestrators/` | `XPoster.Orchestrators` | `FeedOrchestrator` (main paths + `IFeedUrlProvider` integration); `PowerLawOrchestrator`; `NoOrchestrator`; `AiServiceFactory` provider resolution (including `AiProvider.Perplexity`); `OrchestratorFactory` slot selection with synthetic `ISlotProfileProvider` mocks; `DefaultSlotProfileProvider` and `DryRunSlotProfileProvider` behaviour; `ConfigurationFeedUrlProvider` URL binding from config |
+| `Orchestrators/` | `XPoster.Orchestrators` | `FeedOrchestrator` (main paths + `IFeedUrlProvider` integration + #216 explicit-pipeline scenarios); `PowerLawOrchestrator`; `NoOrchestrator`; `OrchestratorFactory` slot selection with synthetic `ISlotProfileProvider` mocks; `DefaultSlotProfileProvider` and `DryRunSlotProfileProvider` behaviour; `ConfigurationFeedUrlProvider` URL binding from config; `ConfigurationTagReplacementProvider` replacement map from config |
 | `Integration/` | `XPoster.*` | Polly resilience pipeline integration tests (retry, circuit-breaker, attempt-timeout) — **not run in CI** |
 | `Models/` | `XPoster.Models` | Domain model invariants, `Post` and `RSSFeed` missing-branch cases, options validators for OpenAI, Azure Foundry, DeepSeek, fal.ai, and Perplexity |
 | `SenderPlugins/` | `XPoster.SenderPlugins` | `XSender` and `InSender` (happy path, `SendAsync`, missing-branch, resilience); `IgSender` (happy path, resilience); `DryRunSender` (null guard, dry-run success/failure paths — no Key Vault probe) |
-| `Services/` | `XPoster.Services` | `OpenAiService`, `AzureFoundryService`, `DeepSeekService`, `PerplexityService`, `FalAiImageService`, `HybridAiService`, `AiServiceHelper`, `CryptoService`, `FeedService`, `TimeProvider` unit tests |
+| `Services/` | `XPoster.Services` | `OpenAiService`, `AzureFoundryService`, `DeepSeekService`, `PerplexityService`, `FalAiImageService`, `AiServiceHelper`, `CryptoService`, `FeedService`, `TimeProvider` unit tests |
 
 ---
 
@@ -156,6 +159,9 @@ dotnet test --filter "FullyQualifiedName~FeedOrchestrator"
 
 # Only DryRunSender tests
 dotnet test --filter "FullyQualifiedName~DryRunSender"
+
+# Only tag replacement provider tests
+dotnet test --filter "FullyQualifiedName~ConfigurationTagReplacementProvider"
 ```
 
 ### With coverage report
@@ -182,39 +188,52 @@ start coverage-report/index.html  # Windows
 
 ## 6. Mocking External Services
 
-All external dependencies (`IAiService`, `IFeedService`, `ISender`, `ILogger`) are injected via constructor and replaced with Moq mocks in tests.
+All external dependencies (`ITextToTextProvider`, `ITextToImageProvider`, `IFeedService`, `IFeedUrlProvider`, `ITagReplacementProvider`, `ISender`, `ILogger`) are injected via constructor and replaced with Moq mocks in tests.
 
 Sender credentials are bound from `IConfiguration` at application startup via the Key Vault Configuration Provider and consumed through `IOptions<TCredentials>`. In unit tests, use `Options.Create(new TCredentials { ... })` to supply test values — no `IKeyVaultService` mock is needed.
 
-### Pattern — mocking `IAiService`
+### Pattern — mocking `ITextToTextProvider` and `ITagReplacementProvider`
 
 ```csharp
 [Fact]
-public async Task OrchestrateAsync_WhenAiReturnsValidSummary_PostContentIsSet()
+public async Task OrchestrateAsync_WhenSummaryIsValid_AppliesTagReplacementsOnce()
 {
     // Arrange
-    var mockAi = new Mock<IAiService>();
-    mockAi
-        .Setup(x => x.GetSummaryAsync(It.IsAny<string>(), It.IsAny<int>()))
+    var mockTextProvider = new Mock<ITextToTextProvider>();
+    mockTextProvider
+        .Setup(x => x.GetSummaryAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
         .ReturnsAsync("BTC breaks ATH driven by ETF inflows");
+    mockTextProvider
+        .Setup(x => x.GetImagePromptAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync("A chart showing BTC price spike");
 
-    var mockSender  = new Mock<ISender>();
-    var mockLogger  = new Mock<ILogger<FeedOrchestrator>>();
-    var mockFeed    = new Mock<IFeedService>();
-    mockFeed
-        .Setup(x => x.GetLatestItemAsync())
-        .ReturnsAsync(new FeedItem { Title = "BTC News", Content = "..." });
+    var mockTagProvider = new Mock<ITagReplacementProvider>();
+    mockTagProvider
+        .Setup(x => x.GetReplacements())
+        .Returns(new Dictionary<string, string> { { "btc", "#BTC" } });
 
-    var orchestrator = new FeedOrchestrator(mockSender.Object, mockLogger.Object,
-                                            mockFeed.Object, mockAi.Object);
+    var mockSender      = new Mock<ISender>();
+    var mockLogger      = new Mock<ILogger<FeedOrchestrator>>();
+    var mockFeedService = new Mock<IFeedService>();
+    mockFeedService
+        .Setup(x => x.GetFeedItemsAsync(It.IsAny<IEnumerable<string>>()))
+        .ReturnsAsync([new FeedItem { Title = "BTC News", Content = "BTC breaks ATH" }]);
+
+    var mockFeedUrlProvider = new Mock<IFeedUrlProvider>();
+    mockFeedUrlProvider.Setup(x => x.GetUrls()).Returns(["https://example.com/feed"]);
+
+    var orchestrator = new FeedOrchestrator(
+        mockSender.Object, mockLogger.Object,
+        mockTextProvider.Object, null,
+        mockFeedService.Object, mockFeedUrlProvider.Object,
+        mockTagProvider.Object);
 
     // Act
     var post = await orchestrator.OrchestrateAsync();
 
     // Assert
     Assert.NotNull(post);
-    Assert.Contains("BTC breaks ATH", post.Content);
-    mockAi.Verify(x => x.GetSummaryAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Once);
+    mockTagProvider.Verify(x => x.GetReplacements(), Times.Once);
 }
 ```
 
@@ -264,6 +283,49 @@ public async Task SendAsync_WhenPostIsValid_ReturnsTrue()
 
     // Assert
     Assert.True(result);
+}
+```
+
+### Pattern — testing `ConfigurationTagReplacementProvider`
+
+```csharp
+[Fact]
+public void GetReplacements_WhenConfigured_ReturnsExpectedMap()
+{
+    // Arrange
+    var options = Options.Create(new TagReplacementOptions
+    {
+        Replacements = new Dictionary<string, string>
+        {
+            { "bitcoin", "#Bitcoin" },
+            { "btc",     "#BTC"     }
+        }
+    });
+    var provider = new ConfigurationTagReplacementProvider(options);
+
+    // Act
+    var replacements = provider.GetReplacements();
+
+    // Assert
+    Assert.Equal(2, replacements.Count);
+    Assert.Equal("#Bitcoin", replacements["bitcoin"]);
+    Assert.Equal("#BTC",     replacements["btc"]);
+}
+
+[Fact]
+public void GetReplacements_WhenSectionAbsent_ReturnsEmptyDictionary()
+{
+    var options  = Options.Create(new TagReplacementOptions());
+    var provider = new ConfigurationTagReplacementProvider(options);
+
+    Assert.Empty(provider.GetReplacements());
+}
+
+[Fact]
+public void Constructor_WhenOptionsIsNull_ThrowsArgumentNullException()
+{
+    Assert.Throws<ArgumentNullException>(
+        () => new ConfigurationTagReplacementProvider(null!));
 }
 ```
 


### PR DESCRIPTION
## Summary

Externalises hashtag/tag replacement logic out of `FeedOrchestrator` into a dedicated `ITagReplacementProvider` abstraction, making keyword mappings operator-managed via configuration rather than hardcoded.

## Changes

### New abstractions
- `ITagReplacementProvider`: contract for config-backed keyword replacement
- `ConfigurationTagReplacementProvider`: implementation bound from `TagReplacementOptions`, with empty-map fallback when the section is absent

### FeedOrchestrator refactor
- Refactored to an explicit staged pipeline: `GetFeedUrls` → `GetFeedsAsync` → `GetSummaryAsync` → tag replacement → `GetImagePromptAsync` → `GenerateImageAsync` → `BuildPost`
- Structured logging at each decision point
- Tag replacement injected via `ITagReplacementProvider`

### Documentation
- `CONTRIBUTING.md`: updated directory tree and component descriptions
- `CHANGELOG.md`: `[Unreleased]` section updated with #216 entries (ordered before #211 per Keep a Changelog)

### Tests
- `ConfigurationTagReplacementProviderTests`: configured map return, empty-map fallback, null-options guard
- `FeedOrchestratorTests`: staged-pipeline coverage — URL invocation, early return on empty URL list, tag replacement execution order, single map retrieval, graceful no-replacement continuation

## Related

Closes #216