### PR TITLE
docs: Instagram setup guide + token reminder workflow

### DIFF
--- a/.github/workflows/instagram-token-reminder.yml
+++ b/.github/workflows/instagram-token-reminder.yml
@@ -1,0 +1,98 @@
+name: Instagram Token Expiry Reminder
+
+# Runs every Monday at 09:00 UTC
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch: # Allow manual trigger for testing
+
+jobs:
+  check-token-expiry:
+    name: Check Instagram Token Expiry
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Check expiry and open reminder issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const expiryDateStr = process.env.INSTAGRAM_TOKEN_EXPIRY;
+
+            if (!expiryDateStr) {
+              core.warning('INSTAGRAM_TOKEN_EXPIRY variable is not set. Skipping check.');
+              return;
+            }
+
+            const expiry = new Date(expiryDateStr);
+            const now = new Date();
+            const daysLeft = Math.floor((expiry - now) / (1000 * 60 * 60 * 24));
+
+            console.log(`Token expiry: ${expiry.toDateString()}`);
+            console.log(`Days left: ${daysLeft}`);
+
+            if (daysLeft > 14) {
+              console.log('Token is healthy. No action needed.');
+              return;
+            }
+
+            // Check if a reminder issue is already open to avoid duplicates
+            const { data: openIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'token-rotation'
+            });
+
+            const alreadyOpen = openIssues.some(issue =>
+              issue.title.includes('Instagram Access Token')
+            );
+
+            if (alreadyOpen) {
+              console.log('A reminder issue is already open. Skipping.');
+              return;
+            }
+
+            const urgency = daysLeft <= 0
+              ? '🔴 EXPIRED'
+              : daysLeft <= 7
+                ? '🔴 CRITICAL'
+                : '⚠️ WARNING';
+
+            const body = daysLeft <= 0
+              ? `## 🔴 Instagram Access Token EXPIRED\n\nThe Instagram Access Token has **expired** on ${expiry.toDateString()}.\nXPoster is no longer able to post on Instagram until the token is renewed.`
+              : `## ⚠️ Instagram Access Token expiring soon\n\nThe Instagram Access Token will expire on **${expiry.toDateString()}** (in **${daysLeft} days**).`;
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `${urgency} - Instagram Access Token expires on ${expiry.toDateString()}`,
+              body: body + `\n\n## Steps to renew\n\n` +
+                `> The Instagram token uses the **Facebook Login flow** and does not support automatic refresh.\n` +
+                `> Manual renewal is required every ~60 days.\n\n` +
+                `1. Open the [Graph API Explorer](https://developers.facebook.com/tools/explorer/)\n` +
+                `2. Select the **XPoster** app from the top-right dropdown\n` +
+                `3. Click **Generate Access Token** and check all four permissions:\n` +
+                `   - \`instagram_basic\`\n` +
+                `   - \`instagram_content_publish\`\n` +
+                `   - \`pages_show_list\`\n` +
+                `   - \`pages_read_engagement\`\n` +
+                `4. Exchange the short-lived token for a long-lived one (valid 60 days):\n` +
+                `\`\`\`\n` +
+                `https://graph.facebook.com/v20.0/oauth/access_token?grant_type=fb_exchange_token&client_id={APP_ID}&client_secret={APP_SECRET}&fb_exchange_token={SHORT_LIVED_TOKEN}\n` +
+                `\`\`\`\n` +
+                `5. Update the secret in Azure Key Vault:\n` +
+                `\`\`\`bash\n` +
+                `az keyvault secret set --vault-name kv-xposter --name IgAccessToken --value "<new_token>"\n` +
+                `\`\`\`\n` +
+                `6. Update the \`INSTAGRAM_TOKEN_EXPIRY\` variable in GitHub repository settings to the new expiry date (+60 days from today)\n` +
+                `7. Close this issue\n\n` +
+                `## Reference\n\n` +
+                `- [Instagram setup guide](../docs/integrations/SenderPlugins/setup-instagram.md) — Steps 5 and 6`,
+              labels: ['infrastructure', 'token-rotation']
+            });
+
+            console.log(`Reminder issue created. Days left: ${daysLeft}`);
+        env:
+          INSTAGRAM_TOKEN_EXPIRY: ${{ vars.INSTAGRAM_TOKEN_EXPIRY }}

