### PR TITLE
feat(#248): normalize AI provider options behind shared abstraction

### DIFF
--- a/src/Contracts/Enums/AiModelClass.cs
+++ b/src/Contracts/Enums/AiModelClass.cs
@@ -1,0 +1,13 @@
+namespace XPoster.Contracts;
+
+/// <summary>
+/// Represents a class of AI model capability that a provider may expose.
+/// </summary>
+public enum AiModelClass
+{
+    /// <summary>Text-to-text generation capability.</summary>
+    Text,
+
+    /// <summary>Text-to-image generation capability.</summary>
+    Image
+}

--- a/src/Contracts/Interfaces/IAiProviderOptions.cs
+++ b/src/Contracts/Interfaces/IAiProviderOptions.cs
@@ -1,0 +1,24 @@
+using XPoster.Models;
+
+namespace XPoster.Contracts;
+
+/// <summary>
+/// Shared abstraction for all AI provider option classes.
+/// Exposes the connectivity settings common to every provider and a normalized
+/// model catalog for capability discovery.
+/// </summary>
+public interface IAiProviderOptions
+{
+    /// <summary>Gets the API key used for authentication.</summary>
+    string ApiKey { get; }
+
+    /// <summary>Gets the provider endpoint base URL.</summary>
+    string Endpoint { get; }
+
+    /// <summary>
+    /// Gets the normalized model catalog for this provider.
+    /// Use <see cref="AiModelCatalog.Supports"/> or <see cref="AiModelCatalog.TryGet"/>
+    /// to check which model classes are available before accessing a model name.
+    /// </summary>
+    AiModelCatalog ModelCatalog { get; }
+}

--- a/src/Extensions/AiProviderOptionsCompositionExtensions.cs
+++ b/src/Extensions/AiProviderOptionsCompositionExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using XPoster.Models;
+
+namespace XPoster.Extensions;
+
+/// <summary>
+/// Registers all AI provider option bindings and validators in a single startup call.
+/// </summary>
+public static class AiProviderOptionsCompositionExtensions
+{
+    /// <summary>
+    /// Binds and validates all AI provider option sections
+    /// (<c>OpenAI</c>, <c>AzureFoundry</c>, <c>DeepSeek</c>, <c>FalAi</c>, <c>Perplexity</c>)
+    /// in one call.  This is the only entrypoint <c>Program.cs</c> needs for AI option wiring.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns>The same <see cref="IServiceCollection"/> for chaining.</returns>
+    public static IServiceCollection AddAiProviderOptions(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddOpenAiOptions(configuration);
+        services.AddAzureFoundryOptions(configuration);
+        services.AddDeepSeekOptions(configuration);
+        services.AddFalAiOptions(configuration);
+        services.AddPerplexityOptions(configuration);
+        return services;
+    }
+}

--- a/src/Models/AiModelCatalog.cs
+++ b/src/Models/AiModelCatalog.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics.CodeAnalysis;
+using XPoster.Contracts;
+
+namespace XPoster.Models;
+
+/// <summary>
+/// Holds the model names that an AI provider exposes, keyed by <see cref="AiModelClass"/>.
+/// Provides safe capability lookup without exposing raw dictionary semantics to consumers.
+/// </summary>
+public sealed class AiModelCatalog
+{
+    /// <summary>An empty catalog representing a provider with no registered models.</summary>
+    public static readonly AiModelCatalog Empty = new(new Dictionary<AiModelClass, string>());
+
+    private readonly IReadOnlyDictionary<AiModelClass, string> _models;
+
+    /// <summary>
+    /// Initialises a new <see cref="AiModelCatalog"/> from the given model name map.
+    /// Entries with null or whitespace model names are silently excluded.
+    /// </summary>
+    public AiModelCatalog(IReadOnlyDictionary<AiModelClass, string> models)
+    {
+        ArgumentNullException.ThrowIfNull(models);
+        _models = models
+            .Where(kv => !string.IsNullOrWhiteSpace(kv.Value))
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the provider has a model configured for the given
+    /// <paramref name="modelClass"/> and populates <paramref name="modelName"/>.
+    /// </summary>
+    public bool TryGet(AiModelClass modelClass, [NotNullWhen(true)] out string? modelName)
+        => _models.TryGetValue(modelClass, out modelName);
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the provider has a model configured for the given
+    /// <paramref name="modelClass"/>.
+    /// </summary>
+    public bool Supports(AiModelClass modelClass) => _models.ContainsKey(modelClass);
+
+    /// <summary>
+    /// Returns the model name for the given <paramref name="modelClass"/>.
+    /// Throws <see cref="InvalidOperationException"/> if the capability is not supported.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the provider does not support <paramref name="modelClass"/>.
+    /// </exception>
+    public string GetRequired(AiModelClass modelClass)
+    {
+        if (!_models.TryGetValue(modelClass, out var name))
+            throw new InvalidOperationException(
+                $"This provider does not support the '{modelClass}' model class.");
+        return name;
+    }
+}

--- a/src/Models/AiProviderValidationHelper.cs
+++ b/src/Models/AiProviderValidationHelper.cs
@@ -1,0 +1,28 @@
+namespace XPoster.Models;
+
+/// <summary>
+/// Shared validation building blocks for AI provider options validators.
+/// Centralises repeated connectivity checks so each validator only adds
+/// its provider-specific rules on top.
+/// </summary>
+internal static class AiProviderValidationHelper
+{
+    /// <summary>
+    /// Appends failure messages for missing <paramref name="apiKey"/> or
+    /// <paramref name="endpoint"/> values. Property names appear in each message
+    /// so failures remain identifiable across providers.
+    /// </summary>
+    internal static void ValidateConnectivity(
+        string apiKey,
+        string endpoint,
+        List<string> failures,
+        string apiKeyPropertyName,
+        string endpointPropertyName)
+    {
+        if (string.IsNullOrWhiteSpace(apiKey))
+            failures.Add($"{apiKeyPropertyName} is required.");
+
+        if (string.IsNullOrWhiteSpace(endpoint))
+            failures.Add($"{endpointPropertyName} must not be empty.");
+    }
+}

--- a/src/Models/AzureFoundry/AzureFoundryOptions.cs
+++ b/src/Models/AzureFoundry/AzureFoundryOptions.cs
@@ -1,9 +1,11 @@
+using XPoster.Contracts;
+
 namespace XPoster.Models;
 
 /// <summary>
 /// Strongly-typed configuration for the Azure AI Foundry provider, bound from the <c>AzureFoundry</c> section.
 /// </summary>
-public sealed class AzureFoundryOptions
+public sealed class AzureFoundryOptions : IAiProviderOptions
 {
     /// <summary>Gets or sets the Foundry endpoint base URL (for example, <c>https://resource-name.services.ai.azure.com/openai/v1</c>).</summary>
     public string Endpoint { get; set; } = string.Empty;
@@ -16,4 +18,11 @@ public sealed class AzureFoundryOptions
 
     /// <summary>Gets or sets the image generation deployment name.</summary>
     public string ImageModelName { get; set; } = string.Empty;
+
+    /// <inheritdoc/>
+    public AiModelCatalog ModelCatalog => new(new Dictionary<AiModelClass, string>
+    {
+        [AiModelClass.Text] = TextModelName,
+        [AiModelClass.Image] = ImageModelName
+    });
 }

--- a/src/Models/AzureFoundry/AzureFoundryOptionsValidator.cs
+++ b/src/Models/AzureFoundry/AzureFoundryOptionsValidator.cs
@@ -12,11 +12,12 @@ public sealed class AzureFoundryOptionsValidator : IValidateOptions<AzureFoundry
     {
         var failures = new List<string>();
 
-        if (string.IsNullOrWhiteSpace(options.Endpoint))
-            failures.Add($"{nameof(AzureFoundryOptions.Endpoint)} is required.");
-
-        if (string.IsNullOrWhiteSpace(options.ApiKey))
-            failures.Add($"{nameof(AzureFoundryOptions.ApiKey)} is required.");
+        AiProviderValidationHelper.ValidateConnectivity(
+            options.ApiKey,
+            options.Endpoint,
+            failures,
+            nameof(AzureFoundryOptions.ApiKey),
+            nameof(AzureFoundryOptions.Endpoint));
 
         if (string.IsNullOrWhiteSpace(options.TextModelName))
             failures.Add($"{nameof(AzureFoundryOptions.TextModelName)} is required.");

--- a/src/Models/DeepSeek/DeepSeekOptions.cs
+++ b/src/Models/DeepSeek/DeepSeekOptions.cs
@@ -1,9 +1,11 @@
+using XPoster.Contracts;
+
 namespace XPoster.Models;
 
 /// <summary>
 /// Strongly-typed configuration for the DeepSeek provider, bound from the <c>DeepSeek</c> section.
 /// </summary>
-public sealed class DeepSeekOptions
+public sealed class DeepSeekOptions : IAiProviderOptions
 {
     /// <summary>Gets or sets the DeepSeek endpoint base URL (for example, <c>https://api.deepseek.com</c>).</summary>
     public string Endpoint { get; set; } = "https://api.deepseek.com";
@@ -13,4 +15,10 @@ public sealed class DeepSeekOptions
 
     /// <summary>Gets or sets the chat/completions model name (e.g. <c>deepseek-chat</c>).</summary>
     public string TextModelName { get; set; } = "deepseek-chat";
+
+    /// <inheritdoc/>
+    public AiModelCatalog ModelCatalog => new(new Dictionary<AiModelClass, string>
+    {
+        [AiModelClass.Text] = TextModelName
+    });
 }

--- a/src/Models/DeepSeek/DeepSeekOptionsValidator.cs
+++ b/src/Models/DeepSeek/DeepSeekOptionsValidator.cs
@@ -12,11 +12,12 @@ public sealed class DeepSeekOptionsValidator : IValidateOptions<DeepSeekOptions>
     {
         var failures = new List<string>();
 
-        if (string.IsNullOrWhiteSpace(options.Endpoint))
-            failures.Add($"{nameof(DeepSeekOptions.Endpoint)} is required.");
-
-        if (string.IsNullOrWhiteSpace(options.ApiKey))
-            failures.Add($"{nameof(DeepSeekOptions.ApiKey)} is required.");
+        AiProviderValidationHelper.ValidateConnectivity(
+            options.ApiKey,
+            options.Endpoint,
+            failures,
+            nameof(DeepSeekOptions.ApiKey),
+            nameof(DeepSeekOptions.Endpoint));
 
         if (string.IsNullOrWhiteSpace(options.TextModelName))
             failures.Add($"{nameof(DeepSeekOptions.TextModelName)} is required.");

--- a/src/Models/FalAi/FalAiOptions.cs
+++ b/src/Models/FalAi/FalAiOptions.cs
@@ -1,11 +1,13 @@
+using XPoster.Contracts;
+
 namespace XPoster.Models;
 
 /// <summary>
 /// Strongly-typed configuration for the Fal.ai provider, bound from the <c>FalAi</c> section.
 /// </summary>
-public sealed class FalAiOptions
+public sealed class FalAiOptions : IAiProviderOptions
 {
-    /// <summary>/// Gets or sets the endpoint URL for the Fal.ai API.</summary>
+    /// <summary>Gets or sets the endpoint URL for the Fal.ai API.</summary>
     public string Endpoint { get; set; } = "https://fal.run";
     /// <summary>Gets or sets the API key used for authentication.</summary>
     public string ApiKey { get; set; } = string.Empty;
@@ -13,4 +15,10 @@ public sealed class FalAiOptions
     public string ImageModelName { get; set; } = "fal-ai/flux/schnell"; // FLUX.1 Turbo
     /// <summary>Gets or sets the number of inference steps for image generation.</summary>
     public int NumInferenceSteps { get; set; } = 4;
+
+    /// <inheritdoc/>
+    public AiModelCatalog ModelCatalog => new(new Dictionary<AiModelClass, string>
+    {
+        [AiModelClass.Image] = ImageModelName
+    });
 }

--- a/src/Models/FalAi/FalAiOptionsValidator.cs
+++ b/src/Models/FalAi/FalAiOptionsValidator.cs
@@ -14,11 +14,12 @@ public sealed class FalAiOptionsValidator : IValidateOptions<FalAiOptions>
     {
         var failures = new List<string>();
 
-        if (string.IsNullOrWhiteSpace(options.Endpoint))
-            failures.Add($"{nameof(FalAiOptions.Endpoint)} is required.");
-
-        if (string.IsNullOrWhiteSpace(options.ApiKey))
-            failures.Add($"{nameof(FalAiOptions.ApiKey)} is required.");
+        AiProviderValidationHelper.ValidateConnectivity(
+            options.ApiKey,
+            options.Endpoint,
+            failures,
+            nameof(FalAiOptions.ApiKey),
+            nameof(FalAiOptions.Endpoint));
 
         if (string.IsNullOrWhiteSpace(options.ImageModelName))
         {

--- a/src/Models/OpenAi/OpenAiOptions.cs
+++ b/src/Models/OpenAi/OpenAiOptions.cs
@@ -1,3 +1,5 @@
+using XPoster.Contracts;
+
 namespace XPoster.Models;
 
 /// <summary>
@@ -5,7 +7,7 @@ namespace XPoster.Models;
 /// Contains only connectivity and model-capability settings.
 /// Prompt data is supplied at runtime via <see cref="PromptRequest"/> / <see cref="ImagePromptRequest"/>.
 /// </summary>
-public sealed class OpenAiOptions
+public sealed class OpenAiOptions : IAiProviderOptions
 {
     /// <summary>Gets or sets the OpenAI API key used for authentication.</summary>
     public string ApiKey { get; set; } = string.Empty;
@@ -18,4 +20,11 @@ public sealed class OpenAiOptions
 
     /// <summary>Gets or sets the model used for image generation requests.</summary>
     public string ImageModelName { get; set; } = "gpt-image-1.5";
+
+    /// <inheritdoc/>
+    public AiModelCatalog ModelCatalog => new(new Dictionary<AiModelClass, string>
+    {
+        [AiModelClass.Text] = TextModelName,
+        [AiModelClass.Image] = ImageModelName
+    });
 }

--- a/src/Models/OpenAi/OpenAiOptionsValidator.cs
+++ b/src/Models/OpenAi/OpenAiOptionsValidator.cs
@@ -7,25 +7,21 @@ namespace XPoster.Models;
 /// </summary>
 public sealed class OpenAiOptionsValidator : IValidateOptions<OpenAiOptions>
 {
-    /// <summary>
-    /// Validates the specified <see cref="OpenAiOptions"/> instance.
-    /// </summary>
-    /// <param name="name"></param>
-    /// <param name="options"></param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public ValidateOptionsResult Validate(string? name, OpenAiOptions options)
     {
         var failures = new List<string>();
 
-        if (string.IsNullOrWhiteSpace(options.ApiKey))
-            failures.Add($"{nameof(OpenAiOptions.ApiKey)} is required.");
-
-        if (string.IsNullOrWhiteSpace(options.Endpoint))
-            failures.Add($"{nameof(OpenAiOptions.Endpoint)} must not be empty.");
+        AiProviderValidationHelper.ValidateConnectivity(
+            options.ApiKey,
+            options.Endpoint,
+            failures,
+            nameof(OpenAiOptions.ApiKey),
+            nameof(OpenAiOptions.Endpoint));
 
         if (string.IsNullOrWhiteSpace(options.TextModelName))
             failures.Add($"{nameof(OpenAiOptions.TextModelName)} is required.");
-    
+
         if (string.IsNullOrWhiteSpace(options.ImageModelName))
             failures.Add($"{nameof(OpenAiOptions.ImageModelName)} is required.");
 

--- a/src/Models/Perplexity/PerplexityOptions.cs
+++ b/src/Models/Perplexity/PerplexityOptions.cs
@@ -1,9 +1,11 @@
+using XPoster.Contracts;
+
 namespace XPoster.Models;
 
 /// <summary>
 /// Strongly-typed configuration for the Perplexity provider, bound from the <c>Perplexity</c> section.
 /// </summary>
-public sealed class PerplexityOptions
+public sealed class PerplexityOptions : IAiProviderOptions
 {
     /// <summary>Gets or sets the Perplexity endpoint base URL (for example, <c>https://api.perplexity.ai</c>).</summary>
     public string Endpoint { get; set; } = "https://api.perplexity.ai";
@@ -13,4 +15,10 @@ public sealed class PerplexityOptions
 
     /// <summary>Gets or sets the chat/completions model name (e.g. <c>sonar</c>).</summary>
     public string TextModelName { get; set; } = "sonar";
+
+    /// <inheritdoc/>
+    public AiModelCatalog ModelCatalog => new(new Dictionary<AiModelClass, string>
+    {
+        [AiModelClass.Text] = TextModelName
+    });
 }

--- a/src/Models/Perplexity/PerplexityOptionsValidator.cs
+++ b/src/Models/Perplexity/PerplexityOptionsValidator.cs
@@ -12,11 +12,12 @@ public sealed class PerplexityOptionsValidator : IValidateOptions<PerplexityOpti
     {
         var failures = new List<string>();
 
-        if (string.IsNullOrWhiteSpace(options.Endpoint))
-            failures.Add($"{nameof(PerplexityOptions.Endpoint)} is required.");
-
-        if (string.IsNullOrWhiteSpace(options.ApiKey))
-            failures.Add($"{nameof(PerplexityOptions.ApiKey)} is required.");
+        AiProviderValidationHelper.ValidateConnectivity(
+            options.ApiKey,
+            options.Endpoint,
+            failures,
+            nameof(PerplexityOptions.ApiKey),
+            nameof(PerplexityOptions.Endpoint));
 
         if (string.IsNullOrWhiteSpace(options.TextModelName))
             failures.Add($"{nameof(PerplexityOptions.TextModelName)} is required.");

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -104,13 +104,9 @@ builder.Services.Configure<TagReplacementOptions>(builder.Configuration.GetSecti
 builder.Services.AddSingleton<ITagReplacementProvider, ConfigurationTagReplacementProvider>();
 builder.Services.AddTransient<ITagReplacementService, TagReplacementService>();
 
-// AI provider options: each extension method owns its SectionName constant
-// and encapsulates Configure<T> + AddSingleton<IValidateOptions<T>> in one call.
-builder.Services.AddOpenAiOptions(builder.Configuration);
-builder.Services.AddAzureFoundryOptions(builder.Configuration);
-builder.Services.AddDeepSeekOptions(builder.Configuration);
-builder.Services.AddFalAiOptions(builder.Configuration);
-builder.Services.AddPerplexityOptions(builder.Configuration);
+// AI provider options: a single call binds and validates all AI provider sections
+// (OpenAI, AzureFoundry, DeepSeek, FalAi, Perplexity) via AddAiProviderOptions().
+builder.Services.AddAiProviderOptions(builder.Configuration);
 
 // Azure Blob Storage — BlobServiceClient registered as singleton per SDK best practice.
 // BlobStorageOptions binds AZURE_STORAGE_CONNECTION_STRING and AZURE_STORAGE_CONTAINER_NAME

--- a/tests/Extensions/AddAiProviderOptionsTests.cs
+++ b/tests/Extensions/AddAiProviderOptionsTests.cs
@@ -1,0 +1,166 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using XPoster.Extensions;
+using XPoster.Models;
+
+namespace XPoster.Tests.Extensions;
+
+/// <summary>
+/// Verifies the centralized <see cref="AiProviderOptionsCompositionExtensions.AddAiProviderOptions"/>
+/// entrypoint registers all AI provider option bindings and validators in a single call.
+/// </summary>
+public class AddAiProviderOptionsTests
+{
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static IConfiguration BuildAllProvidersConfig() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["OpenAI:ApiKey"] = "openai-key",
+                ["OpenAI:Endpoint"] = "https://api.openai.com/v1/",
+                ["OpenAI:TextModelName"] = "gpt-4.1-nano",
+                ["OpenAI:ImageModelName"] = "gpt-image-1.5",
+
+                ["AzureFoundry:ApiKey"] = "az-key",
+                ["AzureFoundry:Endpoint"] = "https://foundry.example.com",
+                ["AzureFoundry:TextModelName"] = "gpt-4.1-nano",
+                ["AzureFoundry:ImageModelName"] = "gpt-image-1",
+
+                ["DeepSeek:ApiKey"] = "ds-key",
+                ["DeepSeek:Endpoint"] = "https://api.deepseek.com",
+                ["DeepSeek:TextModelName"] = "deepseek-chat",
+
+                ["FalAi:ApiKey"] = "fal-key",
+                ["FalAi:Endpoint"] = "https://fal.run",
+                ["FalAi:ImageModelName"] = "fal-ai/flux/schnell",
+
+                ["Perplexity:ApiKey"] = "pplx-key",
+                ["Perplexity:Endpoint"] = "https://api.perplexity.ai",
+                ["Perplexity:TextModelName"] = "sonar",
+            })
+            .Build();
+
+    // ── Registration ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddAiProviderOptions_RegistersAllFiveOptionTypes()
+    {
+        var services = new ServiceCollection();
+        services.AddAiProviderOptions(BuildAllProvidersConfig());
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<IOptions<OpenAiOptions>>());
+        Assert.NotNull(provider.GetService<IOptions<AzureFoundryOptions>>());
+        Assert.NotNull(provider.GetService<IOptions<DeepSeekOptions>>());
+        Assert.NotNull(provider.GetService<IOptions<FalAiOptions>>());
+        Assert.NotNull(provider.GetService<IOptions<PerplexityOptions>>());
+    }
+
+    [Fact]
+    public void AddAiProviderOptions_RegistersAllFiveValidators()
+    {
+        var services = new ServiceCollection();
+        services.AddAiProviderOptions(BuildAllProvidersConfig());
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<IValidateOptions<OpenAiOptions>>());
+        Assert.NotNull(provider.GetService<IValidateOptions<AzureFoundryOptions>>());
+        Assert.NotNull(provider.GetService<IValidateOptions<DeepSeekOptions>>());
+        Assert.NotNull(provider.GetService<IValidateOptions<FalAiOptions>>());
+        Assert.NotNull(provider.GetService<IValidateOptions<PerplexityOptions>>());
+    }
+
+    [Fact]
+    public void AddAiProviderOptions_ReturnsSameServiceCollection()
+    {
+        var services = new ServiceCollection();
+
+        var returned = services.AddAiProviderOptions(BuildAllProvidersConfig());
+
+        Assert.Same(services, returned);
+    }
+
+    // ── Binding ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddAiProviderOptions_BindsOpenAiOptions_FromCorrectSection()
+    {
+        var services = new ServiceCollection();
+        services.AddAiProviderOptions(BuildAllProvidersConfig());
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<OpenAiOptions>>().Value;
+
+        Assert.Equal("openai-key", options.ApiKey);
+        Assert.Equal("gpt-4.1-nano", options.TextModelName);
+        Assert.Equal("gpt-image-1.5", options.ImageModelName);
+    }
+
+    [Fact]
+    public void AddAiProviderOptions_BindsAzureFoundryOptions_FromCorrectSection()
+    {
+        var services = new ServiceCollection();
+        services.AddAiProviderOptions(BuildAllProvidersConfig());
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<AzureFoundryOptions>>().Value;
+
+        Assert.Equal("az-key", options.ApiKey);
+        Assert.Equal("https://foundry.example.com", options.Endpoint);
+    }
+
+    [Fact]
+    public void AddAiProviderOptions_BindsDeepSeekOptions_FromCorrectSection()
+    {
+        var services = new ServiceCollection();
+        services.AddAiProviderOptions(BuildAllProvidersConfig());
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<DeepSeekOptions>>().Value;
+
+        Assert.Equal("ds-key", options.ApiKey);
+        Assert.Equal("deepseek-chat", options.TextModelName);
+    }
+
+    [Fact]
+    public void AddAiProviderOptions_BindsFalAiOptions_FromCorrectSection()
+    {
+        var services = new ServiceCollection();
+        services.AddAiProviderOptions(BuildAllProvidersConfig());
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<FalAiOptions>>().Value;
+
+        Assert.Equal("fal-key", options.ApiKey);
+        Assert.Equal("fal-ai/flux/schnell", options.ImageModelName);
+    }
+
+    [Fact]
+    public void AddAiProviderOptions_BindsPerplexityOptions_FromCorrectSection()
+    {
+        var services = new ServiceCollection();
+        services.AddAiProviderOptions(BuildAllProvidersConfig());
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<PerplexityOptions>>().Value;
+
+        Assert.Equal("pplx-key", options.ApiKey);
+        Assert.Equal("sonar", options.TextModelName);
+    }
+
+    // ── No duplicate registrations ────────────────────────────────────────────
+
+    [Fact]
+    public void AddAiProviderOptions_DoesNotDuplicateValidatorRegistrations_WhenCalledOnce()
+    {
+        var services = new ServiceCollection();
+        services.AddAiProviderOptions(BuildAllProvidersConfig());
+
+        var openAiValidators = services
+            .Count(sd => sd.ServiceType == typeof(IValidateOptions<OpenAiOptions>));
+
+        Assert.Equal(1, openAiValidators);
+    }
+}

--- a/tests/Models/AiModelCatalogTests.cs
+++ b/tests/Models/AiModelCatalogTests.cs
@@ -1,0 +1,116 @@
+using XPoster.Contracts;
+using XPoster.Models;
+
+namespace XPoster.Tests.Models;
+
+/// <summary>
+/// Unit tests for <see cref="AiModelCatalog"/>.
+/// </summary>
+public class AiModelCatalogTests
+{
+    // ── Construction ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Empty_SupportsNoModelClass()
+    {
+        Assert.False(AiModelCatalog.Empty.Supports(AiModelClass.Text));
+        Assert.False(AiModelCatalog.Empty.Supports(AiModelClass.Image));
+    }
+
+    [Fact]
+    public void Constructor_NullDictionary_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new AiModelCatalog(null!));
+    }
+
+    [Fact]
+    public void Constructor_ExcludesNullOrWhitespaceEntries()
+    {
+        var catalog = new AiModelCatalog(new Dictionary<AiModelClass, string>
+        {
+            [AiModelClass.Text] = "   ",
+            [AiModelClass.Image] = "image-model"
+        });
+
+        Assert.False(catalog.Supports(AiModelClass.Text));
+        Assert.True(catalog.Supports(AiModelClass.Image));
+    }
+
+    // ── Supports ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Supports_ReturnsTrueForRegisteredModelClass()
+    {
+        var catalog = new AiModelCatalog(new Dictionary<AiModelClass, string>
+        {
+            [AiModelClass.Text] = "gpt-4"
+        });
+
+        Assert.True(catalog.Supports(AiModelClass.Text));
+    }
+
+    [Fact]
+    public void Supports_ReturnsFalseForMissingModelClass()
+    {
+        var catalog = new AiModelCatalog(new Dictionary<AiModelClass, string>
+        {
+            [AiModelClass.Text] = "gpt-4"
+        });
+
+        Assert.False(catalog.Supports(AiModelClass.Image));
+    }
+
+    // ── TryGet ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TryGet_ReturnsTrueAndPopulatesModelName_WhenSupported()
+    {
+        var catalog = new AiModelCatalog(new Dictionary<AiModelClass, string>
+        {
+            [AiModelClass.Image] = "flux-schnell"
+        });
+
+        var found = catalog.TryGet(AiModelClass.Image, out var modelName);
+
+        Assert.True(found);
+        Assert.Equal("flux-schnell", modelName);
+    }
+
+    [Fact]
+    public void TryGet_ReturnsFalseAndNullModelName_WhenNotSupported()
+    {
+        var catalog = new AiModelCatalog(new Dictionary<AiModelClass, string>
+        {
+            [AiModelClass.Image] = "flux-schnell"
+        });
+
+        var found = catalog.TryGet(AiModelClass.Text, out var modelName);
+
+        Assert.False(found);
+        Assert.Null(modelName);
+    }
+
+    // ── GetRequired ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetRequired_ReturnsModelName_WhenSupported()
+    {
+        var catalog = new AiModelCatalog(new Dictionary<AiModelClass, string>
+        {
+            [AiModelClass.Text] = "deepseek-chat"
+        });
+
+        Assert.Equal("deepseek-chat", catalog.GetRequired(AiModelClass.Text));
+    }
+
+    [Fact]
+    public void GetRequired_Throws_WhenNotSupported()
+    {
+        var catalog = new AiModelCatalog(new Dictionary<AiModelClass, string>
+        {
+            [AiModelClass.Text] = "deepseek-chat"
+        });
+
+        Assert.Throws<InvalidOperationException>(() => catalog.GetRequired(AiModelClass.Image));
+    }
+}

--- a/tests/Models/AiProviderOptionsAbstractionTests.cs
+++ b/tests/Models/AiProviderOptionsAbstractionTests.cs
@@ -1,0 +1,152 @@
+using XPoster.Contracts;
+using XPoster.Models;
+
+namespace XPoster.Tests.Models;
+
+/// <summary>
+/// Verifies that every concrete AI provider options class correctly implements
+/// <see cref="IAiProviderOptions"/> and exposes the right capabilities through
+/// <see cref="AiModelCatalog"/>.
+/// </summary>
+public class AiProviderOptionsAbstractionTests
+{
+    // ── OpenAiOptions ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OpenAiOptions_ImplementsIAiProviderOptions()
+    {
+        Assert.IsAssignableFrom<IAiProviderOptions>(new OpenAiOptions());
+    }
+
+    [Fact]
+    public void OpenAiOptions_ModelCatalog_ExposesTextAndImage()
+    {
+        var options = new OpenAiOptions
+        {
+            TextModelName = "gpt-4.1-nano",
+            ImageModelName = "gpt-image-1.5"
+        };
+
+        IAiProviderOptions sut = options;
+
+        Assert.True(sut.ModelCatalog.TryGet(AiModelClass.Text, out var text));
+        Assert.Equal("gpt-4.1-nano", text);
+
+        Assert.True(sut.ModelCatalog.TryGet(AiModelClass.Image, out var image));
+        Assert.Equal("gpt-image-1.5", image);
+    }
+
+    [Fact]
+    public void OpenAiOptions_ApiKeyAndEndpoint_AccessibleThroughAbstraction()
+    {
+        IAiProviderOptions sut = new OpenAiOptions { ApiKey = "k", Endpoint = "https://api.openai.com/v1/" };
+
+        Assert.Equal("k", sut.ApiKey);
+        Assert.Equal("https://api.openai.com/v1/", sut.Endpoint);
+    }
+
+    // ── AzureFoundryOptions ───────────────────────────────────────────────────
+
+    [Fact]
+    public void AzureFoundryOptions_ImplementsIAiProviderOptions()
+    {
+        Assert.IsAssignableFrom<IAiProviderOptions>(new AzureFoundryOptions());
+    }
+
+    [Fact]
+    public void AzureFoundryOptions_ModelCatalog_ExposesTextAndImage()
+    {
+        IAiProviderOptions sut = new AzureFoundryOptions
+        {
+            TextModelName = "gpt-4.1-nano",
+            ImageModelName = "gpt-image-1"
+        };
+
+        Assert.True(sut.ModelCatalog.Supports(AiModelClass.Text));
+        Assert.True(sut.ModelCatalog.Supports(AiModelClass.Image));
+    }
+
+    // ── PerplexityOptions ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void PerplexityOptions_ImplementsIAiProviderOptions()
+    {
+        Assert.IsAssignableFrom<IAiProviderOptions>(new PerplexityOptions());
+    }
+
+    [Fact]
+    public void PerplexityOptions_ModelCatalog_ExposesTextOnly()
+    {
+        IAiProviderOptions sut = new PerplexityOptions { TextModelName = "sonar" };
+
+        Assert.True(sut.ModelCatalog.Supports(AiModelClass.Text));
+        Assert.False(sut.ModelCatalog.Supports(AiModelClass.Image));
+    }
+
+    // ── DeepSeekOptions ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void DeepSeekOptions_ImplementsIAiProviderOptions()
+    {
+        Assert.IsAssignableFrom<IAiProviderOptions>(new DeepSeekOptions());
+    }
+
+    [Fact]
+    public void DeepSeekOptions_ModelCatalog_ExposesTextOnly()
+    {
+        IAiProviderOptions sut = new DeepSeekOptions { TextModelName = "deepseek-chat" };
+
+        Assert.True(sut.ModelCatalog.Supports(AiModelClass.Text));
+        Assert.False(sut.ModelCatalog.Supports(AiModelClass.Image));
+    }
+
+    // ── FalAiOptions ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FalAiOptions_ImplementsIAiProviderOptions()
+    {
+        Assert.IsAssignableFrom<IAiProviderOptions>(new FalAiOptions());
+    }
+
+    [Fact]
+    public void FalAiOptions_ModelCatalog_ExposesImageOnly()
+    {
+        IAiProviderOptions sut = new FalAiOptions { ImageModelName = "fal-ai/flux/schnell" };
+
+        Assert.False(sut.ModelCatalog.Supports(AiModelClass.Text));
+        Assert.True(sut.ModelCatalog.Supports(AiModelClass.Image));
+    }
+
+    [Fact]
+    public void FalAiOptions_NumInferenceSteps_RemainsOnConcreteClass()
+    {
+        // Provider-specific settings must not be erased by the shared abstraction.
+        var options = new FalAiOptions { NumInferenceSteps = 8 };
+
+        Assert.Equal(8, options.NumInferenceSteps);
+    }
+
+    // ── Capability lookup semantics ───────────────────────────────────────────
+
+    [Fact]
+    public void ModelCatalog_UnsupportedCapability_GetRequired_Throws()
+    {
+        IAiProviderOptions sut = new PerplexityOptions { TextModelName = "sonar" };
+
+        Assert.Throws<InvalidOperationException>(() => sut.ModelCatalog.GetRequired(AiModelClass.Image));
+    }
+
+    [Fact]
+    public void ModelCatalog_EmptyModelName_NotExposedAsSupported()
+    {
+        // If a concrete property holds an empty string, the catalog must not advertise it.
+        IAiProviderOptions sut = new AzureFoundryOptions
+        {
+            TextModelName = "gpt-4.1-nano",
+            ImageModelName = string.Empty    // not configured
+        };
+
+        Assert.True(sut.ModelCatalog.Supports(AiModelClass.Text));
+        Assert.False(sut.ModelCatalog.Supports(AiModelClass.Image));
+    }
+}


### PR DESCRIPTION
- Add AiModelClass enum (Contracts/Enums) for Text and Image capability keys
- Add AiModelCatalog value type (Models/) with TryGet, Supports, GetRequired helpers
- Add IAiProviderOptions interface (Contracts/Interfaces) exposing ApiKey, Endpoint, ModelCatalog
- Implement IAiProviderOptions on all five provider options classes (OpenAiOptions, AzureFoundryOptions, PerplexityOptions, DeepSeekOptions, FalAiOptions)
- ModelCatalog computed from existing concrete properties (backward-compatible)
- Add AiProviderValidationHelper internal helper to centralize shared connectivity checks
- Refactor all five *OptionsValidator classes to call the shared helper
- Add AiProviderOptionsCompositionExtensions with AddAiProviderOptions() single entrypoint
- Update Program.cs to use AddAiProviderOptions() instead of five separate calls
- Add AiModelCatalogTests (11 tests), AiProviderOptionsAbstractionTests (12 tests), AddAiProviderOptionsTests (9 tests) — 32 new tests, all passing
- Full suite: 744/744 passed, 0 warnings

## Summary

<!-- Briefly describe what this PR does and why. -->

Closes #<!-- issue number -->

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📖 Documentation update
- [x] ♻️ Refactor (no functional change)
- [ ] ✅ Tests only
- [ ] 🚨 Breaking change (fix or feature that would cause existing behaviour to change)

---

## Testing Checklist

- [ ] `dotnet build` passes with no warnings
- [ ] `dotnet test` passes locally
- [ ] New/modified code is covered by unit tests
- [ ] Code coverage has not decreased

---

## Documentation

- [ ] Relevant `docs/` pages updated
- [ ] `tests/README.md` updated if testing approach changed
- [ ] `CONTRIBUTING.md` still accurate
- [ ] No dead links introduced

---

## Breaking Changes

<!-- If this PR introduces breaking changes, describe what breaks and the migration path. -->
N/A

---

## Screenshots / Logs (if applicable)

<!-- Add screenshots or log excerpts that help reviewers understand the change. -->