--- a/docs/integrations/SenderPlugins/setup-instagram.md
+++ b/docs/integrations/SenderPlugins/setup-instagram.md
@@ -2,30 +2,15 @@
 
 > This document covers **only** the Instagram and Meta platform configuration required to enable programmatic publishing via the Instagram Platform API. For XPoster integration details, see [issue #72](https://github.com/artcava/XPoster/issues/72).
 
----
-
-## Which API to use
-
-Meta currently offers two configurations for Instagram publishing:
-
-| | **Instagram API with Instagram Login** | Instagram API with Facebook Login |
-|---|---|---|
-| Login | Instagram credentials | Facebook credentials |
-| Facebook Page required | ❌ No | ✅ Yes |
-| API host | `graph.instagram.com` | `graph.facebook.com` |
-| Content Publishing | ✅ | ✅ |
-| Recommended | ✅ **Yes** | For legacy integrations only |
-
-XPoster uses the **Instagram API with Instagram Login**, which is the current recommended path by Meta as of 2024 and removes the dependency on a Facebook Page.
-
-> **Reference**: [developers.facebook.com/documentation/instagram-platform](https://developers.facebook.com/documentation/instagram-platform)
+> ⚠️ This guide uses the **Instagram API with Facebook Login** flow, which requires an Instagram Business account linked to a Facebook Page. This is the recommended path if you already have a Facebook Page connected to your Instagram account.
 
 ---
 
 ## Prerequisites
 
-- An **Instagram account** (personal accounts must be converted — see Step 1)
-- A **Facebook account** (required to access the Meta Developer Portal and create an app)
+- An **Instagram Business or Creator account** (personal accounts must be converted — see Step 1)
+- A **Facebook Page** connected to the Instagram account (see Step 2)
+- A **Facebook personal account** with Admin role on the Page
 - Access to [developers.facebook.com](https://developers.facebook.com)
 
 ---
@@ -41,194 +26,186 @@ Conversion is free and reversible:
 3. Choose **Business** (recommended) or **Creator**.
 4. Select a category and complete the optional contact info step.
 
-> ✅ No content is lost. The account remains usable for normal Instagram activity after conversion.
+> ✅ No content is lost. The account remains fully usable for normal Instagram activity after conversion.
 
 ---
 
-## Step 2 — Create a Meta Developer App
+## Step 2 — Connect Instagram to a Facebook Page
+
+The Facebook Login flow routes all API requests through a Facebook Page. The Instagram Business account must be linked to a Page.
+
+1. On Facebook, go to your Page.
+2. Open **Settings → Linked Accounts** (or **Professional Dashboard → Settings → Instagram**).
+3. Click **Connect Instagram** and complete the login flow.
+
+Alternatively via Meta Business Suite ([business.facebook.com](https://business.facebook.com)):
+1. Go to **Settings → Accounts → Instagram accounts**.
+2. Click **Add** and follow the OAuth flow.
+
+> ⚠️ This link is mandatory. Without it, the `instagram_business_account` field will not be accessible via the Graph API.
+
+---
+
+## Step 3 — Create a Meta Developer App
 
 1. Go to [developers.facebook.com](https://developers.facebook.com) and log in with your Facebook account.
 2. Click **My Apps → Create App**.
-3. When asked *"What do you want your app to do?"*, select **Other**, then click **Next**.
-4. Select app type **Business**, then click **Next**.
-5. Enter a name, a contact email, and optionally link a Business Portfolio. Click **Create App**.
+3. Select app type **Business**, then click **Next**.
+4. Enter a name, a contact email, and click **Create App**.
+5. In the app dashboard, go to **Facebook Login → Settings** and add the following **Valid OAuth Redirect URI**:
+   ```
+   https://developers.facebook.com/tools/explorer/
+   ```
+   This allows using the Graph API Explorer to generate tokens without setting up a real redirect endpoint.
 
 ---
 
-## Step 3 — Add the Instagram Product (Business Login for Instagram)
+## Step 4 — Add Your Account as Administrator or Tester
 
-1. In the app dashboard, scroll to **Add Products to Your App**.
-2. Find **Instagram** and click **Set up**.
-3. In the Instagram setup page, choose **API setup with Instagram login**.
-4. Note the **Instagram App ID** and **Instagram App Secret** shown in this section — these are your app credentials.
-
-> ⚠️ The Instagram App ID shown here may differ from the Meta App ID displayed in **App Settings → Basic**. Use the one from the Instagram product section.
-
----
-
-## Step 4 — Configure Permissions
-
-In the Instagram product dashboard, under **Permissions**, enable:
-
-| Permission | Purpose |
-|---|---|
-| `instagram_business_basic` | Read profile info and media |
-| `instagram_business_content_publish` | Publish photos and videos |
-
-In **Development mode** these permissions are pre-approved and work immediately for accounts with a role in the app (see Step 5). No App Review is needed for personal use.
-
-> ⚠️ These are the **new permission names** introduced with the Instagram Login flow. The old names (`instagram_basic`, `instagram_content_publish`) belong to the Facebook Login flow and are **not interchangeable**.
-
----
-
-## Step 5 — Add Your Instagram Account as a Tester
-
-In Development mode, the API only works for accounts explicitly assigned a role in the app.
+In Development mode, the API only works for accounts with an explicit role in the app.
 
 1. In the app dashboard, go to **App Roles → Roles**.
-2. Under **Testers**, click **Add Testers**.
-3. Search for the Instagram username (not Facebook) of the account you want to publish from.
-4. The invited account must **accept the invitation**: open the Instagram app → **Settings → Apps and Websites → Tester Invites** and accept.
-
-> If this step is skipped, all API calls will return error code `10` (*Permission Denied*) even with a valid token.
+2. Under **Administrators** or **Testers**, add the Facebook account that owns the Page.
+3. Accept the invitation if prompted.
 
 ---
 
-## Step 6 — Generate a Short-Lived Access Token
+## Step 5 — Generate a Short-Lived Access Token via Graph API Explorer
 
-With Instagram Login, token generation uses Instagram's own OAuth flow, not the Graph API Explorer.
+1. Open the [Graph API Explorer](https://developers.facebook.com/tools/explorer/).
+2. In the top-right dropdown **Meta App**, select your app.
+3. Click **Generate Access Token**.
+4. In the permissions dialog, check all four of the following:
+   - `instagram_basic`
+   - `instagram_content_publish`
+   - `pages_show_list`
+   - `pages_read_engagement`
+5. Click **Generate Access Token** and complete the Facebook login consent screen.
 
-### Option A — Via the App Dashboard (quickest for initial setup)
+The token displayed is a **short-lived User Access Token**, valid for approximately **1–2 hours**.
 
-1. In the app dashboard, go to the **Instagram → API setup with Instagram login** section.
-2. Click **Generate Token** next to your Instagram account.
-3. Complete the Instagram OAuth consent screen, granting `instagram_business_basic` and `instagram_business_content_publish`.
-4. Copy the **Instagram User Access Token** displayed.
+### Verify the token
 
-### Option B — Via OAuth URL (for automation or re-generation)
-
-Construct the authorization URL:
-
-```
-https://api.instagram.com/oauth/authorize
-  ?client_id={instagram-app-id}
-  &redirect_uri={your-redirect-uri}
-  &scope=instagram_business_basic,instagram_business_content_publish
-  &response_type=code
-```
-
-After the user authorizes, Instagram redirects to `{redirect_uri}?code={auth-code}`. Exchange the code for a token:
-
-```
-POST https://api.instagram.com/oauth/access_token
-
-Content-Type: application/x-www-form-urlencoded
-client_id={instagram-app-id}
-client_secret={instagram-app-secret}
-grant_type=authorization_code
-redirect_uri={your-redirect-uri}
-code={auth-code}
-```
-
-The response contains a **short-lived Instagram User Access Token** valid for **1 hour**.
+Open the [Access Token Debugger](https://developers.facebook.com/tools/debug/accesstoken/), paste the token and click **Debug**. Confirm:
+- **Type**: User
+- **Scopes**: includes all four permissions above
+- **Valid**: true
 
 ---
 
-## Step 7 — Exchange for a Long-Lived Access Token
+## Step 6 — Exchange for a Long-Lived Access Token
 
-Short-lived tokens are not suitable for production. Exchange for a **long-lived token** (valid 60 days):
+Short-lived tokens are not suitable for production. Exchange for a **long-lived token** valid for 60 days.
+
+Open the following URL in your browser (replace the three placeholders):
 
 ```
-GET https://graph.instagram.com/access_token
-  ?grant_type=ig_exchange_token
-  &client_secret={instagram-app-secret}
-  &access_token={short-lived-token}
+https://graph.facebook.com/v20.0/oauth/access_token?grant_type=fb_exchange_token&client_id={APP_ID}&client_secret={APP_SECRET}&fb_exchange_token={SHORT_LIVED_TOKEN}
 ```
 
-The response contains:
+- `APP_ID` and `APP_SECRET` are found in **App Settings → Basic** in the Meta App Dashboard.
+
+The response will be:
 ```json
 {
-  "access_token": "IGAAx...",
+  "access_token": "EAABsbCS...",
   "token_type": "bearer",
-  "expires_in": 5183944
+  "expires_in": 5183999
 }
 ```
 
-`expires_in` is in seconds — approximately 60 days.
+`expires_in` ≈ 5,184,000 seconds ≈ **60 days**.
 
-### Refresh before expiry
+Store the `access_token` value as `IG_ACCESS_TOKEN` in Azure Key Vault.
 
-Before the token expires (renew from day 50 onwards), call:
-
-```
-GET https://graph.instagram.com/refresh_access_token
-  ?grant_type=ig_refresh_token
-  &access_token={long-lived-token}
-```
-
-This resets the expiry to a fresh 60 days. The same token value is returned with an updated `expires_in`.
-
-> ⚠️ Note: both exchange and refresh calls target `graph.instagram.com`, **not** `graph.facebook.com`. This is a key difference from the Facebook Login flow.
+> ⚠️ Tokens expire after 60 days. To renew, repeat Steps 5 and 6 before expiry. Automated refresh is tracked in [#72](https://github.com/artcava/XPoster/issues/72).
 
 ---
 
-## Step 8 — Retrieve the Instagram Account ID
+## Step 7 — Retrieve the Instagram Account ID
 
-The Instagram Account ID (`IG_ACCOUNT_ID`) is required to construct API request URLs.
+The `IG_ACCOUNT_ID` is needed to form API request URLs in XPoster.
 
-With Instagram Login, the ID is retrieved directly — no Facebook Page lookup is needed:
+### Step 7a — Find your Facebook Page
+
+In the Graph API Explorer, paste the **long-lived token** and run:
 
 ```
-GET https://graph.instagram.com/v22.0/me
-  ?fields=id,name,username
-  &access_token={long-lived-token}
+GET /me/accounts
 ```
 
-Example response:
+> ⚠️ If this returns only your personal user ID and no Pages, it means the `pages_show_list` permission was not granted. Regenerate the token (Step 5) making sure all four permissions are checked.
+
+If you know your Page's vanity name (e.g. `ArtCavaProjects`), you can query it directly and skip Step 7b:
+
+```
+GET /ArtCavaProjects?fields=id,instagram_business_account
+```
+
+### Step 7b — Get the Instagram Business Account ID
+
+Using the Page ID from the previous step:
+
+```
+GET /{page-id}?fields=instagram_business_account
+```
+
+The response will contain:
+
 ```json
 {
-  "id": "17841400000000000",
-  "name": "Your Name",
-  "username": "yourusername"
+  "instagram_business_account": {
+    "id": "17841400000000000"
+  },
+  "id": "{page-id}"
 }
 ```
 
-The `id` value is your `IG_ACCOUNT_ID`. Store it in the `IG_ACCOUNT_ID` app setting.
+The `instagram_business_account.id` value is your `IG_ACCOUNT_ID`. Store it in Azure Key Vault.
+
+### Verify the connection
+
+Confirm the account is reachable with the token:
+
+```
+GET /{IG_ACCOUNT_ID}?fields=id,name,username
+```
+
+You should see the Instagram account name and username. If this call succeeds, the configuration is complete.
 
 ---
 
-## Step 9 — App Review (Production Only)
+## Step 8 — App Review (Production Only)
 
-In **Development mode**, the setup above works only for accounts added as Testers (Step 5). For a private single-account automation like XPoster, **App Review is not required**.
+In **Development mode**, everything above works only for accounts with a role in the app. For a private single-account automation like XPoster, **App Review is not required**.
 
-App Review is only needed if the app will publish on behalf of **third-party Instagram accounts** (i.e., other users' accounts via OAuth). In that case:
-
-1. Go to **App Review → Permissions and Features**.
-2. Request `instagram_business_basic` and `instagram_business_content_publish`.
-3. Provide screen recordings and usage descriptions.
-4. Switch the app to **Live mode** after approval.
+App Review is only needed if the app will publish on behalf of **third-party Instagram accounts**. In that case, request the following permissions via **App Review → Permissions and Features**:
+- `instagram_basic`
+- `instagram_content_publish`
+- `pages_show_list`
+- `pages_read_engagement`
 
 ---
 
 ## App Settings Reference
 
-At the end of this setup, you will have the following values to store securely (e.g. Azure Key Vault):
+At the end of this setup, store the following values securely in Azure Key Vault:
 
-| Setting | Where to find it |
+| Setting | How to obtain |
 |---|---|
-| `IG_ACCESS_TOKEN` | Generated in Step 7 (long-lived token) |
-| `IG_ACCOUNT_ID` | Retrieved in Step 8 (`/me?fields=id`) |
+| `IG_ACCESS_TOKEN` | Long-lived token from Step 6 |
+| `IG_ACCOUNT_ID` | `instagram_business_account.id` from Step 7 |
 
 > Never commit tokens to source control or expose them in logs.
 
 ---
 
-## Token Management Summary
+## Token Management
 
-| Token type | Validity | Host | Notes |
-|---|---|---|---|
-| Short-lived Instagram User Token | ~1 hour | `api.instagram.com` | Only used to generate long-lived token |
-| Long-lived Instagram User Token | 60 days | `graph.instagram.com` | Use in production; refresh before day 50 |
+| Token type | Validity | Exchange endpoint |
+|---|---|---|
+| Short-lived User Token | ~1–2 hours | — |
+| Long-lived User Token | 60 days | `graph.facebook.com/v20.0/oauth/access_token` with `grant_type=fb_exchange_token` |
 
 ---
 
@@ -261,8 +238,8 @@ Exceeding the publishing limit returns HTTP `429`. The `Retry-After` header indi
 ## References
 
 - [Instagram Platform Overview](https://developers.facebook.com/documentation/instagram-platform)
-- [Instagram API with Instagram Login — Content Publishing](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/content-publishing/)
-- [Instagram API with Instagram Login — Overview](https://developers.facebook.com/docs/instagram-platform/overview/)
-- [Meta Developer Portal](https://developers.facebook.com)
+- [Instagram API with Facebook Login — Overview](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-facebook-login/overview)
+- [Graph API Explorer](https://developers.facebook.com/tools/explorer/)
 - [Access Token Debugger](https://developers.facebook.com/tools/debug/accesstoken/)
+- [Meta App Dashboard](https://developers.facebook.com/apps/)
 - Tracking issue: [#72](https://github.com/artcava/XPoster/issues/72)

--- a/docs/integrations/SenderPlugins/setup-instagram.md
+++ b/docs/integrations/SenderPlugins/setup-instagram.md
@@ -1,225 +1,249 @@
 # Instagram Account Setup
 
-> This document covers **only** the Instagram and Meta platform configuration required to enable programmatic publishing via the Instagram Graph API. For XPoster integration details, see [issue #72](https://github.com/artcava/XPoster/issues/72).
+> This document covers **only** the Instagram and Meta platform configuration required to enable programmatic publishing via the Instagram Platform API. For XPoster integration details, see [issue #72](https://github.com/artcava/XPoster/issues/72).
+
+---
+
+## Which API to use
+
+Meta currently offers two configurations for Instagram publishing:
+
+| | **Instagram API with Instagram Login** | Instagram API with Facebook Login |
+|---|---|---|
+| Login | Instagram credentials | Facebook credentials |
+| Facebook Page required | ❌ No | ✅ Yes |
+| API host | `graph.instagram.com` | `graph.facebook.com` |
+| Content Publishing | ✅ | ✅ |
+| Recommended | ✅ **Yes** | For legacy integrations only |
+
+XPoster uses the **Instagram API with Instagram Login**, which is the current recommended path by Meta as of 2024 and removes the dependency on a Facebook Page.
+
+> **Reference**: [developers.facebook.com/documentation/instagram-platform](https://developers.facebook.com/documentation/instagram-platform)
 
 ---
 
 ## Prerequisites
 
-Before starting, verify you have:
-
-- A **Facebook personal account** (required to own a Business Page and a Meta Developer App)
-- An **Instagram account** (personal is fine as a starting point — it will be converted to Business/Creator)
-- Access to the **Meta Developer Portal**: [developers.facebook.com](https://developers.facebook.com)
+- An **Instagram account** (personal accounts must be converted — see Step 1)
+- A **Facebook account** (required to access the Meta Developer Portal and create an app)
+- Access to [developers.facebook.com](https://developers.facebook.com)
 
 ---
 
 ## Step 1 — Convert Instagram to a Business or Creator Account
 
-The Instagram Graph API is **not available for personal accounts**. The Instagram Basic Display API, which historically served personal accounts, was **deprecated and shut down in 2024**. As of 2026, the only supported path for programmatic publishing is the Graph API, which requires a **Professional account** (Business or Creator).
+The Instagram Platform API is **not available for personal accounts**. The Instagram Basic Display API, which historically served personal accounts, was **deprecated and shut down in 2024**. Programmatic publishing requires a **Professional account** (Business or Creator).
 
 Conversion is free and reversible:
 
 1. Open the Instagram app.
 2. Go to **Settings → Account → Switch to Professional Account**.
-3. Choose **Business** (recommended for API publishing) or **Creator**.
+3. Choose **Business** (recommended) or **Creator**.
 4. Select a category and complete the optional contact info step.
 
-> ✅ After conversion the account remains fully usable for normal Instagram activity. No content is lost.
+> ✅ No content is lost. The account remains usable for normal Instagram activity after conversion.
 
 ---
 
-## Step 2 — Create a Facebook Page
+## Step 2 — Create a Meta Developer App
 
-The Instagram Graph API routes all requests through a **Facebook Page**. An Instagram Business account must be linked to a Page before the API can be used.
-
-If you don’t have a Page yet:
-
-1. On Facebook, click **Pages → Create new Page**.
-2. Give it a name (it can be a test page — it does not need to be public).
-3. Complete the minimal required fields and publish.
-
----
-
-## Step 3 — Link Instagram to the Facebook Page
-
-1. Go to your Facebook Page.
-2. Open **Settings → Linked Accounts** (or **Professional Dashboard → Settings → Instagram**).
-3. Click **Connect Instagram**.
-4. Log in with your Instagram credentials and confirm the connection.
-
-Alternatively, via **Meta Business Suite** ([business.facebook.com](https://business.facebook.com)):
-
-1. Go to **Settings → Accounts → Instagram accounts**.
-2. Click **Add** and follow the OAuth flow.
-
-> ⚠️ This step is **mandatory**. Without the Page–Instagram link, all Graph API calls return an authorization error regardless of the token scopes.
-
----
-
-## Step 4 — Create a Meta Developer App
-
-1. Go to [developers.facebook.com](https://developers.facebook.com) and log in.
+1. Go to [developers.facebook.com](https://developers.facebook.com) and log in with your Facebook account.
 2. Click **My Apps → Create App**.
-3. Under **Use case**, select **Content Management** → **Manage messaging and content on Instagram**, then click **Next**.
-4. Optionally connect a Business Portfolio, then click **Next**.
-5. Give the app a name, enter a contact email, and click **Create App**.
-
-> The app type must be **Business**. Consumer-type apps cannot add the Instagram Graph API product.
+3. When asked *"What do you want your app to do?"*, select **Other**, then click **Next**.
+4. Select app type **Business**, then click **Next**.
+5. Enter a name, a contact email, and optionally link a Business Portfolio. Click **Create App**.
 
 ---
 
-## Step 5 — Add Instagram Graph API Product
+## Step 3 — Add the Instagram Product (Business Login for Instagram)
 
-1. Inside the app dashboard, go to **Customize** under the *Manage messaging and content on Instagram* use case.
-2. Select **API Setup with Facebook Login**.
-3. Under **Permissions**, add all required scopes:
-   - `instagram_basic`
-   - `instagram_content_publish`
-   - `pages_read_engagement`
-   - `pages_show_list`
+1. In the app dashboard, scroll to **Add Products to Your App**.
+2. Find **Instagram** and click **Set up**.
+3. In the Instagram setup page, choose **API setup with Instagram login**.
+4. Note the **Instagram App ID** and **Instagram App Secret** shown in this section — these are your app credentials.
 
-> In **Development mode** these permissions are available immediately without App Review, but they only work for accounts explicitly added as Testers or Administrators of the app (see Step 6).
+> ⚠️ The Instagram App ID shown here may differ from the Meta App ID displayed in **App Settings → Basic**. Use the one from the Instagram product section.
 
 ---
 
-## Step 6 — Add Your Instagram Account as a Tester
+## Step 4 — Configure Permissions
 
-While the app is in Development mode (the default state), the API only accepts requests on behalf of accounts that have been granted a role in the app.
+In the Instagram product dashboard, under **Permissions**, enable:
+
+| Permission | Purpose |
+|---|---|
+| `instagram_business_basic` | Read profile info and media |
+| `instagram_business_content_publish` | Publish photos and videos |
+
+In **Development mode** these permissions are pre-approved and work immediately for accounts with a role in the app (see Step 5). No App Review is needed for personal use.
+
+> ⚠️ These are the **new permission names** introduced with the Instagram Login flow. The old names (`instagram_basic`, `instagram_content_publish`) belong to the Facebook Login flow and are **not interchangeable**.
+
+---
+
+## Step 5 — Add Your Instagram Account as a Tester
+
+In Development mode, the API only works for accounts explicitly assigned a role in the app.
 
 1. In the app dashboard, go to **App Roles → Roles**.
-2. Under **Testers**, click **Add** and enter the Facebook account linked to your Instagram.
-3. The invited account must **accept the invitation**: open Facebook Notifications → accept the developer role.
-4. On Instagram, also go to **Settings → Apps and Websites** and verify the app appears as authorized.
+2. Under **Testers**, click **Add Testers**.
+3. Search for the Instagram username (not Facebook) of the account you want to publish from.
+4. The invited account must **accept the invitation**: open the Instagram app → **Settings → Apps and Websites → Tester Invites** and accept.
 
-> If you skip this step, token generation will succeed but API calls will return error code `10` (*Not authorized*).
-
----
-
-## Step 7 — Generate a Short-Lived Access Token
-
-1. Open the **Graph API Explorer**: [developers.facebook.com/tools/explorer](https://developers.facebook.com/tools/explorer)
-2. In the top-right dropdown, select the app you just created.
-3. Click **Get Token → Get User Access Token**.
-4. In the permissions dialog, check:
-   - `instagram_basic`
-   - `instagram_content_publish`
-   - `pages_read_engagement`
-   - `pages_show_list`
-5. Click **Generate Access Token** and complete the OAuth consent flow.
-6. Select the Instagram account you want to publish from, click **Save**, then **Got it**.
-
-The token shown in the Explorer is a **short-lived User Access Token** valid for approximately **1–2 hours**.
+> If this step is skipped, all API calls will return error code `10` (*Permission Denied*) even with a valid token.
 
 ---
 
-## Step 8 — Exchange for a Long-Lived Access Token
+## Step 6 — Generate a Short-Lived Access Token
 
-Short-lived tokens are not usable in production. Exchange them for a **long-lived token** (valid 60 days).
+With Instagram Login, token generation uses Instagram's own OAuth flow, not the Graph API Explorer.
 
-Call the following endpoint from a browser or curl:
+### Option A — Via the App Dashboard (quickest for initial setup)
 
-```
-GET https://graph.facebook.com/v20.0/oauth/access_token
-  ?grant_type=fb_exchange_token
-  &client_id={your-app-id}
-  &client_secret={your-app-secret}
-  &fb_exchange_token={short-lived-token}
-```
+1. In the app dashboard, go to the **Instagram → API setup with Instagram login** section.
+2. Click **Generate Token** next to your Instagram account.
+3. Complete the Instagram OAuth consent screen, granting `instagram_business_basic` and `instagram_business_content_publish`.
+4. Copy the **Instagram User Access Token** displayed.
 
-- `{your-app-id}` and `{your-app-secret}` are found in the app dashboard under **App Settings → Basic**.
-- The response contains `access_token` (the long-lived token) and `expires_in` (seconds, approximately 5,184,000 ≈ 60 days).
+### Option B — Via OAuth URL (for automation or re-generation)
 
-Verify the token and confirm its scopes via the **Access Token Debugger**:
+Construct the authorization URL:
 
 ```
-https://developers.facebook.com/tools/debug/accesstoken/
+https://api.instagram.com/oauth/authorize
+  ?client_id={instagram-app-id}
+  &redirect_uri={your-redirect-uri}
+  &scope=instagram_business_basic,instagram_business_content_publish
+  &response_type=code
 ```
 
-Paste the token and click **Debug**. Confirm:
-- **Type**: User
-- **Expires**: ~60 days from now
-- **Scopes**: includes `instagram_basic`, `instagram_content_publish`, `pages_read_engagement`
+After the user authorizes, Instagram redirects to `{redirect_uri}?code={auth-code}`. Exchange the code for a token:
 
-> ⚠️ Long-lived tokens expire after **60 days**. To avoid disruption, renew them **before day 50** by calling the same exchange endpoint with the still-valid long-lived token.
+```
+POST https://api.instagram.com/oauth/access_token
+
+Content-Type: application/x-www-form-urlencoded
+client_id={instagram-app-id}
+client_secret={instagram-app-secret}
+grant_type=authorization_code
+redirect_uri={your-redirect-uri}
+code={auth-code}
+```
+
+The response contains a **short-lived Instagram User Access Token** valid for **1 hour**.
 
 ---
 
-## Step 9 — Retrieve the Instagram Account ID
+## Step 7 — Exchange for a Long-Lived Access Token
 
-The numeric Instagram Account ID (`IG_ACCOUNT_ID`) is needed to form API request URLs.
+Short-lived tokens are not suitable for production. Exchange for a **long-lived token** (valid 60 days):
 
-**Step 9a** — Get your Facebook Pages:
 ```
-GET https://graph.facebook.com/v20.0/me/accounts
-  ?access_token={long-lived-token}
-```
-Note the `id` of the Page connected to your Instagram account.
-
-**Step 9b** — Get the linked Instagram Business Account ID:
-```
-GET https://graph.facebook.com/v20.0/{page-id}
-  ?fields=instagram_business_account
-  &access_token={long-lived-token}
+GET https://graph.instagram.com/access_token
+  ?grant_type=ig_exchange_token
+  &client_secret={instagram-app-secret}
+  &access_token={short-lived-token}
 ```
 
 The response contains:
 ```json
 {
-  "instagram_business_account": {
-    "id": "17841400000000000"
-  },
-  "id": "{page-id}"
+  "access_token": "IGAAx...",
+  "token_type": "bearer",
+  "expires_in": 5183944
 }
 ```
 
-The `instagram_business_account.id` value is your `IG_ACCOUNT_ID`.
+`expires_in` is in seconds — approximately 60 days.
 
-Alternatively, from the **Graph API Explorer**, search the `instagram_business_account.id` field from the debugger output under **Granular Scopes → instagram_basic**.
+### Refresh before expiry
+
+Before the token expires (renew from day 50 onwards), call:
+
+```
+GET https://graph.instagram.com/refresh_access_token
+  ?grant_type=ig_refresh_token
+  &access_token={long-lived-token}
+```
+
+This resets the expiry to a fresh 60 days. The same token value is returned with an updated `expires_in`.
+
+> ⚠️ Note: both exchange and refresh calls target `graph.instagram.com`, **not** `graph.facebook.com`. This is a key difference from the Facebook Login flow.
 
 ---
 
-## Step 10 — App Review (Production Only)
+## Step 8 — Retrieve the Instagram Account ID
 
-In **Development mode**, everything above works only for accounts with a role in the app (Admins, Testers). This is sufficient for a single-owner automation.
+The Instagram Account ID (`IG_ACCOUNT_ID`) is required to construct API request URLs.
 
-If the app needs to act on behalf of **third-party Instagram accounts**, it must pass **Meta App Review**:
+With Instagram Login, the ID is retrieved directly — no Facebook Page lookup is needed:
+
+```
+GET https://graph.instagram.com/v22.0/me
+  ?fields=id,name,username
+  &access_token={long-lived-token}
+```
+
+Example response:
+```json
+{
+  "id": "17841400000000000",
+  "name": "Your Name",
+  "username": "yourusername"
+}
+```
+
+The `id` value is your `IG_ACCOUNT_ID`. Store it in the `IG_ACCOUNT_ID` app setting.
+
+---
+
+## Step 9 — App Review (Production Only)
+
+In **Development mode**, the setup above works only for accounts added as Testers (Step 5). For a private single-account automation like XPoster, **App Review is not required**.
+
+App Review is only needed if the app will publish on behalf of **third-party Instagram accounts** (i.e., other users' accounts via OAuth). In that case:
 
 1. Go to **App Review → Permissions and Features**.
-2. Request each permission used (`instagram_content_publish`, etc.).
-3. Provide screen recordings and a written description of how the app uses each permission.
+2. Request `instagram_business_basic` and `instagram_business_content_publish`.
+3. Provide screen recordings and usage descriptions.
 4. Switch the app to **Live mode** after approval.
 
-> For a private automation (posting to your own account only), App Review is **not required**. Development mode is sufficient indefinitely.
+---
+
+## App Settings Reference
+
+At the end of this setup, you will have the following values to store securely (e.g. Azure Key Vault):
+
+| Setting | Where to find it |
+|---|---|
+| `IG_ACCESS_TOKEN` | Generated in Step 7 (long-lived token) |
+| `IG_ACCOUNT_ID` | Retrieved in Step 8 (`/me?fields=id`) |
+
+> Never commit tokens to source control or expose them in logs.
 
 ---
 
 ## Token Management Summary
 
-| Token type | Validity | Use |
-|---|---|---|
-| Short-lived User Token | ~1–2 hours | Only for generating long-lived tokens |
-| Long-lived User Token | 60 days | Use in production; renew before day 50 |
-| Page Token | Never expires | Not used for Instagram content publishing |
-
-> Tokens must be stored securely (e.g. Azure Key Vault). Never commit tokens to source control or expose them in logs.
+| Token type | Validity | Host | Notes |
+|---|---|---|---|
+| Short-lived Instagram User Token | ~1 hour | `api.instagram.com` | Only used to generate long-lived token |
+| Long-lived Instagram User Token | 60 days | `graph.instagram.com` | Use in production; refresh before day 50 |
 
 ---
 
 ## Image Requirements
 
-The Instagram Graph API enforces strict constraints on images submitted for publishing:
-
 | Constraint | Requirement |
 |---|---|
-| Format | JPEG only (PNG, GIF, MPO, JPS not accepted) |
+| Format | **JPEG only** (PNG, GIF, MPO, JPS not accepted) |
 | Aspect ratio | Between 4:5 (portrait) and 1.91:1 (landscape) |
 | Minimum width | 320 px |
 | Maximum width | 1440 px |
 | Maximum file size | 8 MB |
 | Color space | sRGB recommended |
 
-Images must be hosted at a **publicly accessible URL** (direct JPEG URL, no authentication, no redirects). Sharing links from Google Drive, OneDrive, or similar services are rejected by Meta’s media pipeline.
+Images must be hosted at a **direct, publicly accessible URL** — no authentication, no redirects. Sharing links from Google Drive, OneDrive, or similar services are rejected by Meta's media pipeline.
 
 ---
 
@@ -227,7 +251,7 @@ Images must be hosted at a **publicly accessible URL** (direct JPEG URL, no auth
 
 | Limit | Value |
 |---|---|
-| Content publishing | 25 posts per 24 hours per account |
+| Content publishing | **50 posts per 24 hours** per account |
 | API calls | 200 calls per hour per user token |
 
 Exceeding the publishing limit returns HTTP `429`. The `Retry-After` header indicates when the limit resets.
@@ -236,9 +260,9 @@ Exceeding the publishing limit returns HTTP `429`. The `Retry-After` header indi
 
 ## References
 
+- [Instagram Platform Overview](https://developers.facebook.com/documentation/instagram-platform)
+- [Instagram API with Instagram Login — Content Publishing](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/content-publishing/)
+- [Instagram API with Instagram Login — Overview](https://developers.facebook.com/docs/instagram-platform/overview/)
 - [Meta Developer Portal](https://developers.facebook.com)
-- [Graph API Explorer](https://developers.facebook.com/tools/explorer)
 - [Access Token Debugger](https://developers.facebook.com/tools/debug/accesstoken/)
-- [Instagram Graph API — IG User Media endpoint](https://developers.facebook.com/docs/instagram-platform/instagram-graph-api/reference/ig-user/media/)
-- [Instagram Graph API — Content Publishing guide](https://developers.facebook.com/docs/instagram-platform/content-publishing)
-- [Meta Business Suite](https://business.facebook.com)
+- Tracking issue: [#72](https://github.com/artcava/XPoster/issues/72)

--- a/docs/integrations/SenderPlugins/setup-instagram.md
+++ b/docs/integrations/SenderPlugins/setup-instagram.md
@@ -1,151 +1,244 @@
-# Instagram Setup
+# Instagram Account Setup
 
-> ⚠️ **Not yet active** — Instagram support is tracked in [#72](https://github.com/artcava/XPoster/issues/72). The sender plugin (`IgSender`) exists but is not production-ready. Do not enable Instagram slots in `OrchestratorFactory` until all prerequisites below are satisfied.
-
-## Overview
-
-XPoster publishes image posts to Instagram via the **Instagram Graph API v20.0** using a two-step flow:
-1. Create a media container (`POST /{ig-user-id}/media`)
-2. Publish the container (`POST /{ig-user-id}/media_publish`)
-
-The API requires the image to be hosted at a **publicly accessible URL** (no redirects, no authentication). XPoster uses Azure Blob Storage to serve this URL.
+> This document covers **only** the Instagram and Meta platform configuration required to enable programmatic publishing via the Instagram Graph API. For XPoster integration details, see [issue #72](https://github.com/artcava/XPoster/issues/72).
 
 ---
 
-## Account Requirements
+## Prerequisites
 
-> ⚠️ The Instagram Graph API is **not available for personal accounts**. It is exclusively designed for Business and Creator accounts.
+Before starting, verify you have:
 
-The Basic Display API (which supported personal accounts) was deprecated and shut down in 2024. As of 2026, the only supported path for programmatic publishing is the Graph API, which requires:
-
-- An **Instagram Business or Creator** account (not a personal/private account)
-- The account must be **connected to a Facebook Page**
-- A **Meta Developer App** of type Business with the Instagram Graph API product added
-
-Converting a personal account to Business/Creator is free and can be done from Instagram app settings → Account → Switch to Professional Account.
+- A **Facebook personal account** (required to own a Business Page and a Meta Developer App)
+- An **Instagram account** (personal is fine as a starting point — it will be converted to Business/Creator)
+- Access to the **Meta Developer Portal**: [developers.facebook.com](https://developers.facebook.com)
 
 ---
 
-## Part 1 — Instagram Platform Prerequisites (Manual)
+## Step 1 — Convert Instagram to a Business or Creator Account
 
-Complete these steps before any code deployment. They are one-time manual operations.
+The Instagram Graph API is **not available for personal accounts**. The Instagram Basic Display API, which historically served personal accounts, was **deprecated and shut down in 2024**. As of 2026, the only supported path for programmatic publishing is the Graph API, which requires a **Professional account** (Business or Creator).
 
-### 1.1 Meta Developer App
+Conversion is free and reversible:
 
-1. Go to [Meta for Developers](https://developers.facebook.com) and create a new app (type: **Business**).
-2. Add the **Instagram Graph API** product to the app.
-3. In App Review, request the following permissions:
+1. Open the Instagram app.
+2. Go to **Settings → Account → Switch to Professional Account**.
+3. Choose **Business** (recommended for API publishing) or **Creator**.
+4. Select a category and complete the optional contact info step.
+
+> ✅ After conversion the account remains fully usable for normal Instagram activity. No content is lost.
+
+---
+
+## Step 2 — Create a Facebook Page
+
+The Instagram Graph API routes all requests through a **Facebook Page**. An Instagram Business account must be linked to a Page before the API can be used.
+
+If you don’t have a Page yet:
+
+1. On Facebook, click **Pages → Create new Page**.
+2. Give it a name (it can be a test page — it does not need to be public).
+3. Complete the minimal required fields and publish.
+
+---
+
+## Step 3 — Link Instagram to the Facebook Page
+
+1. Go to your Facebook Page.
+2. Open **Settings → Linked Accounts** (or **Professional Dashboard → Settings → Instagram**).
+3. Click **Connect Instagram**.
+4. Log in with your Instagram credentials and confirm the connection.
+
+Alternatively, via **Meta Business Suite** ([business.facebook.com](https://business.facebook.com)):
+
+1. Go to **Settings → Accounts → Instagram accounts**.
+2. Click **Add** and follow the OAuth flow.
+
+> ⚠️ This step is **mandatory**. Without the Page–Instagram link, all Graph API calls return an authorization error regardless of the token scopes.
+
+---
+
+## Step 4 — Create a Meta Developer App
+
+1. Go to [developers.facebook.com](https://developers.facebook.com) and log in.
+2. Click **My Apps → Create App**.
+3. Under **Use case**, select **Content Management** → **Manage messaging and content on Instagram**, then click **Next**.
+4. Optionally connect a Business Portfolio, then click **Next**.
+5. Give the app a name, enter a contact email, and click **Create App**.
+
+> The app type must be **Business**. Consumer-type apps cannot add the Instagram Graph API product.
+
+---
+
+## Step 5 — Add Instagram Graph API Product
+
+1. Inside the app dashboard, go to **Customize** under the *Manage messaging and content on Instagram* use case.
+2. Select **API Setup with Facebook Login**.
+3. Under **Permissions**, add all required scopes:
    - `instagram_basic`
    - `instagram_content_publish`
    - `pages_read_engagement`
+   - `pages_show_list`
 
-### 1.2 Connect Instagram to a Facebook Page
-
-1. In the Meta Business Suite, link your Instagram Business/Creator account to a Facebook Page.
-2. In the Meta Developer App, add the Facebook Page under **Instagram Graph API → Instagram Accounts**.
-
-### 1.3 Generate a Long-Lived Access Token
-
-1. Generate a short-lived User Access Token from the [Graph API Explorer](https://developers.facebook.com/tools/explorer/).
-2. Exchange it for a **long-lived token** (valid 60 days) via:
-   ```
-   GET https://graph.facebook.com/v20.0/oauth/access_token
-     ?grant_type=fb_exchange_token
-     &client_id={app-id}
-     &client_secret={app-secret}
-     &fb_exchange_token={short-lived-token}
-   ```
-3. Store the token in the `IG_ACCESS_TOKEN` app setting (Azure Key Vault or Function App Configuration).
-
-> ⚠️ Long-lived tokens expire after **60 days**. Manual rotation is required until a refresh flow is implemented (tracked separately).
-
-### 1.4 Retrieve the Instagram Account ID
-
-```
-GET https://graph.facebook.com/v20.0/me/accounts?access_token={token}
-```
-From the response, locate your Page, then:
-```
-GET https://graph.facebook.com/v20.0/{page-id}?fields=instagram_business_account&access_token={token}
-```
-Store the returned `id` in the `IG_ACCOUNT_ID` app setting.
+> In **Development mode** these permissions are available immediately without App Review, but they only work for accounts explicitly added as Testers or Administrators of the app (see Step 6).
 
 ---
 
-## Part 2 — Azure Blob Storage Setup
+## Step 6 — Add Your Instagram Account as a Tester
 
-Instagram requires images to be served from a public URL. XPoster uses Azure Blob Storage for this purpose.
+While the app is in Development mode (the default state), the API only accepts requests on behalf of accounts that have been granted a role in the app.
 
-1. Create (or reuse) an **Azure Storage Account** in the same resource group as the Function App.
-2. Create a container named `xposter-images` with **Blob (anonymous read)** access level.
-3. Add a **lifecycle rule** to auto-delete blobs older than 1 day (images are ephemeral — only needed during API processing).
-4. For production, prefer **Managed Identity** with `DefaultAzureCredential` and the `Storage Blob Data Contributor` role assigned to the Function App identity.
+1. In the app dashboard, go to **App Roles → Roles**.
+2. Under **Testers**, click **Add** and enter the Facebook account linked to your Instagram.
+3. The invited account must **accept the invitation**: open Facebook Notifications → accept the developer role.
+4. On Instagram, also go to **Settings → Apps and Websites** and verify the app appears as authorized.
 
-> ⚠️ The blob URL passed to Instagram must be a **direct JPEG file URL** with no redirects. Google Drive, OneDrive, and similar sharing links are rejected by Meta's media upload pipeline.
+> If you skip this step, token generation will succeed but API calls will return error code `10` (*Not authorized*).
 
 ---
 
-## Part 3 — App Settings
+## Step 7 — Generate a Short-Lived Access Token
 
-Add the following settings to the Function App Configuration (or `local.settings.json` for local development):
+1. Open the **Graph API Explorer**: [developers.facebook.com/tools/explorer](https://developers.facebook.com/tools/explorer)
+2. In the top-right dropdown, select the app you just created.
+3. Click **Get Token → Get User Access Token**.
+4. In the permissions dialog, check:
+   - `instagram_basic`
+   - `instagram_content_publish`
+   - `pages_read_engagement`
+   - `pages_show_list`
+5. Click **Generate Access Token** and complete the OAuth consent flow.
+6. Select the Instagram account you want to publish from, click **Save**, then **Got it**.
 
-| Variable | Required | Description |
+The token shown in the Explorer is a **short-lived User Access Token** valid for approximately **1–2 hours**.
+
+---
+
+## Step 8 — Exchange for a Long-Lived Access Token
+
+Short-lived tokens are not usable in production. Exchange them for a **long-lived token** (valid 60 days).
+
+Call the following endpoint from a browser or curl:
+
+```
+GET https://graph.facebook.com/v20.0/oauth/access_token
+  ?grant_type=fb_exchange_token
+  &client_id={your-app-id}
+  &client_secret={your-app-secret}
+  &fb_exchange_token={short-lived-token}
+```
+
+- `{your-app-id}` and `{your-app-secret}` are found in the app dashboard under **App Settings → Basic**.
+- The response contains `access_token` (the long-lived token) and `expires_in` (seconds, approximately 5,184,000 ≈ 60 days).
+
+Verify the token and confirm its scopes via the **Access Token Debugger**:
+
+```
+https://developers.facebook.com/tools/debug/accesstoken/
+```
+
+Paste the token and click **Debug**. Confirm:
+- **Type**: User
+- **Expires**: ~60 days from now
+- **Scopes**: includes `instagram_basic`, `instagram_content_publish`, `pages_read_engagement`
+
+> ⚠️ Long-lived tokens expire after **60 days**. To avoid disruption, renew them **before day 50** by calling the same exchange endpoint with the still-valid long-lived token.
+
+---
+
+## Step 9 — Retrieve the Instagram Account ID
+
+The numeric Instagram Account ID (`IG_ACCOUNT_ID`) is needed to form API request URLs.
+
+**Step 9a** — Get your Facebook Pages:
+```
+GET https://graph.facebook.com/v20.0/me/accounts
+  ?access_token={long-lived-token}
+```
+Note the `id` of the Page connected to your Instagram account.
+
+**Step 9b** — Get the linked Instagram Business Account ID:
+```
+GET https://graph.facebook.com/v20.0/{page-id}
+  ?fields=instagram_business_account
+  &access_token={long-lived-token}
+```
+
+The response contains:
+```json
+{
+  "instagram_business_account": {
+    "id": "17841400000000000"
+  },
+  "id": "{page-id}"
+}
+```
+
+The `instagram_business_account.id` value is your `IG_ACCOUNT_ID`.
+
+Alternatively, from the **Graph API Explorer**, search the `instagram_business_account.id` field from the debugger output under **Granular Scopes → instagram_basic**.
+
+---
+
+## Step 10 — App Review (Production Only)
+
+In **Development mode**, everything above works only for accounts with a role in the app (Admins, Testers). This is sufficient for a single-owner automation.
+
+If the app needs to act on behalf of **third-party Instagram accounts**, it must pass **Meta App Review**:
+
+1. Go to **App Review → Permissions and Features**.
+2. Request each permission used (`instagram_content_publish`, etc.).
+3. Provide screen recordings and a written description of how the app uses each permission.
+4. Switch the app to **Live mode** after approval.
+
+> For a private automation (posting to your own account only), App Review is **not required**. Development mode is sufficient indefinitely.
+
+---
+
+## Token Management Summary
+
+| Token type | Validity | Use |
 |---|---|---|
-| `IG_ACCESS_TOKEN` | ✅ | Long-lived Instagram Graph API access token |
-| `IG_ACCOUNT_ID` | ✅ | Instagram Business Account numeric ID |
-| `AZURE_STORAGE_CONNECTION_STRING` | ✅ | Azure Storage connection string (or use Managed Identity) |
-| `AZURE_STORAGE_CONTAINER_NAME` | Optional | Blob container name (default: `xposter-images`) |
+| Short-lived User Token | ~1–2 hours | Only for generating long-lived tokens |
+| Long-lived User Token | 60 days | Use in production; renew before day 50 |
+| Page Token | Never expires | Not used for Instagram content publishing |
 
-All secrets must be stored in **Azure Key Vault** and referenced via the Key Vault Configuration Provider. Never hardcode tokens or connection strings.
-
----
-
-## Part 4 — Image Requirements
-
-The Instagram Graph API enforces strict image constraints:
-
-- **Format**: JPEG only (PNG, MPO, JPS are not supported)
-- **Aspect ratio**: between 4:5 and 1.91:1
-- **Minimum width**: 320px
-- **Maximum width**: 1440px
-- **Maximum file size**: 8 MB
-
-`IgSender` validates the JPEG format via magic bytes (`FF D8`) before uploading. Posts with non-JPEG images are rejected with a warning log and `return false`.
+> Tokens must be stored securely (e.g. Azure Key Vault). Never commit tokens to source control or expose them in logs.
 
 ---
 
-## Part 5 — Known Limitations and Production Gaps
+## Image Requirements
 
-The following issues are tracked in [#72](https://github.com/artcava/XPoster/issues/72) and must be resolved before enabling Instagram slots in production:
+The Instagram Graph API enforces strict constraints on images submitted for publishing:
 
-| # | Gap | Status |
-|---|---|---|
-| 1 | `UploadImageToPublicUrl` throws `NotImplementedException` | 🔴 Open |
-| 2 | `IBlobStorageService` not yet implemented or registered | 🔴 Open |
-| 3 | `access_token` currently sent in JSON body (must be query param) | 🟠 Open |
-| 4 | Raw API error response logged (may echo token) | 🟠 Open |
-| 5 | No Polly retry-after handling for HTTP 429 (25 posts/24h limit) | 🟡 Open |
-| 6 | No `container_status` polling before `/media_publish` | 🟡 Open |
-| 7 | Token expiry (60 days) — no automated refresh flow | 🟡 Open |
+| Constraint | Requirement |
+|---|---|
+| Format | JPEG only (PNG, GIF, MPO, JPS not accepted) |
+| Aspect ratio | Between 4:5 (portrait) and 1.91:1 (landscape) |
+| Minimum width | 320 px |
+| Maximum width | 1440 px |
+| Maximum file size | 8 MB |
+| Color space | sRGB recommended |
+
+Images must be hosted at a **publicly accessible URL** (direct JPEG URL, no authentication, no redirects). Sharing links from Google Drive, OneDrive, or similar services are rejected by Meta’s media pipeline.
 
 ---
 
-## Part 6 — Enabling Instagram Slots
+## Rate Limits
 
-Once all prerequisites are met and staging validation is complete, re-enable the Instagram time slots in `OrchestratorFactory`:
+| Limit | Value |
+|---|---|
+| Content publishing | 25 posts per 24 hours per account |
+| API calls | 200 calls per hour per user token |
 
-```csharp
-{ 10, MessageSender.IgSummaryFeed },
-{ 18, MessageSender.IgPowerLow },
-```
-
-This step is gated on successful end-to-end staging validation with a real Instagram Business account.
+Exceeding the publishing limit returns HTTP `429`. The `Retry-After` header indicates when the limit resets.
 
 ---
 
 ## References
 
-- [Instagram Graph API — Content Publishing](https://developers.facebook.com/docs/instagram-platform/instagram-graph-api/reference/ig-user/media/)
-- [IG User Media Publish endpoint](https://developers.facebook.com/docs/instagram-platform/instagram-graph-api/reference/ig-user/media_publish/)
-- [Meta for Developers — Graph API Explorer](https://developers.facebook.com/tools/explorer/)
-- Tracking issue: [#72](https://github.com/artcava/XPoster/issues/72)
+- [Meta Developer Portal](https://developers.facebook.com)
+- [Graph API Explorer](https://developers.facebook.com/tools/explorer)
+- [Access Token Debugger](https://developers.facebook.com/tools/debug/accesstoken/)
+- [Instagram Graph API — IG User Media endpoint](https://developers.facebook.com/docs/instagram-platform/instagram-graph-api/reference/ig-user/media/)
+- [Instagram Graph API — Content Publishing guide](https://developers.facebook.com/docs/instagram-platform/content-publishing)
+- [Meta Business Suite](https://business.facebook.com)

--- a/docs/integrations/SenderPlugins/setup-instagram.md
+++ b/docs/integrations/SenderPlugins/setup-instagram.md
@@ -1,15 +1,151 @@
 # Instagram Setup
 
-> ⚠️ **Not yet active** — Instagram support is planned but not yet implemented. See [#72](https://github.com/artcava/XPoster/issues/72) for tracking.
+> ⚠️ **Not yet active** — Instagram support is tracked in [#72](https://github.com/artcava/XPoster/issues/72). The sender plugin (`IgSender`) exists but is not production-ready. Do not enable Instagram slots in `OrchestratorFactory` until all prerequisites below are satisfied.
 
 ## Overview
 
-This page will document how to configure XPoster for Instagram publishing once the feature is implemented.
+XPoster publishes image posts to Instagram via the **Instagram Graph API v20.0** using a two-step flow:
+1. Create a media container (`POST /{ig-user-id}/media`)
+2. Publish the container (`POST /{ig-user-id}/media_publish`)
 
-## Status
+The API requires the image to be hosted at a **publicly accessible URL** (no redirects, no authentication). XPoster uses Azure Blob Storage to serve this URL.
 
-Instagram integration is currently a placeholder. No sender plugin is active for this platform.
+---
 
+## Account Requirements
+
+> ⚠️ The Instagram Graph API is **not available for personal accounts**. It is exclusively designed for Business and Creator accounts.
+
+The Basic Display API (which supported personal accounts) was deprecated and shut down in 2024. As of 2026, the only supported path for programmatic publishing is the Graph API, which requires:
+
+- An **Instagram Business or Creator** account (not a personal/private account)
+- The account must be **connected to a Facebook Page**
+- A **Meta Developer App** of type Business with the Instagram Graph API product added
+
+Converting a personal account to Business/Creator is free and can be done from Instagram app settings → Account → Switch to Professional Account.
+
+---
+
+## Part 1 — Instagram Platform Prerequisites (Manual)
+
+Complete these steps before any code deployment. They are one-time manual operations.
+
+### 1.1 Meta Developer App
+
+1. Go to [Meta for Developers](https://developers.facebook.com) and create a new app (type: **Business**).
+2. Add the **Instagram Graph API** product to the app.
+3. In App Review, request the following permissions:
+   - `instagram_basic`
+   - `instagram_content_publish`
+   - `pages_read_engagement`
+
+### 1.2 Connect Instagram to a Facebook Page
+
+1. In the Meta Business Suite, link your Instagram Business/Creator account to a Facebook Page.
+2. In the Meta Developer App, add the Facebook Page under **Instagram Graph API → Instagram Accounts**.
+
+### 1.3 Generate a Long-Lived Access Token
+
+1. Generate a short-lived User Access Token from the [Graph API Explorer](https://developers.facebook.com/tools/explorer/).
+2. Exchange it for a **long-lived token** (valid 60 days) via:
+   ```
+   GET https://graph.facebook.com/v20.0/oauth/access_token
+     ?grant_type=fb_exchange_token
+     &client_id={app-id}
+     &client_secret={app-secret}
+     &fb_exchange_token={short-lived-token}
+   ```
+3. Store the token in the `IG_ACCESS_TOKEN` app setting (Azure Key Vault or Function App Configuration).
+
+> ⚠️ Long-lived tokens expire after **60 days**. Manual rotation is required until a refresh flow is implemented (tracked separately).
+
+### 1.4 Retrieve the Instagram Account ID
+
+```
+GET https://graph.facebook.com/v20.0/me/accounts?access_token={token}
+```
+From the response, locate your Page, then:
+```
+GET https://graph.facebook.com/v20.0/{page-id}?fields=instagram_business_account&access_token={token}
+```
+Store the returned `id` in the `IG_ACCOUNT_ID` app setting.
+
+---
+
+## Part 2 — Azure Blob Storage Setup
+
+Instagram requires images to be served from a public URL. XPoster uses Azure Blob Storage for this purpose.
+
+1. Create (or reuse) an **Azure Storage Account** in the same resource group as the Function App.
+2. Create a container named `xposter-images` with **Blob (anonymous read)** access level.
+3. Add a **lifecycle rule** to auto-delete blobs older than 1 day (images are ephemeral — only needed during API processing).
+4. For production, prefer **Managed Identity** with `DefaultAzureCredential` and the `Storage Blob Data Contributor` role assigned to the Function App identity.
+
+> ⚠️ The blob URL passed to Instagram must be a **direct JPEG file URL** with no redirects. Google Drive, OneDrive, and similar sharing links are rejected by Meta's media upload pipeline.
+
+---
+
+## Part 3 — App Settings
+
+Add the following settings to the Function App Configuration (or `local.settings.json` for local development):
+
+| Variable | Required | Description |
+|---|---|---|
+| `IG_ACCESS_TOKEN` | ✅ | Long-lived Instagram Graph API access token |
+| `IG_ACCOUNT_ID` | ✅ | Instagram Business Account numeric ID |
+| `AZURE_STORAGE_CONNECTION_STRING` | ✅ | Azure Storage connection string (or use Managed Identity) |
+| `AZURE_STORAGE_CONTAINER_NAME` | Optional | Blob container name (default: `xposter-images`) |
+
+All secrets must be stored in **Azure Key Vault** and referenced via the Key Vault Configuration Provider. Never hardcode tokens or connection strings.
+
+---
+
+## Part 4 — Image Requirements
+
+The Instagram Graph API enforces strict image constraints:
+
+- **Format**: JPEG only (PNG, MPO, JPS are not supported)
+- **Aspect ratio**: between 4:5 and 1.91:1
+- **Minimum width**: 320px
+- **Maximum width**: 1440px
+- **Maximum file size**: 8 MB
+
+`IgSender` validates the JPEG format via magic bytes (`FF D8`) before uploading. Posts with non-JPEG images are rejected with a warning log and `return false`.
+
+---
+
+## Part 5 — Known Limitations and Production Gaps
+
+The following issues are tracked in [#72](https://github.com/artcava/XPoster/issues/72) and must be resolved before enabling Instagram slots in production:
+
+| # | Gap | Status |
+|---|---|---|
+| 1 | `UploadImageToPublicUrl` throws `NotImplementedException` | 🔴 Open |
+| 2 | `IBlobStorageService` not yet implemented or registered | 🔴 Open |
+| 3 | `access_token` currently sent in JSON body (must be query param) | 🟠 Open |
+| 4 | Raw API error response logged (may echo token) | 🟠 Open |
+| 5 | No Polly retry-after handling for HTTP 429 (25 posts/24h limit) | 🟡 Open |
+| 6 | No `container_status` polling before `/media_publish` | 🟡 Open |
+| 7 | Token expiry (60 days) — no automated refresh flow | 🟡 Open |
+
+---
+
+## Part 6 — Enabling Instagram Slots
+
+Once all prerequisites are met and staging validation is complete, re-enable the Instagram time slots in `OrchestratorFactory`:
+
+```csharp
+{ 10, MessageSender.IgSummaryFeed },
+{ 18, MessageSender.IgPowerLow },
+```
+
+This step is gated on successful end-to-end staging validation with a real Instagram Business account.
+
+---
+
+## References
+
+- [Instagram Graph API — Content Publishing](https://developers.facebook.com/docs/instagram-platform/instagram-graph-api/reference/ig-user/media/)
+- [IG User Media Publish endpoint](https://developers.facebook.com/docs/instagram-platform/instagram-graph-api/reference/ig-user/media_publish/)
+- [Meta for Developers — Graph API Explorer](https://developers.facebook.com/tools/explorer/)
 - Tracking issue: [#72](https://github.com/artcava/XPoster/issues/72)
-
-<!-- TODO: Fill in setup steps once Instagram sender plugin is implemented -->


### PR DESCRIPTION
## Summary

This PR adds and completes the Instagram platform setup documentation and introduces a token expiry reminder workflow, modeled after the existing LinkedIn one.

Closes part of #72 (Part 1 manual prerequisites documentation).

---

## Changes

### `docs/integrations/SenderPlugins/setup-instagram.md`

Fully rewritten from a placeholder stub. The guide now covers the complete **Instagram API with Facebook Login** flow, verified hands-on against the Meta Developer Platform (June 2026):

- Step 1: Convert Instagram account to Business/Creator
- Step 2: Connect Instagram to a Facebook Page
- Step 3: Create a Meta Developer App (Business type)
- Step 4: Add account as Administrator/Tester in Development mode
- Step 5: Generate short-lived token via Graph API Explorer with the four required permissions (`instagram_basic`, `instagram_content_publish`, `pages_show_list`, `pages_read_engagement`)
- Step 6: Exchange for a long-lived token (60 days) via `fb_exchange_token` on `graph.facebook.com`
- Step 7: Retrieve `IG_ACCOUNT_ID` via `/me/accounts` or directly via Page vanity name (`/{PageName}?fields=instagram_business_account`)
- Step 8: App Review guidance (not required for private single-account use)
- App Settings reference, Token Management table, Image Requirements, Rate Limits, References

> Note: an earlier iteration of this document described the **Instagram Login** flow (no Facebook Page required). That flow was found to be inapplicable to this project's configuration. The document now reflects the verified Facebook Login flow.

### `.github/workflows/instagram-token-reminder.yml`

New workflow modeled after `linkedin-token-reminder.yml`:

- Runs every Monday at 09:00 UTC
- Reads `INSTAGRAM_TOKEN_EXPIRY` repository variable
- Opens a labeled issue (`infrastructure`, `token-rotation`) when ≤ 14 days remain
- Issue body includes step-by-step renewal instructions (Graph API Explorer → `fb_exchange_token` → Azure Key Vault update)
- Deduplicates: skips if a reminder issue is already open
- Supports `workflow_dispatch` for manual testing

## Post-merge action required

Add the repository variable `INSTAGRAM_TOKEN_EXPIRY` in **Settings → Secrets and variables → Actions → Variables**:

- Name: `INSTAGRAM_TOKEN_EXPIRY`
- Value: `2026-08-26` (today + 60 days — adjust to the actual token expiry date)
